### PR TITLE
add: pin libpf-v1 release checksums EnsureLibrary works out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,41 @@ The pipeline:
 
 ---
 
+## Anonymize: mask, replace, redact
+
+Detection gives you spans; the `anonymizer` package turns them into sanitized
+text. Pick an operator — mask with the character of your choice (`#`, `*`, …),
+keep a recognizable tail, replace with a placeholder, or redact — and apply it
+to the results of an `Analyze` call:
+
+```go
+import "github.com/hoophq/alcatraz/anonymizer"
+
+text := "Email jane@example.com, card 4532015112830366, ssn 536-90-4399."
+results := eng.Analyze(text, alcatraz.Options{})
+
+anonymizer.Anonymize(text, results, anonymizer.Mask('*'))
+// Email ****************, card ****************, ssn ***********.
+
+anonymizer.AnonymizeWith(text, results, anonymizer.Config{
+    Default: anonymizer.Replace(), // <ENTITY_TYPE> placeholders
+    PerEntity: map[string]anonymizer.Operator{
+        entities.CreditCard: anonymizer.MaskKeepLast('#', 4),
+    },
+})
+// Email <EMAIL_ADDRESS>, card ############0366, ssn <US_SSN>.
+```
+
+Built-in operators: `Mask(char)` (length-preserving, one mask rune per text
+rune), `MaskKeepLast(char, n)`, `Replace()`, `ReplaceWith(s)`, `Redact()`. An
+`Operator` is just a `func(entityType, match string) string`, so hashing,
+tokenization or encryption plug in the same way. Overlapping spans of
+different entity types are resolved before replacement — the higher-scoring
+span wins and the rest is trimmed, never leaked. Pure Go, dependency-free,
+part of the core module.
+
+---
+
 ## Make it yours
 
 Add your own detector by implementing `analyzer.Recognizer` (or reuse
@@ -368,6 +403,7 @@ entities/          Canonical entity-type identifier constants.
 analyzer/          Framework: Result, dedup, Recognizer, Pattern, Matcher,
                    PatternRecognizer, Registry, Engine, allow list, and the
                    NLP seam (NlpEngine, NlpArtifacts, ArtifactRecognizer).
+anonymizer/        Mask/replace/redact detected spans (Operator, Config).
 recognizers/       The 45 built-in recognizers, checksum helpers, loader.
 lookaround/        Optional, separate module: regexp2-backed Matcher for
                    lookahead/lookbehind in user-configured patterns.

--- a/TODO.md
+++ b/TODO.md
@@ -54,10 +54,10 @@ lives in a **separate module** so importers of the core never pull the dep.
       Face, verified against the published LFS sha256) — users need neither
       cmake nor a manual download. `pfilter/dist` builds one self-contained
       shared library (ggml linked statically, force-loaded pf archive).
-- [ ] `pfilter`: publish the first `libpf-v1` release (run
-      `libpf-release.yml`), then pin its checksums.txt values in
-      `pfilter/download.go:libraryChecksums`. Until then `EnsureLibrary`
-      returns "no prebuilt libpf" and users build via `pfilter/dist`.
+- [x] `pfilter`: `libpf-v1` published (all four platforms built + smoke-
+      tested by `libpf-release.yml`) and its checksums pinned in
+      `pfilter/download.go:libraryChecksums` — `EnsureLibrary` verified end
+      to end against the release (download, hash check, dlopen, inference).
 - [x] `pfilter`: ctx pool instead of one mutex-guarded pf_ctx —
       `Config.PoolSize` (default 1) contexts behind a channel pool; classify
       calls run in parallel up to the pool size, Close waits for in-flight

--- a/anonymizer/anonymizer.go
+++ b/anonymizer/anonymizer.go
@@ -1,0 +1,183 @@
+// Package anonymizer replaces detected PII spans in text, turning the
+// analyzer's []Result into a sanitized string:
+//
+//	results := eng.Analyze(text, alcatraz.Options{})
+//	safe := anonymizer.Anonymize(text, results, anonymizer.Mask('*'))
+//
+// Operators decide what each span becomes: Mask keeps the span's length
+// using a chosen character ('#', '*', …), MaskKeepLast leaves a recognizable
+// tail (last 4 card digits), Replace emits "<ENTITY_TYPE>" placeholders,
+// ReplaceWith a fixed string, and Redact removes the span. An Operator is
+// just a func, so custom transforms (hashing, encryption, tokenization) drop
+// in the same way. Per-entity operators are configured via Config.
+//
+// Overlapping spans are resolved safely: higher-scoring spans keep their
+// full extent and lower-scoring ones are trimmed to the uncovered remainder,
+// so every detected byte is anonymized exactly once — a partial overlap
+// never leaks the uncovered part of a detection.
+//
+// Like the rest of the core, this package is pure Go and dependency-free.
+package anonymizer
+
+import (
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/hoophq/alcatraz/analyzer"
+)
+
+// Operator produces the replacement for one detected span. entityType is the
+// canonical entity name (e.g. "EMAIL_ADDRESS") and match is the exact text
+// being replaced. When overlap resolution trims a span, match is the trimmed
+// portion.
+type Operator func(entityType, match string) string
+
+// Mask replaces every rune of the match with char, preserving the match's
+// rune length: "555-1234" masked with '#' becomes "########".
+func Mask(char rune) Operator {
+	return func(_, match string) string {
+		return strings.Repeat(string(char), utf8.RuneCountInString(match))
+	}
+}
+
+// MaskKeepLast is Mask but leaves the trailing keep runes visible:
+// MaskKeepLast('*', 4) turns "4532015112830366" into "************0366".
+// When the match has keep runes or fewer, it is returned unchanged.
+func MaskKeepLast(char rune, keep int) Operator {
+	if keep < 0 {
+		keep = 0
+	}
+	return func(_, match string) string {
+		runes := []rune(match)
+		if len(runes) <= keep {
+			return match
+		}
+		cut := len(runes) - keep
+		return strings.Repeat(string(char), cut) + string(runes[cut:])
+	}
+}
+
+// Replace substitutes each span with its entity type in angle brackets:
+// "jane@example.com" becomes "<EMAIL_ADDRESS>". This is the default operator
+// when Config.Default is nil.
+func Replace() Operator {
+	return func(entityType, _ string) string { return "<" + entityType + ">" }
+}
+
+// ReplaceWith substitutes each span with a fixed placeholder.
+func ReplaceWith(placeholder string) Operator {
+	return func(_, _ string) string { return placeholder }
+}
+
+// Redact removes each span entirely.
+func Redact() Operator {
+	return func(_, _ string) string { return "" }
+}
+
+// Config selects operators per entity type, with a fallback for the rest.
+type Config struct {
+	// Default handles every entity type without a PerEntity entry.
+	// Nil means Replace().
+	Default Operator
+	// PerEntity overrides the operator for specific entity types, keyed by
+	// canonical name (see the entities package constants).
+	PerEntity map[string]Operator
+}
+
+// Anonymize rewrites text by applying op to every detected span. results is
+// the output of an Analyze call on the same text.
+func Anonymize(text string, results []analyzer.Result, op Operator) string {
+	return AnonymizeWith(text, results, Config{Default: op})
+}
+
+// AnonymizeWith is Anonymize with per-entity operator selection.
+func AnonymizeWith(text string, results []analyzer.Result, cfg Config) string {
+	def := cfg.Default
+	if def == nil {
+		def = Replace()
+	}
+	out := []byte(text)
+	// Spans come back sorted by Start descending, so each replacement
+	// leaves the offsets of the spans still to process untouched.
+	for _, s := range resolve(results, len(text)) {
+		op := def
+		if o, ok := cfg.PerEntity[s.EntityType]; ok && o != nil {
+			op = o
+		}
+		repl := op(s.EntityType, text[s.Start:s.End])
+		out = append(out[:s.Start], append([]byte(repl), out[s.End:]...)...)
+	}
+	return string(out)
+}
+
+// resolve turns detections into non-overlapping spans sorted by Start
+// descending. The engine only de-duplicates same-type overlaps, so spans of
+// different entity types can still intersect here. Higher-scoring spans keep
+// their full extent; lower-scoring ones are trimmed to whatever they cover
+// that nothing above them does, guaranteeing every detected byte is
+// anonymized under exactly one entity type.
+func resolve(results []analyzer.Result, textLen int) []analyzer.Result {
+	spans := make([]analyzer.Result, 0, len(results))
+	for _, r := range results {
+		// Results may come from outside the engine; clamp instead of
+		// trusting the offsets.
+		if r.Start < 0 {
+			r.Start = 0
+		}
+		if r.End > textLen {
+			r.End = textLen
+		}
+		if r.End > r.Start {
+			spans = append(spans, r)
+		}
+	}
+	sort.SliceStable(spans, func(i, j int) bool {
+		if spans[i].Score != spans[j].Score {
+			return spans[i].Score > spans[j].Score
+		}
+		if spans[i].Len() != spans[j].Len() {
+			return spans[i].Len() > spans[j].Len()
+		}
+		return spans[i].Start < spans[j].Start
+	})
+
+	var kept []analyzer.Result
+	for _, s := range spans {
+		pieces := []analyzer.Result{s}
+		for _, k := range kept {
+			var next []analyzer.Result
+			for _, p := range pieces {
+				next = append(next, subtract(p, k)...)
+			}
+			pieces = next
+			if len(pieces) == 0 {
+				break
+			}
+		}
+		kept = append(kept, pieces...)
+	}
+
+	sort.Slice(kept, func(i, j int) bool { return kept[i].Start > kept[j].Start })
+	return kept
+}
+
+// subtract returns the parts of p not covered by k: zero pieces (p contained
+// in k), one (no overlap, or overlap on one side) or two (k strictly inside p).
+func subtract(p, k analyzer.Result) []analyzer.Result {
+	if p.End <= k.Start || k.End <= p.Start {
+		return []analyzer.Result{p}
+	}
+	var out []analyzer.Result
+	if p.Start < k.Start {
+		left := p
+		left.End = k.Start
+		out = append(out, left)
+	}
+	if p.End > k.End {
+		right := p
+		right.Start = k.End
+		out = append(out, right)
+	}
+	return out
+}

--- a/anonymizer/anonymizer_test.go
+++ b/anonymizer/anonymizer_test.go
@@ -1,0 +1,163 @@
+package anonymizer_test
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/anonymizer"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+func span(entity string, start, end int, score float64) analyzer.Result {
+	return analyzer.Result{EntityType: entity, Start: start, End: end, Score: score}
+}
+
+func TestOperators(t *testing.T) {
+	text := "ssn 536-90-4399 ok"
+	ssn := []analyzer.Result{span(entities.USSSN, 4, 15, 1.0)}
+
+	cases := []struct {
+		name string
+		op   anonymizer.Operator
+		want string
+	}{
+		{"Mask hash", anonymizer.Mask('#'), "ssn ########### ok"},
+		{"Mask star", anonymizer.Mask('*'), "ssn *********** ok"},
+		{"MaskKeepLast", anonymizer.MaskKeepLast('*', 4), "ssn *******4399 ok"},
+		{"Replace", anonymizer.Replace(), "ssn <US_SSN> ok"},
+		{"ReplaceWith", anonymizer.ReplaceWith("[PII]"), "ssn [PII] ok"},
+		{"Redact", anonymizer.Redact(), "ssn  ok"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := anonymizer.Anonymize(text, ssn, c.op); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestMaskKeepLastShortMatch(t *testing.T) {
+	text := "pin 123"
+	res := []analyzer.Result{span("PIN", 4, 7, 1.0)}
+	if got := anonymizer.Anonymize(text, res, anonymizer.MaskKeepLast('*', 4)); got != "pin 123" {
+		t.Errorf("match shorter than keep should be unchanged, got %q", got)
+	}
+}
+
+func TestMaskMultiByte(t *testing.T) {
+	text := "name José Núñez end"
+	res := []analyzer.Result{span(entities.Person, 5, 5+len("José Núñez"), 0.9)}
+	// 10 runes, so 10 mask characters regardless of byte length.
+	want := "name ########## end"
+	if got := anonymizer.Anonymize(text, res, anonymizer.Mask('#')); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMultipleSpansReplacedIndependently(t *testing.T) {
+	text := "a@b.com and c@d.com"
+	res := []analyzer.Result{
+		span(entities.EmailAddress, 0, 7, 0.5),
+		span(entities.EmailAddress, 12, 19, 0.5),
+	}
+	want := "<EMAIL_ADDRESS> and <EMAIL_ADDRESS>"
+	if got := anonymizer.Anonymize(text, res, anonymizer.Replace()); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPerEntityConfig(t *testing.T) {
+	text := "card 4532015112830366 mail a@b.com"
+	res := []analyzer.Result{
+		span(entities.CreditCard, 5, 21, 1.0),
+		span(entities.EmailAddress, 27, 34, 0.5),
+	}
+	got := anonymizer.AnonymizeWith(text, res, anonymizer.Config{
+		Default: anonymizer.Mask('*'),
+		PerEntity: map[string]anonymizer.Operator{
+			entities.CreditCard: anonymizer.MaskKeepLast('*', 4),
+		},
+	})
+	want := "card ************0366 mail *******"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultOperatorIsReplace(t *testing.T) {
+	text := "mail a@b.com"
+	res := []analyzer.Result{span(entities.EmailAddress, 5, 12, 0.5)}
+	if got := anonymizer.AnonymizeWith(text, res, anonymizer.Config{}); got != "mail <EMAIL_ADDRESS>" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestOverlapHigherScoreWinsLowerTrimmed(t *testing.T) {
+	// PERSON (low score) overlaps EMAIL (high score): the email keeps its
+	// full span, the person span is trimmed to its uncovered prefix, and
+	// no detected byte survives unmasked.
+	text := "by jane jane@x.com!"
+	res := []analyzer.Result{
+		span(entities.Person, 3, 12, 0.4),        // "jane jane"
+		span(entities.EmailAddress, 8, 18, 0.95), // "jane@x.com"
+	}
+	got := anonymizer.Anonymize(text, res, anonymizer.Mask('#'))
+	want := "by ###############!" // 5 (trimmed "jane ") + 10 (email), one '#' each
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestContainedSpanFullyCovered(t *testing.T) {
+	// A span contained in a higher-scoring one disappears into it.
+	text := "x 4532015112830366 y"
+	res := []analyzer.Result{
+		span(entities.CreditCard, 2, 18, 1.0),
+		span(entities.USBankNumber, 2, 18, 0.05),
+	}
+	got := anonymizer.Anonymize(text, res, anonymizer.Replace())
+	want := "x <CREDIT_CARD> y"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestOutOfRangeSpansClamped(t *testing.T) {
+	text := "short"
+	res := []analyzer.Result{
+		span("X", -2, 3, 0.9),
+		span("Y", 4, 99, 0.9),
+		span("Z", 5, 5, 0.9), // empty after clamp: dropped
+	}
+	got := anonymizer.Anonymize(text, res, anonymizer.Mask('*'))
+	want := "***r*" // X clamps to [0,3), Y to [4,5); byte 3 ('r') is untouched
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNoResultsReturnsTextUnchanged(t *testing.T) {
+	if got := anonymizer.Anonymize("nothing here", nil, anonymizer.Mask('#')); got != "nothing here" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestEndToEndWithEngine(t *testing.T) {
+	eng := alcatraz.NewEngine()
+	text := "Email jane.doe@example.com, card 4532015112830366."
+	results := eng.Analyze(text, alcatraz.Options{
+		Entities: []string{entities.EmailAddress, entities.CreditCard},
+	})
+	got := anonymizer.AnonymizeWith(text, results, anonymizer.Config{
+		Default: anonymizer.Replace(),
+		PerEntity: map[string]anonymizer.Operator{
+			entities.CreditCard: anonymizer.MaskKeepLast('#', 4),
+		},
+	})
+	want := "Email <EMAIL_ADDRESS>, card ############0366."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/anonymizer/example_test.go
+++ b/anonymizer/example_test.go
@@ -1,0 +1,31 @@
+package anonymizer_test
+
+import (
+	"fmt"
+
+	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/anonymizer"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+// Example detects PII with the standard engine and masks it: one operator as
+// the default and a per-entity override that keeps the last card digits.
+func Example() {
+	eng := alcatraz.NewEngine()
+	text := "Email jane@example.com, card 4532015112830366, ssn 536-90-4399."
+
+	results := eng.Analyze(text, alcatraz.Options{
+		Entities: []string{entities.EmailAddress, entities.CreditCard, entities.USSSN},
+	})
+
+	fmt.Println(anonymizer.Anonymize(text, results, anonymizer.Mask('*')))
+	fmt.Println(anonymizer.AnonymizeWith(text, results, anonymizer.Config{
+		Default: anonymizer.Replace(),
+		PerEntity: map[string]anonymizer.Operator{
+			entities.CreditCard: anonymizer.MaskKeepLast('#', 4),
+		},
+	}))
+	// Output:
+	// Email ****************, card ****************, ssn ***********.
+	// Email <EMAIL_ADDRESS>, card ############0366, ssn <US_SSN>.
+}

--- a/ner/example_test.go
+++ b/ner/example_test.go
@@ -1,0 +1,43 @@
+package ner_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/ner"
+	"github.com/hoophq/alcatraz/recognizers"
+)
+
+// Example wires the statistical NER backend into an analyzer engine so
+// free-text entities (PERSON, LOCATION, NRP, DATE_TIME) are detected
+// alongside the pattern recognizers. The ONNX model is downloaded from
+// Hugging Face on first use and cached under the user cache directory.
+//
+// There is no // Output: comment on purpose: the example is compiled but
+// not executed by go test, because it downloads a model.
+func Example() {
+	nlp, err := ner.New(context.Background(), ner.DefaultConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nlp.Close()
+
+	// Pattern recognizers plus the NER recognizer in one registry.
+	reg := analyzer.NewRegistry("en")
+	recognizers.LoadDefaults(reg, "en")
+	reg.Add("en", nlp.Recognizer("en"))
+
+	eng := analyzer.NewEngine(reg, []string{"en"})
+	// With SetNlpEngine the model runs once per Analyze call and its
+	// artifacts are shared with every artifact-aware recognizer.
+	eng.SetNlpEngine(nlp)
+
+	text := "John Smith moved to Berlin; reach him at john@example.com"
+	for _, hit := range eng.Analyze(text, analyzer.Options{}) {
+		fmt.Printf("%s %q %.2f\n", hit.EntityType, hit.Text, hit.Score)
+	}
+	// Prints PERSON "John Smith" and LOCATION "Berlin" (from the model)
+	// plus EMAIL_ADDRESS "john@example.com" (from the pattern recognizer).
+}

--- a/pfilter/download.go
+++ b/pfilter/download.go
@@ -105,12 +105,12 @@ var libraryBaseURL = "https://github.com/hoophq/alcatraz/releases/download"
 // trusting checksums.txt at download time) is what makes the download
 // verifiable.
 var libraryChecksums = map[string]string{
-	// Populated when the libpf-release workflow publishes the first
-	// artifact set, e.g.:
-	//	"darwin-arm64": "<sha256 of libpf-darwin-arm64.dylib>",
-	//	"darwin-amd64": "<sha256 of libpf-darwin-amd64.dylib>",
-	//	"linux-amd64":  "<sha256 of libpf-linux-amd64.so>",
-	//	"linux-arm64":  "<sha256 of libpf-linux-arm64.so>",
+	// libpf-v1: built from localai-org/privacy-filter.cpp@735a6c2 by the
+	// libpf-release workflow (run 28973430209).
+	"darwin-arm64": "5b7aedb042244ce0ae6424e2dd9ad5400d251180e316539bd4022125596ad76b",
+	"darwin-amd64": "a1cb3be9c0b851d5440ac5ece2a9fa3a61298bdd4a8bf864673feb71987fe097",
+	"linux-amd64":  "c1fe627e825f5dc31fdcd0a686aac85f8b9a7238c5846bdea73adec8b189c280",
+	"linux-arm64":  "a97f7a2b36edbc3dfbefae68b701b1002a43f2401c9ae3c4f934393f9f55f5a3",
 }
 
 // libraryArtifactName returns the release asset name for a platform, e.g.

--- a/pfilter/download_test.go
+++ b/pfilter/download_test.go
@@ -240,10 +240,17 @@ func TestEnsureLibraryRedownloadsCorruptedCache(t *testing.T) {
 }
 
 func TestEnsureLibraryUnsupportedPlatform(t *testing.T) {
+	// Remove the current platform from the support matrix so the
+	// unsupported branch is exercised regardless of the host.
 	key := runtime.GOOS + "-" + runtime.GOARCH
-	if _, ok := libraryChecksums[key]; ok {
-		t.Skipf("a prebuilt libpf exists for %s; nothing to test", key)
-	}
+	orig, had := libraryChecksums[key]
+	delete(libraryChecksums, key)
+	t.Cleanup(func() {
+		if had {
+			libraryChecksums[key] = orig
+		}
+	})
+
 	_, err := EnsureLibrary(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "no prebuilt libpf") {
 		t.Fatalf("want no-prebuilt error, got %v", err)

--- a/pfilter/example_test.go
+++ b/pfilter/example_test.go
@@ -1,0 +1,57 @@
+package pfilter_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/pfilter"
+	"github.com/hoophq/alcatraz/recognizers"
+)
+
+// Example wires the privacy-filter GGML backend into an analyzer engine.
+// The first run downloads (and sha256-verifies) the prebuilt libpf shared
+// library for this OS/arch and the Q8 GGUF (~1.6 GB); later runs hit the
+// cache. New finds the EnsureLibrary-cached libpf automatically when
+// Config.Library is empty.
+//
+// There is no // Output: comment on purpose: the example is compiled but
+// not executed by go test, because it downloads a model and a native
+// library.
+func Example() {
+	ctx := context.Background()
+
+	if _, err := pfilter.EnsureLibrary(ctx); err != nil {
+		log.Fatal(err)
+	}
+	model, err := pfilter.EnsureModel(ctx, pfilter.ModelQ8)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	nlp, err := pfilter.New(pfilter.DefaultConfig(model))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nlp.Close()
+
+	// Pattern recognizers plus the privacy-filter recognizer in one
+	// registry.
+	reg := analyzer.NewRegistry("en")
+	recognizers.LoadDefaults(reg, "en")
+	reg.Add("en", nlp.Recognizer("en"))
+
+	eng := analyzer.NewEngine(reg, []string{"en"})
+	// With SetNlpEngine the model runs once per Analyze call and its
+	// artifacts are shared with every artifact-aware recognizer.
+	eng.SetNlpEngine(nlp)
+
+	text := "Maria Silva lives at 12 Baker Street, card 4532015112830366"
+	for _, hit := range eng.Analyze(text, analyzer.Options{}) {
+		fmt.Printf("%s %q %.2f\n", hit.EntityType, hit.Text, hit.Score)
+	}
+	// Prints PERSON "Maria Silva" and LOCATION "12 Baker Street" (from
+	// the model) plus CREDIT_CARD "4532015112830366" (Luhn-validated
+	// pattern recognizer).
+}


### PR DESCRIPTION
## Summary

Completes the pfilter distribution story from #5: pins the sha256 of each
`libpf-v1` release artifact in `pfilter/download.go:libraryChecksums`, so
`pfilter.EnsureLibrary` can download and verify a prebuilt libpf instead of
returning "no prebuilt libpf".

- Hashes come from the `checksums.txt` of the `libpf-release.yml` run
  ([28973430209](https://github.com/hoophq/alcatraz/actions/runs/28973430209)),
  built from `localai-org/privacy-filter.cpp@735a6c2` for darwin/linux ×
  amd64/arm64. Pinning them in reviewed source (not trusting checksums.txt at
  download time) is what makes the download verifiable.
- With this, pfilter onboarding needs no cmake and no manual download:
  `EnsureLibrary(ctx)` + `EnsureModel(ctx, pfilter.ModelQ8)` + `New(...)`.
- Ticks the corresponding TODO item.

## Validation

Verified end to end on darwin/arm64 with a cold cache and no `PF_LIBRARY` /
`Config.Library` set: `EnsureLibrary` downloaded the release artifact, the
pinned sha256 matched, `New` found it via loadLibrary's cache-path fallback,
dlopen'ed it (ad-hoc codesign accepted), loaded the q8 GGUF on Metal, and
inference returned PERSON (0.9999) / EMAIL_ADDRESS (0.9968) spans.

Unit tests (`go test -race`), vet and gofmt are clean.