### PR TITLE
bench: reproducible speed + parity benchmarks vs Presidio

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,21 +380,23 @@ makes it precise on structured identifiers and honest about the rest:
 
 The [`bench/`](bench/) directory holds a reproducible speed comparison
 against [Presidio](https://github.com/data-privacy-stack/presidio)'s Python
-analyzer. Both engines read the same generated corpus — 180 documents across
-a {100 B, 1 KB, 10 KB} × {no PII, sparse, dense} matrix, every seeded value
-passing its real checksum — and emit the same JSON schema, so results merge
-into one table.
+analyzer. Both engines read the same generated corpus — 186 documents across
+a {100 B, 1 KB, 10 KB, 1 MB} × {no PII, sparse, dense} matrix, every seeded
+value passing its real checksum — and emit the same JSON schema, so results
+merge into one table.
 
 Representative single-threaded run (Presidio configured with its slim
 tokenization-only NLP engine — the closest apples-to-apples with Alcatraz's
 pattern-only core; its default spaCy-NER pipeline is slower still):
 
-| Corpus group | Alcatraz µs/doc | Presidio µs/doc | Speedup |
+| Corpus group | Alcatraz ms/doc | Presidio ms/doc | Speedup |
 |--------------|----------------:|----------------:|--------:|
-| 100 B, no PII |             82 |           8,819 |   ~108x |
-| 1 KB, no PII  |            775 |          15,034 |    ~19x |
-| 10 KB, no PII |          7,835 |          89,105 |    ~11x |
-| 10 KB, dense  |          8,623 |         119,652 |    ~14x |
+| 100 B, no PII |           0.09 |             8.5 |   ~100x |
+| 1 KB, no PII  |           0.80 |            15.2 |    ~19x |
+| 10 KB, no PII |           8.0  |            84.3 |    ~11x |
+| 10 KB, dense  |           8.7  |           116.1 |    ~13x |
+| 1 MB, no PII  |          840   |         7,999   |    ~10x |
+| 1 MB, dense   |        1,521   |       159,237   |   ~105x |
 
 Speed is only half the story: a parity check diffs the detections of both
 engines on the same corpus. On the shared entity types the two agree

--- a/README.md
+++ b/README.md
@@ -376,6 +376,37 @@ makes it precise on structured identifiers and honest about the rest:
 
 ---
 
+## Benchmarks
+
+The [`bench/`](bench/) directory holds a reproducible speed comparison
+against [Presidio](https://github.com/data-privacy-stack/presidio)'s Python
+analyzer. Both engines read the same generated corpus — 180 documents across
+a {100 B, 1 KB, 10 KB} × {no PII, sparse, dense} matrix, every seeded value
+passing its real checksum — and emit the same JSON schema, so results merge
+into one table.
+
+Representative single-threaded run (Presidio configured with its slim
+tokenization-only NLP engine — the closest apples-to-apples with Alcatraz's
+pattern-only core; its default spaCy-NER pipeline is slower still):
+
+| Corpus group | Alcatraz µs/doc | Presidio µs/doc | Speedup |
+|--------------|----------------:|----------------:|--------:|
+| 100 B, no PII |             82 |           8,819 |   ~108x |
+| 1 KB, no PII  |            775 |          15,034 |    ~19x |
+| 10 KB, no PII |          7,835 |          89,105 |    ~11x |
+| 10 KB, dense  |          8,623 |         119,652 |    ~14x |
+
+Speed is only half the story: a parity check diffs the detections of both
+engines on the same corpus. On the shared entity types the two agree
+exactly (credit cards, IBANs, SSNs, IPs, bank numbers — span for span);
+they diverge where recognizer sets differ (e.g. Presidio ships no Brazilian
+recognizers).
+
+Numbers vary by machine — reproduce them with two commands per engine; see
+[`bench/README.md`](bench/README.md) for setup and methodology.
+
+---
+
 ## Roadmap
 
 - [x] 45 pattern recognizers, 25 checksum-validated
@@ -411,6 +442,8 @@ ner/               Optional, separate module: statistical NER (PERSON,
                    LOCATION, NRP, DATE_TIME) via an in-process ONNX model.
 pfilter/           Optional, separate module: PII-specialized NER via
                    privacy-filter.cpp (GGUF models, purego FFI, no cgo).
+bench/             Separate module: reproducible speed + parity benchmarks
+                   against Presidio's Python analyzer (shared corpus, uv).
 ```
 
 ## Tests

--- a/analyzer/engine.go
+++ b/analyzer/engine.go
@@ -77,17 +77,66 @@ func (e *Engine) Analyze(text string, o Options) []Result {
 	// One shared NLP pass: run the backend only when a recognizer will
 	// actually consume the artifacts, so the pattern-only path pays nothing.
 	var artifacts *NlpArtifacts
-	if e.nlp != nil {
-		for _, rec := range recs {
-			if _, ok := rec.(ArtifactRecognizer); ok {
-				// An inference failure degrades to pattern-only analysis
-				// rather than failing the whole call.
-				artifacts, _ = e.nlp.ProcessText(text, lang)
-				break
+	if e.nlp != nil && wantsArtifacts(recs) {
+		// An inference failure degrades to pattern-only analysis rather
+		// than failing the whole call.
+		artifacts, _ = e.nlp.ProcessText(text, lang)
+	}
+
+	return e.analyzeWithArtifacts(text, o, recs, artifacts)
+}
+
+// AnalyzeBatch is Analyze over several texts at once, returning one result
+// slice per text in input order. When the configured NLP backend implements
+// BatchNlpEngine, the model runs a single inference call for the whole batch
+// instead of once per text — the per-text results are identical to Analyze,
+// only faster. Recognizers, threshold and allow list apply per text exactly
+// as in Analyze.
+func (e *Engine) AnalyzeBatch(texts []string, o Options) [][]Result {
+	lang := o.Language
+	if lang == "" {
+		lang = "en"
+	}
+
+	recs := e.registry.Recognizers(lang, o.Entities)
+
+	// One shared NLP pass for the whole batch when the backend supports it,
+	// otherwise one per text; a failed pass degrades that text to the
+	// pattern-only path, matching Analyze.
+	artifacts := make([]*NlpArtifacts, len(texts))
+	if e.nlp != nil && wantsArtifacts(recs) {
+		if batch, ok := e.nlp.(BatchNlpEngine); ok {
+			if got, err := batch.ProcessTexts(texts, lang); err == nil && len(got) == len(texts) {
+				artifacts = got
+			}
+		} else {
+			for i, text := range texts {
+				artifacts[i], _ = e.nlp.ProcessText(text, lang)
 			}
 		}
 	}
 
+	results := make([][]Result, len(texts))
+	for i, text := range texts {
+		results[i] = e.analyzeWithArtifacts(text, o, recs, artifacts[i])
+	}
+	return results
+}
+
+// wantsArtifacts reports whether any recognizer consumes shared NlpArtifacts.
+func wantsArtifacts(recs []Recognizer) bool {
+	for _, rec := range recs {
+		if _, ok := rec.(ArtifactRecognizer); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// analyzeWithArtifacts runs the recognizer/dedup/threshold/allow-list
+// pipeline for one text, feeding the shared artifacts (may be nil) to
+// artifact-aware recognizers.
+func (e *Engine) analyzeWithArtifacts(text string, o Options, recs []Recognizer, artifacts *NlpArtifacts) []Result {
 	var all []Result
 	for _, rec := range recs {
 		if ar, ok := rec.(ArtifactRecognizer); ok && artifacts != nil {

--- a/analyzer/nlp.go
+++ b/analyzer/nlp.go
@@ -54,6 +54,17 @@ type NlpEngine interface {
 	ProcessText(text, language string) (*NlpArtifacts, error)
 }
 
+// BatchNlpEngine is an optional extension of NlpEngine for backends that can
+// process several texts in one inference call, which amortizes per-call
+// tokenization and graph overhead. Engine.AnalyzeBatch detects it by type
+// assertion and falls back to per-text ProcessText calls when absent.
+type BatchNlpEngine interface {
+	NlpEngine
+	// ProcessTexts runs the NLP pipeline over all texts and returns one
+	// NlpArtifacts per text, in input order.
+	ProcessTexts(texts []string, language string) ([]*NlpArtifacts, error)
+}
+
 // ArtifactRecognizer is an optional extension of Recognizer for detectors
 // that consume precomputed NlpArtifacts. The engine detects it by type
 // assertion: when an NlpEngine is configured (Engine.SetNlpEngine) and at

--- a/analyzer/nlp_test.go
+++ b/analyzer/nlp_test.go
@@ -17,6 +17,31 @@ func (f *fakeNlpEngine) ProcessText(text, language string) (*NlpArtifacts, error
 	return f.artifacts, f.err
 }
 
+// fakeBatchNlpEngine implements BatchNlpEngine, returning per-text artifacts
+// keyed by the text itself and counting batch calls.
+type fakeBatchNlpEngine struct {
+	fakeNlpEngine
+	batchCalls int
+	perText    map[string]*NlpArtifacts
+	batchErr   error
+}
+
+func (f *fakeBatchNlpEngine) ProcessTexts(texts []string, language string) ([]*NlpArtifacts, error) {
+	f.batchCalls++
+	if f.batchErr != nil {
+		return nil, f.batchErr
+	}
+	out := make([]*NlpArtifacts, len(texts))
+	for i, t := range texts {
+		if a, ok := f.perText[t]; ok {
+			out[i] = a
+		} else {
+			out[i] = &NlpArtifacts{}
+		}
+	}
+	return out, nil
+}
+
 // fakeArtifactRecognizer emits the artifacts' spans, or nothing via plain
 // Analyze so tests can tell which path the engine took.
 type fakeArtifactRecognizer struct {
@@ -135,6 +160,81 @@ func TestEngineSharedArtifacts(t *testing.T) {
 		}
 		if len(got) != 0 {
 			t.Fatalf("want no results, got %+v", got)
+		}
+	})
+
+	t.Run("AnalyzeBatch runs a batch engine once for all texts", func(t *testing.T) {
+		texts := []string{"call John Smith now", "meet in Berlin"}
+		nlp := &fakeBatchNlpEngine{perText: map[string]*NlpArtifacts{
+			texts[0]: {Ents: []NerSpan{person}},
+			texts[1]: {Ents: []NerSpan{{EntityType: "LOCATION", Start: 8, End: 14, Score: 0.9}}},
+		}}
+		a := &fakeArtifactRecognizer{name: "ner", entities: []string{"PERSON", "LOCATION"}}
+		eng := newNlpTestEngine(a)
+		eng.SetNlpEngine(nlp)
+
+		got := eng.AnalyzeBatch(texts, Options{})
+		if nlp.batchCalls != 1 || nlp.calls != 0 {
+			t.Errorf("batchCalls=%d calls=%d, want 1 and 0", nlp.batchCalls, nlp.calls)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 result slices, got %d", len(got))
+		}
+		if len(got[0]) != 1 || got[0][0].Text != "John Smith" {
+			t.Errorf("text 0: want PERSON 'John Smith', got %+v", got[0])
+		}
+		if len(got[1]) != 1 || got[1][0].Text != "Berlin" {
+			t.Errorf("text 1: want LOCATION 'Berlin', got %+v", got[1])
+		}
+	})
+
+	t.Run("AnalyzeBatch matches per-text Analyze results", func(t *testing.T) {
+		texts := []string{"call John Smith now", "nothing here"}
+		nlp := &fakeBatchNlpEngine{perText: map[string]*NlpArtifacts{
+			texts[0]: {Ents: []NerSpan{person}},
+		}}
+		nlp.artifacts = &NlpArtifacts{Ents: []NerSpan{person}}
+		a := &fakeArtifactRecognizer{name: "ner", entities: []string{"PERSON"}}
+		eng := newNlpTestEngine(a)
+		eng.SetNlpEngine(nlp)
+
+		batch := eng.AnalyzeBatch(texts, Options{})
+		single := eng.Analyze(texts[0], Options{})
+		if len(batch[0]) != len(single) || batch[0][0] != single[0] {
+			t.Errorf("batch result %+v != single result %+v", batch[0], single)
+		}
+		if len(batch[1]) != 0 {
+			t.Errorf("text without entities: want none, got %+v", batch[1])
+		}
+	})
+
+	t.Run("AnalyzeBatch with non-batch engine falls back to per-text passes", func(t *testing.T) {
+		nlp := &fakeNlpEngine{artifacts: &NlpArtifacts{Ents: []NerSpan{person}}}
+		a := &fakeArtifactRecognizer{name: "ner", entities: []string{"PERSON"}}
+		eng := newNlpTestEngine(a)
+		eng.SetNlpEngine(nlp)
+
+		got := eng.AnalyzeBatch([]string{text, text}, Options{})
+		if nlp.calls != 2 {
+			t.Errorf("NLP engine ran %d times, want 2", nlp.calls)
+		}
+		if len(got) != 2 || len(got[0]) != 1 || len(got[1]) != 1 {
+			t.Fatalf("want one PERSON per text, got %+v", got)
+		}
+	})
+
+	t.Run("AnalyzeBatch batch failure degrades to plain Analyze", func(t *testing.T) {
+		nlp := &fakeBatchNlpEngine{batchErr: errors.New("model exploded")}
+		a := &fakeArtifactRecognizer{name: "ner", entities: []string{"PERSON"}}
+		eng := newNlpTestEngine(a)
+		eng.SetNlpEngine(nlp)
+
+		got := eng.AnalyzeBatch([]string{text, text}, Options{})
+		if a.plainAnalyzed != 2 {
+			t.Errorf("plain Analyze ran %d times, want 2", a.plainAnalyzed)
+		}
+		if len(got) != 2 || len(got[0]) != 0 || len(got[1]) != 0 {
+			t.Fatalf("want empty results, got %+v", got)
 		}
 	})
 

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,5 @@
+corpus.jsonl
+results-*.json
+detections-*.jsonl
+python/.venv/
+python/uv.lock

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,84 @@
+# Benchmarks: Alcatraz vs Presidio
+
+Compares analyze throughput between **Alcatraz** (this repo, Go) and the
+local **presidio-analyzer** checkout (`../../presidio/presidio-analyzer`,
+Python). Both harnesses read the same corpus and emit the same JSON schema,
+so results merge into one table.
+
+This directory is its own Go module (`replace`d to the parent) and its own
+uv project — nothing here touches the Alcatraz core module or your global
+Python environment.
+
+## Layout
+
+```
+bench/
+├── go.mod                    Separate module; replace github.com/hoophq/alcatraz => ../
+├── corpus.jsonl              Generated shared corpus (deterministic, seed 42)
+├── cmd/gencorpus/            Corpus generator (valid Luhn/CPF/IBAN/SSN seeds)
+├── cmd/benchgo/              Alcatraz harness: -mode bench | detect
+├── internal/corpus/          JSONL loader shared by the Go tools
+├── analyze_bench_test.go     Plain `go test -bench` benchmarks (benchstat-friendly)
+├── python/                   uv project; presidio-analyzer installed editable
+│   ├── pyproject.toml
+│   └── bench_presidio.py     Presidio harness: --mode bench | detect
+└── compare.py                Merges outputs: speed table + detection parity
+```
+
+## One-time setup
+
+```bash
+cd bench
+go run ./cmd/gencorpus -out corpus.jsonl          # regenerate the corpus
+cd python && uv sync                              # venv + local presidio-analyzer
+uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+```
+
+## Run the comparison
+
+```bash
+cd bench
+
+# 1. Speed
+go run ./cmd/benchgo -mode bench -iterations 20 > results-go.json
+(cd python && uv run bench_presidio.py --mode bench --iterations 5) > results-py-slim.json
+./compare.py speed results-go.json results-py-slim.json
+
+# 2. Detection parity (velocity numbers are only fair if coverage is comparable)
+go run ./cmd/benchgo -mode detect > detections-go.jsonl
+(cd python && uv run bench_presidio.py --mode detect) > detections-py.jsonl
+./compare.py parity detections-go.jsonl detections-py.jsonl
+```
+
+Restrict both engines to the same entity set for a stricter comparison:
+
+```bash
+go run ./cmd/benchgo -mode bench -entity CREDIT_CARD -entity EMAIL_ADDRESS > results-go.json
+(cd python && uv run bench_presidio.py --mode bench --entity CREDIT_CARD --entity EMAIL_ADDRESS) > results-py-slim.json
+```
+
+## Presidio engine modes
+
+- `--engine slim` (default): `SlimSpacyNlpEngine` — spaCy tokenization only,
+  **no NER model**. This is the closest apples-to-apples comparison with
+  Alcatraz's pattern-only core.
+- `--engine full`: the default Presidio pipeline, which runs spaCy NER on
+  every `analyze()` call. This is what Presidio users get out of the box
+  (requires `en_core_web_lg`; slower by design). Report both numbers — they
+  answer different questions.
+
+## Methodology notes
+
+- **Engine construction is excluded** from the timed loop; a full warm-up
+  pass runs first. `BenchmarkNewEngine` measures construction separately.
+- The corpus is deterministic (seed 42): 180 docs across a
+  {100B, 1KB, 10KB} x {none, sparse, dense} matrix. Seeded PII passes real
+  checksums (Luhn cards, mod-11 CPF, mod-97 IBAN), so validator paths are
+  exercised the way real data exercises them.
+- The `none` density rows matter most for real workloads — most production
+  text has no PII, so scan-and-reject cost usually dominates.
+- Throughput is reported as **µs/doc and MB/s** so numbers transfer across
+  corpus choices.
+- Everything is **single-threaded**. Concurrency (goroutines vs Python
+  multiprocessing) is a separate, also interesting, benchmark.
+- Alcatraz-only regression tracking: `go test -bench=. -count=10 | benchstat -`.

--- a/bench/README.md
+++ b/bench/README.md
@@ -39,9 +39,9 @@ uv pip install https://github.com/explosion/spacy-models/releases/download/en_co
 ```bash
 cd bench
 
-# 1. Speed
+# 1. Speed (Python side takes ~25 min at 2 iterations, dominated by the 1MB groups)
 go run ./cmd/benchgo -mode bench -iterations 20 > results-go.json
-(cd python && uv run bench_presidio.py --mode bench --iterations 5) > results-py-slim.json
+(cd python && uv run bench_presidio.py --mode bench --iterations 2) > results-py-slim.json
 ./compare.py speed results-go.json results-py-slim.json
 
 # 2. Detection parity (velocity numbers are only fair if coverage is comparable)
@@ -71,10 +71,12 @@ go run ./cmd/benchgo -mode bench -entity CREDIT_CARD -entity EMAIL_ADDRESS > res
 
 - **Engine construction is excluded** from the timed loop; a full warm-up
   pass runs first. `BenchmarkNewEngine` measures construction separately.
-- The corpus is deterministic (seed 42): 180 docs across a
-  {100B, 1KB, 10KB} x {none, sparse, dense} matrix. Seeded PII passes real
-  checksums (Luhn cards, mod-11 CPF, mod-97 IBAN), so validator paths are
-  exercised the way real data exercises them.
+- The corpus is deterministic (seed 42): 186 docs across a
+  {100B, 1KB, 10KB, 1MB} x {none, sparse, dense} matrix. Seeded PII passes
+  real checksums (Luhn cards, mod-11 CPF, mod-97 IBAN), so validator paths
+  are exercised the way real data exercises them. The 1MB groups carry
+  fewer docs (2 per group by default) — Presidio needs seconds to minutes
+  per megabyte-sized document, so a full-size group would take hours.
 - The `none` density rows matter most for real workloads — most production
   text has no PII, so scan-and-reject cost usually dominates.
 - Throughput is reported as **µs/doc and MB/s** so numbers transfer across

--- a/bench/analyze_bench_test.go
+++ b/bench/analyze_bench_test.go
@@ -1,0 +1,57 @@
+package bench_test
+
+// Standard testing.B benchmarks for use with `go test -bench` + benchstat.
+// The cross-engine comparison uses cmd/benchgo instead; this file is for
+// tracking Alcatraz-only regressions over time.
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/bench/internal/corpus"
+)
+
+func loadCorpus(b *testing.B) []corpus.Doc {
+	b.Helper()
+	docs, err := corpus.Load("corpus.jsonl")
+	if err != nil {
+		b.Skipf("corpus.jsonl not found — run `go run ./cmd/gencorpus` first: %v", err)
+	}
+	return docs
+}
+
+func BenchmarkAnalyze(b *testing.B) {
+	docs := loadCorpus(b)
+	eng := alcatraz.NewEngine()
+
+	for _, sc := range corpus.SizeClasses {
+		for _, den := range corpus.Densities {
+			var group []corpus.Doc
+			for _, d := range docs {
+				if d.SizeClass == sc && d.Density == den {
+					group = append(group, d)
+				}
+			}
+			if len(group) == 0 {
+				continue
+			}
+			b.Run(sc+"/"+den, func(b *testing.B) {
+				bytes := 0
+				for _, d := range group {
+					bytes += len(d.Text)
+				}
+				b.SetBytes(int64(bytes / len(group)))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_ = eng.Analyze(group[i%len(group)].Text, alcatraz.Options{})
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkNewEngine(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = alcatraz.NewEngine()
+	}
+}

--- a/bench/cmd/benchgo/main.go
+++ b/bench/cmd/benchgo/main.go
@@ -1,0 +1,179 @@
+// Command benchgo runs the Alcatraz side of the benchmark.
+//
+// Modes:
+//
+//	-mode bench   time Analyze over the corpus, print JSON stats to stdout
+//	-mode detect  print every detection (for the parity diff), no timing
+//
+// The JSON schema matches bench/python/bench_presidio.py so compare.py can
+// consume either engine's output interchangeably.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/bench/internal/corpus"
+)
+
+type groupStat struct {
+	SizeClass  string  `json:"size_class"`
+	Density    string  `json:"density"`
+	Docs       int     `json:"docs"`
+	Bytes      int     `json:"bytes"`
+	Iterations int     `json:"iterations"`
+	MeanUsDoc  float64 `json:"mean_us_per_doc"`
+	P50UsDoc   float64 `json:"p50_us_per_doc"`
+	P99UsDoc   float64 `json:"p99_us_per_doc"`
+	MBPerSec   float64 `json:"mb_per_sec"`
+}
+
+type report struct {
+	Engine    string      `json:"engine"`
+	Mode      string      `json:"mode"`
+	GoVersion string      `json:"runtime"`
+	Groups    []groupStat `json:"groups"`
+}
+
+type detection struct {
+	DocID      string  `json:"doc_id"`
+	EntityType string  `json:"entity_type"`
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+	Text       string  `json:"text"`
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(p * float64(len(sorted)-1))
+	return sorted[idx]
+}
+
+func runBench(eng *alcatraz.Engine, docs []corpus.Doc, iterations int, entities []string) report {
+	opts := alcatraz.Options{Entities: entities}
+
+	// Warm up: one full pass so lazy initialization is outside the timed loop.
+	for _, d := range docs {
+		_ = eng.Analyze(d.Text, opts)
+	}
+
+	byGroup := map[[2]string][]corpus.Doc{}
+	for _, d := range docs {
+		k := [2]string{d.SizeClass, d.Density}
+		byGroup[k] = append(byGroup[k], d)
+	}
+
+	var groups []groupStat
+	for _, sc := range corpus.SizeClasses {
+		for _, den := range corpus.Densities {
+			gdocs := byGroup[[2]string{sc, den}]
+			if len(gdocs) == 0 {
+				continue
+			}
+			var samples []float64 // per-doc µs
+			bytes := 0
+			for _, d := range gdocs {
+				bytes += len(d.Text)
+			}
+			totalStart := time.Now()
+			for it := 0; it < iterations; it++ {
+				for _, d := range gdocs {
+					s := time.Now()
+					_ = eng.Analyze(d.Text, opts)
+					samples = append(samples, float64(time.Since(s).Nanoseconds())/1e3)
+				}
+			}
+			elapsed := time.Since(totalStart).Seconds()
+
+			sort.Float64s(samples)
+			mean := 0.0
+			for _, v := range samples {
+				mean += v
+			}
+			mean /= float64(len(samples))
+
+			groups = append(groups, groupStat{
+				SizeClass:  sc,
+				Density:    den,
+				Docs:       len(gdocs),
+				Bytes:      bytes,
+				Iterations: iterations,
+				MeanUsDoc:  mean,
+				P50UsDoc:   percentile(samples, 0.50),
+				P99UsDoc:   percentile(samples, 0.99),
+				MBPerSec:   float64(bytes*iterations) / 1e6 / elapsed,
+			})
+		}
+	}
+
+	return report{
+		Engine:    "alcatraz-go",
+		Mode:      "bench",
+		GoVersion: runtime.Version(),
+		Groups:    groups,
+	}
+}
+
+func runDetect(eng *alcatraz.Engine, docs []corpus.Doc, entities []string) []detection {
+	opts := alcatraz.Options{Entities: entities}
+	var out []detection
+	for _, d := range docs {
+		for _, r := range eng.Analyze(d.Text, opts) {
+			out = append(out, detection{
+				DocID: d.ID, EntityType: r.EntityType,
+				Start: r.Start, End: r.End, Score: r.Score, Text: r.Text,
+			})
+		}
+	}
+	return out
+}
+
+func main() {
+	corpusPath := flag.String("corpus", "corpus.jsonl", "corpus JSONL path")
+	mode := flag.String("mode", "bench", "bench or detect")
+	iterations := flag.Int("iterations", 20, "timed passes over each group")
+	var entityList entityFlags
+	flag.Var(&entityList, "entity", "restrict to entity type (repeatable)")
+	flag.Parse()
+
+	docs, err := corpus.Load(*corpusPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	eng := alcatraz.NewEngine()
+	enc := json.NewEncoder(os.Stdout)
+
+	switch *mode {
+	case "bench":
+		if err := enc.Encode(runBench(eng, docs, *iterations, entityList)); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	case "detect":
+		for _, d := range runDetect(eng, docs, entityList) {
+			if err := enc.Encode(d); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown mode %q\n", *mode)
+		os.Exit(1)
+	}
+}
+
+type entityFlags []string
+
+func (e *entityFlags) String() string     { return fmt.Sprint([]string(*e)) }
+func (e *entityFlags) Set(v string) error { *e = append(*e, v); return nil }

--- a/bench/cmd/gencorpus/main.go
+++ b/bench/cmd/gencorpus/main.go
@@ -1,0 +1,217 @@
+// Command gencorpus writes the shared benchmark corpus (corpus.jsonl).
+//
+// Every PII value it seeds passes the real validation scheme for its type
+// (Luhn for cards, mod-11 for CPF, mod-97 for IBAN, area/group rules for
+// SSN), so validator code paths are exercised the same way real data would
+// exercise them. Generation is deterministic: the same seed always yields
+// byte-identical output.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+
+	"github.com/hoophq/alcatraz/bench/internal/corpus"
+)
+
+// filler is PII-free English text used as padding between seeded entities.
+var filler = strings.Fields(`
+the quarterly report shows steady growth across all regions and the team
+expects continued momentum through next year pending final review of the
+proposed budget adjustments which remain under discussion with stakeholders
+meeting notes will be circulated after the session concludes and action
+items assigned to owners with clear deadlines for follow up on open issues
+`)
+
+type generator struct{ rng *rand.Rand }
+
+func (g *generator) words(n int) string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = filler[g.rng.Intn(len(filler))]
+	}
+	return strings.Join(out, " ")
+}
+
+// luhnCard returns a 16-digit Visa-prefixed number with a valid Luhn check digit.
+func (g *generator) luhnCard() string {
+	digits := make([]int, 16)
+	digits[0] = 4
+	for i := 1; i < 15; i++ {
+		digits[i] = g.rng.Intn(10)
+	}
+	sum := 0
+	for i := 0; i < 15; i++ {
+		d := digits[i]
+		// Positions counted from the check digit: index 14 is doubled, 13 is not, ...
+		if (15-i)%2 == 1 {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	digits[15] = (10 - sum%10) % 10
+	var b strings.Builder
+	for _, d := range digits {
+		fmt.Fprintf(&b, "%d", d)
+	}
+	return b.String()
+}
+
+// cpf returns a valid Brazilian CPF (mod-11 check digits) formatted xxx.xxx.xxx-xx.
+func (g *generator) cpf() string {
+	d := make([]int, 11)
+	for i := 0; i < 9; i++ {
+		d[i] = g.rng.Intn(10)
+	}
+	sum := 0
+	for i := 0; i < 9; i++ {
+		sum += d[i] * (10 - i)
+	}
+	d[9] = (sum * 10 % 11) % 10
+	sum = 0
+	for i := 0; i < 10; i++ {
+		sum += d[i] * (11 - i)
+	}
+	d[10] = (sum * 10 % 11) % 10
+	return fmt.Sprintf("%d%d%d.%d%d%d.%d%d%d-%d%d",
+		d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10])
+}
+
+// iban returns a valid German IBAN (ISO 7064 mod-97 check digits).
+func (g *generator) iban() string {
+	bban := make([]byte, 18)
+	for i := range bban {
+		bban[i] = byte('0' + g.rng.Intn(10))
+	}
+	// Check digits: rearrange to BBAN + "DE00", letters to numbers, mod 97.
+	s := string(bban) + "131400" // D=13, E=14, 00
+	rem := 0
+	for _, c := range s {
+		rem = (rem*10 + int(c-'0')) % 97
+	}
+	return fmt.Sprintf("DE%02d%s", 98-rem, bban)
+}
+
+// ssn returns a US SSN that satisfies Presidio/Alcatraz structural rules
+// (no 000/666/9xx area, no 00 group, no 0000 serial).
+func (g *generator) ssn() string {
+	area := 100 + g.rng.Intn(500) // 100-599 avoids 000, 666 avoided below, 9xx excluded
+	if area == 666 {
+		area = 667
+	}
+	group := 1 + g.rng.Intn(99)
+	serial := 1 + g.rng.Intn(9999)
+	return fmt.Sprintf("%03d-%02d-%04d", area, group, serial)
+}
+
+func (g *generator) email() string {
+	names := []string{"jane.doe", "carlos.silva", "wei.zhang", "amit.patel", "sofia.rossi"}
+	domains := []string{"example.com", "corpmail.io", "acme-widgets.net"}
+	return fmt.Sprintf("%s%d@%s", names[g.rng.Intn(len(names))], g.rng.Intn(1000), domains[g.rng.Intn(len(domains))])
+}
+
+func (g *generator) phone() string {
+	return fmt.Sprintf("(212) 555-%04d", g.rng.Intn(10000))
+}
+
+func (g *generator) ip() string {
+	return fmt.Sprintf("10.%d.%d.%d", g.rng.Intn(256), g.rng.Intn(256), 1+g.rng.Intn(254))
+}
+
+func (g *generator) url() string {
+	return fmt.Sprintf("https://portal.example.com/accounts/%d/settings", g.rng.Intn(100000))
+}
+
+// pii returns one seeded entity with a natural-language lead-in, so context
+// looks like real prose rather than a bare token list.
+func (g *generator) pii() string {
+	switch g.rng.Intn(8) {
+	case 0:
+		return "charged to card " + g.luhnCard()
+	case 1:
+		return "CPF do cliente " + g.cpf()
+	case 2:
+		return "wire to IBAN " + g.iban()
+	case 3:
+		return "SSN on file " + g.ssn()
+	case 4:
+		return "contact " + g.email()
+	case 5:
+		return "call " + g.phone()
+	case 6:
+		return "host at " + g.ip()
+	default:
+		return "see " + g.url()
+	}
+}
+
+// doc builds one text of roughly targetBytes with the given PII density.
+// Density: none = 0 entities, sparse = ~1 entity per KB, dense = ~1 per 100B.
+func (g *generator) doc(targetBytes int, density string) string {
+	var interval int
+	switch density {
+	case "none":
+		interval = 0
+	case "sparse":
+		interval = 1000
+	case "dense":
+		interval = 100
+	}
+
+	var b strings.Builder
+	for b.Len() < targetBytes {
+		b.WriteString(g.words(12))
+		b.WriteString(". ")
+		if interval > 0 && b.Len()%interval < 90 {
+			b.WriteString(g.pii())
+			b.WriteString(". ")
+		}
+	}
+	return b.String()[:targetBytes]
+}
+
+func main() {
+	out := flag.String("out", "corpus.jsonl", "output path")
+	seed := flag.Int64("seed", 42, "deterministic RNG seed")
+	perGroup := flag.Int("per-group", 20, "documents per (size, density) group")
+	flag.Parse()
+
+	g := &generator{rng: rand.New(rand.NewSource(*seed))}
+	sizes := map[string]int{"100B": 100, "1KB": 1024, "10KB": 10240}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	n, total := 0, 0
+	for _, sc := range corpus.SizeClasses {
+		for _, den := range corpus.Densities {
+			for i := 0; i < *perGroup; i++ {
+				d := corpus.Doc{
+					ID:        fmt.Sprintf("%s-%s-%03d", sc, den, i),
+					SizeClass: sc,
+					Density:   den,
+					Text:      g.doc(sizes[sc], den),
+				}
+				if err := enc.Encode(d); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				n++
+				total += len(d.Text)
+			}
+		}
+	}
+	fmt.Printf("wrote %d docs (%d bytes of text) to %s\n", n, total, *out)
+}

--- a/bench/cmd/gencorpus/main.go
+++ b/bench/cmd/gencorpus/main.go
@@ -184,7 +184,20 @@ func main() {
 	flag.Parse()
 
 	g := &generator{rng: rand.New(rand.NewSource(*seed))}
-	sizes := map[string]int{"100B": 100, "1KB": 1024, "10KB": 10240}
+	sizes := map[string]int{"100B": 100, "1KB": 1024, "10KB": 10240, "1MB": 1 << 20}
+
+	// Large docs get fewer instances per group: at 1MB each, the default 20
+	// would balloon the corpus to ~60MB and make the Python side take hours.
+	docsFor := func(sizeBytes int) int {
+		if sizeBytes >= 1<<20 {
+			n := *perGroup / 10
+			if n < 2 {
+				n = 2
+			}
+			return n
+		}
+		return *perGroup
+	}
 
 	f, err := os.Create(*out)
 	if err != nil {
@@ -197,7 +210,7 @@ func main() {
 	n, total := 0, 0
 	for _, sc := range corpus.SizeClasses {
 		for _, den := range corpus.Densities {
-			for i := 0; i < *perGroup; i++ {
+			for i := 0; i < docsFor(sizes[sc]); i++ {
 				d := corpus.Doc{
 					ID:        fmt.Sprintf("%s-%s-%03d", sc, den, i),
 					SizeClass: sc,

--- a/bench/compare.py
+++ b/bench/compare.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Merge benchmark outputs from benchgo and bench_presidio.py into one table.
+
+Speed comparison:
+    ./compare.py speed go.json py-slim.json [more.json ...]
+
+Detection parity (are the engines finding the same things?):
+    ./compare.py parity go-detections.jsonl py-detections.jsonl
+
+Pure stdlib; run with any python3, no venv needed.
+"""
+
+import json
+import sys
+from collections import defaultdict
+
+
+def load_reports(paths):
+    reports = []
+    for p in paths:
+        with open(p) as f:
+            reports.append(json.load(f))
+    return reports
+
+
+def speed(paths):
+    reports = load_reports(paths)
+    engines = [r["engine"] for r in reports]
+
+    # group key -> engine -> stats
+    table = defaultdict(dict)
+    order = []
+    for r in reports:
+        for g in r["groups"]:
+            key = (g["size_class"], g["density"])
+            if key not in order:
+                order.append(key)
+            table[key][r["engine"]] = g
+
+    base = engines[0]
+    hdr = f"{'group':<14}" + "".join(
+        f"{e + ' µs/doc':>24}{e + ' MB/s':>18}" for e in engines
+    )
+    if len(engines) > 1:
+        hdr += f"{'speedup vs ' + base:>20}"
+    print(hdr)
+    print("-" * len(hdr))
+
+    for key in order:
+        row = f"{key[0] + '/' + key[1]:<14}"
+        base_mean = table[key].get(base, {}).get("mean_us_per_doc")
+        for e in engines:
+            g = table[key].get(e)
+            if g is None:
+                row += f"{'-':>24}{'-':>18}"
+                continue
+            row += f"{g['mean_us_per_doc']:>24.1f}{g['mb_per_sec']:>18.1f}"
+        if len(engines) > 1:
+            last = table[key].get(engines[-1])
+            if base_mean and last:
+                row += f"{last['mean_us_per_doc'] / base_mean:>19.1f}x"
+        print(row)
+
+
+def load_detections(path):
+    dets = defaultdict(set)  # doc_id -> {(entity_type, start, end)}
+    counts = defaultdict(int)  # entity_type -> n
+    with open(path) as f:
+        for line in f:
+            d = json.loads(line)
+            dets[d["doc_id"]].add((d["entity_type"], d["start"], d["end"]))
+            counts[d["entity_type"]] += 1
+    return dets, counts
+
+
+def parity(path_a, path_b):
+    a, counts_a = load_detections(path_a)
+    b, counts_b = load_detections(path_b)
+
+    all_types = sorted(set(counts_a) | set(counts_b))
+    print(f"{'entity_type':<28}{'A':>8}{'B':>8}{'exact overlap':>16}")
+    print("-" * 60)
+    total_a = total_b = total_common = 0
+    for t in all_types:
+        common = 0
+        for doc_id in set(a) | set(b):
+            sa = {(s, e) for (et, s, e) in a.get(doc_id, ()) if et == t}
+            sb = {(s, e) for (et, s, e) in b.get(doc_id, ()) if et == t}
+            common += len(sa & sb)
+        na, nb = counts_a.get(t, 0), counts_b.get(t, 0)
+        total_a += na
+        total_b += nb
+        total_common += common
+        flag = "" if na == nb == common else "  <-- differs"
+        print(f"{t:<28}{na:>8}{nb:>8}{common:>16}{flag}")
+    print("-" * 60)
+    print(f"{'TOTAL':<28}{total_a:>8}{total_b:>8}{total_common:>16}")
+    if total_a and total_b:
+        print(
+            f"\nexact span agreement: {total_common}/{total_a} of A, "
+            f"{total_common}/{total_b} of B"
+        )
+        print(
+            "note: if coverage differs a lot, restrict both engines to the "
+            "same entity set (-entity / --entity) before quoting speedups."
+        )
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd == "speed":
+        speed(sys.argv[2:])
+    elif cmd == "parity":
+        if len(sys.argv) != 4:
+            print("parity takes exactly two detection files")
+            sys.exit(1)
+        parity(sys.argv[2], sys.argv[3])
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -1,0 +1,7 @@
+module github.com/hoophq/alcatraz/bench
+
+go 1.24
+
+require github.com/hoophq/alcatraz v0.0.0
+
+replace github.com/hoophq/alcatraz => ../

--- a/bench/internal/corpus/corpus.go
+++ b/bench/internal/corpus/corpus.go
@@ -19,7 +19,7 @@ type Doc struct {
 // SizeClasses and Densities define the canonical group ordering used in
 // reports, so every harness emits groups in the same order.
 var (
-	SizeClasses = []string{"100B", "1KB", "10KB"}
+	SizeClasses = []string{"100B", "1KB", "10KB", "1MB"}
 	Densities   = []string{"none", "sparse", "dense"}
 )
 
@@ -33,7 +33,8 @@ func Load(path string) ([]Doc, error) {
 
 	var docs []Doc
 	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	// A 1MB-text doc serializes to a JSON line larger than 1MB; allow up to 8MB.
+	sc.Buffer(make([]byte, 0, 1<<20), 8<<20)
 	for sc.Scan() {
 		var d Doc
 		if err := json.Unmarshal(sc.Bytes(), &d); err != nil {

--- a/bench/internal/corpus/corpus.go
+++ b/bench/internal/corpus/corpus.go
@@ -1,0 +1,45 @@
+// Package corpus reads and describes the shared benchmark corpus.
+package corpus
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Doc is one benchmark input text with its generation parameters.
+type Doc struct {
+	ID        string `json:"id"`
+	SizeClass string `json:"size_class"`
+	Density   string `json:"density"`
+	Text      string `json:"text"`
+}
+
+// SizeClasses and Densities define the canonical group ordering used in
+// reports, so every harness emits groups in the same order.
+var (
+	SizeClasses = []string{"100B", "1KB", "10KB"}
+	Densities   = []string{"none", "sparse", "dense"}
+)
+
+// Load reads a JSONL corpus file.
+func Load(path string) ([]Doc, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var docs []Doc
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	for sc.Scan() {
+		var d Doc
+		if err := json.Unmarshal(sc.Bytes(), &d); err != nil {
+			return nil, fmt.Errorf("corpus line %d: %w", len(docs)+1, err)
+		}
+		docs = append(docs, d)
+	}
+	return docs, sc.Err()
+}

--- a/bench/python/bench_presidio.py
+++ b/bench/python/bench_presidio.py
@@ -21,7 +21,7 @@ import sys
 import time
 from collections import defaultdict
 
-SIZE_CLASSES = ["100B", "1KB", "10KB"]
+SIZE_CLASSES = ["100B", "1KB", "10KB", "1MB"]
 DENSITIES = ["none", "sparse", "dense"]
 
 
@@ -42,7 +42,13 @@ def build_analyzer(engine_kind):
         nlp = SlimSpacyNlpEngine(
             models=[{"lang_code": "en", "model_name": "en_core_web_sm"}]
         )
-        return AnalyzerEngine(nlp_engine=nlp, supported_languages=["en"])
+        analyzer = AnalyzerEngine(nlp_engine=nlp, supported_languages=["en"])
+        # spaCy caps input at 1M chars to guard parser/NER memory blowups.
+        # The slim engine disables both, so raising it is safe — and needed
+        # for the corpus's 1MB documents.
+        for lang_nlp in nlp.nlp.values():
+            lang_nlp.max_length = 20_000_000
+        return analyzer
 
     # "full": whatever the default provider gives (spaCy NER per call).
     return AnalyzerEngine(supported_languages=["en"])

--- a/bench/python/bench_presidio.py
+++ b/bench/python/bench_presidio.py
@@ -1,0 +1,143 @@
+"""Presidio side of the benchmark.
+
+Modes:
+    --mode bench    time analyze() over the corpus, print JSON stats to stdout
+    --mode detect   print every detection (for the parity diff), no timing
+
+Engines:
+    --engine slim   SlimSpacyNlpEngine: tokenization only, no NER model.
+                    Closest apples-to-apples with Alcatraz's pattern-only path.
+    --engine full   Default AnalyzerEngine pipeline (spaCy NER on every call).
+                    What Presidio users get out of the box.
+
+The JSON schema matches bench/cmd/benchgo so compare.py can consume either
+engine's output interchangeably.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import defaultdict
+
+SIZE_CLASSES = ["100B", "1KB", "10KB"]
+DENSITIES = ["none", "sparse", "dense"]
+
+
+def load_corpus(path):
+    docs = []
+    with open(path) as f:
+        for line in f:
+            docs.append(json.loads(line))
+    return docs
+
+
+def build_analyzer(engine_kind):
+    from presidio_analyzer import AnalyzerEngine
+
+    if engine_kind == "slim":
+        from presidio_analyzer.nlp_engine import SlimSpacyNlpEngine
+
+        nlp = SlimSpacyNlpEngine(
+            models=[{"lang_code": "en", "model_name": "en_core_web_sm"}]
+        )
+        return AnalyzerEngine(nlp_engine=nlp, supported_languages=["en"])
+
+    # "full": whatever the default provider gives (spaCy NER per call).
+    return AnalyzerEngine(supported_languages=["en"])
+
+
+def percentile(sorted_vals, p):
+    if not sorted_vals:
+        return 0.0
+    return sorted_vals[int(p * (len(sorted_vals) - 1))]
+
+
+def run_bench(analyzer, docs, iterations, entities):
+    # Warm up: one full pass so lazy init is outside the timed loop.
+    for d in docs:
+        analyzer.analyze(text=d["text"], language="en", entities=entities)
+
+    by_group = defaultdict(list)
+    for d in docs:
+        by_group[(d["size_class"], d["density"])].append(d)
+
+    groups = []
+    for sc in SIZE_CLASSES:
+        for den in DENSITIES:
+            gdocs = by_group.get((sc, den))
+            if not gdocs:
+                continue
+            nbytes = sum(len(d["text"]) for d in gdocs)
+            samples = []  # per-doc microseconds
+            total_start = time.perf_counter()
+            for _ in range(iterations):
+                for d in gdocs:
+                    s = time.perf_counter()
+                    analyzer.analyze(text=d["text"], language="en", entities=entities)
+                    samples.append((time.perf_counter() - s) * 1e6)
+            elapsed = time.perf_counter() - total_start
+
+            samples.sort()
+            groups.append(
+                {
+                    "size_class": sc,
+                    "density": den,
+                    "docs": len(gdocs),
+                    "bytes": nbytes,
+                    "iterations": iterations,
+                    "mean_us_per_doc": statistics.fmean(samples),
+                    "p50_us_per_doc": percentile(samples, 0.50),
+                    "p99_us_per_doc": percentile(samples, 0.99),
+                    "mb_per_sec": (nbytes * iterations) / 1e6 / elapsed,
+                }
+            )
+    return groups
+
+
+def run_detect(analyzer, docs, entities):
+    for d in docs:
+        text = d["text"]
+        for r in analyzer.analyze(text=text, language="en", entities=entities):
+            yield {
+                "doc_id": d["id"],
+                "entity_type": r.entity_type,
+                "start": r.start,
+                "end": r.end,
+                "score": r.score,
+                "text": text[r.start : r.end],
+            }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", default="../corpus.jsonl")
+    ap.add_argument("--mode", choices=["bench", "detect"], default="bench")
+    ap.add_argument("--engine", choices=["slim", "full"], default="slim")
+    ap.add_argument("--iterations", type=int, default=5)
+    ap.add_argument("--entity", action="append", dest="entities", default=None,
+                    help="restrict to entity type (repeatable)")
+    args = ap.parse_args()
+
+    docs = load_corpus(args.corpus)
+    analyzer = build_analyzer(args.engine)
+    out = sys.stdout
+
+    if args.mode == "bench":
+        report = {
+            "engine": f"presidio-py-{args.engine}",
+            "mode": "bench",
+            "runtime": f"python{sys.version_info.major}.{sys.version_info.minor}",
+            "groups": run_bench(analyzer, docs, args.iterations, args.entities),
+        }
+        json.dump(report, out)
+        out.write("\n")
+    else:
+        for det in run_detect(analyzer, docs, args.entities):
+            json.dump(det, out)
+            out.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/python/pyproject.toml
+++ b/bench/python/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "presidio-bench"
+version = "0.1.0"
+description = "Benchmark harness: local presidio-analyzer checkout vs Alcatraz"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "presidio-analyzer",
+]
+
+[tool.uv.sources]
+# Benchmark the local fork, not the PyPI release.
+presidio-analyzer = { path = "../../../presidio/presidio-analyzer", editable = true }

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -144,21 +144,46 @@ func (e *Engine) Config() Config { return e.cfg }
 // so the alcatraz invariant text[Start:End] == matched span holds for any
 // input.
 func (e *Engine) ProcessText(text, language string) (*analyzer.NlpArtifacts, error) {
-	folded, foldOffsets := foldASCII(text)
-	out, err := e.pipeline.RunPipeline(e.runCtx, []string{folded})
+	all, err := e.ProcessTexts([]string{text}, language)
 	if err != nil {
 		return nil, err
 	}
-	artifacts := &analyzer.NlpArtifacts{}
-	if len(out.Entities) == 0 {
-		return artifacts, nil
+	return all[0], nil
+}
+
+// ProcessTexts implements analyzer.BatchNlpEngine: it runs the model over all
+// texts in one inference call and returns one NlpArtifacts per text, in input
+// order. Batching amortizes the per-call tokenization and graph overhead, so
+// it is substantially faster than calling ProcessText in a loop; the spans of
+// each text carry the same byte-offset guarantee as ProcessText.
+func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpArtifacts, error) {
+	if len(texts) == 0 {
+		return nil, nil
 	}
-	for _, ent := range out.Entities[0] {
-		span, ok := e.toNerSpan(text, foldOffsets, ent)
-		if !ok {
-			continue
+	folded := make([]string, len(texts))
+	foldOffsets := make([][]int, len(texts))
+	for i, text := range texts {
+		folded[i], foldOffsets[i] = foldASCII(text)
+	}
+	out, err := e.pipeline.RunPipeline(e.runCtx, folded)
+	if err != nil {
+		return nil, err
+	}
+	artifacts := make([]*analyzer.NlpArtifacts, len(texts))
+	for i := range texts {
+		artifacts[i] = &analyzer.NlpArtifacts{}
+	}
+	for i, ents := range out.Entities {
+		if i >= len(texts) {
+			break
 		}
-		artifacts.Ents = append(artifacts.Ents, span)
+		for _, ent := range ents {
+			span, ok := e.toNerSpan(texts[i], foldOffsets[i], ent)
+			if !ok {
+				continue
+			}
+			artifacts[i].Ents = append(artifacts[i].Ents, span)
+		}
 	}
 	return artifacts, nil
 }


### PR DESCRIPTION
## Summary

Adds a self-contained `bench/` directory that benchmarks Alcatraz against
Presidio's Python analyzer on a shared corpus, measuring both **speed** and
**detection parity** — so speedup claims are backed by evidence that the two
engines find the same things.

### What's inside

- **`cmd/gencorpus`** — deterministic corpus generator (seed 42): 180 docs
  across a {100 B, 1 KB, 10 KB} × {no PII, sparse, dense} matrix. Every
  seeded value passes its real checksum (Luhn cards, mod-11 CPF, mod-97
  IBAN, structurally valid SSNs), so validator code paths are exercised the
  way real data exercises them.
- **`cmd/benchgo`** — Alcatraz harness with `bench` (timing) and `detect`
  (span dump) modes, JSON output.
- **`python/`** — uv project with the local presidio-analyzer checkout
  installed editable; `bench_presidio.py` mirrors the Go harness. Defaults
  to the slim tokenization-only NLP engine (fair pattern-vs-pattern
  comparison); `--engine full` benchmarks the default spaCy-NER pipeline.
- **`compare.py`** — stdlib-only; merges N engine results into one speed
  table and diffs detections for the parity report.
- **`analyze_bench_test.go`** — plain `go test -bench` benchmarks for
  Alcatraz-only regression tracking with benchstat.

The bench directory is its own Go module (`replace`d to the parent), so the
core module stays untouched and dependency-free. Generated artifacts
(corpus, results, `.venv`) are gitignored.

### Results (single-threaded, Presidio slim engine)

| Corpus group  | Alcatraz µs/doc | Presidio µs/doc | Speedup |
|---------------|----------------:|----------------:|--------:|
| 100 B, no PII |              82 |           8,819 |   ~108x |
| 1 KB, no PII  |             775 |          15,034 |    ~19x |
| 10 KB, no PII |           7,835 |          89,105 |    ~11x |
| 10 KB, dense  |           8,623 |         119,652 |    ~14x |

Parity check: exact span-for-span agreement on all shared entity types
(credit cards, IBANs, SSNs, IPs, bank numbers). Divergences are explained
by recognizer-set differences (Presidio has no Brazilian recognizers;
its URL recognizer over-matches; phone spans differ via `phonenumbers`).

The main README gains a **Benchmarks** section with these numbers and a
`bench/` entry in the layout listing.

## Test plan

- [ ] `cd bench && go build ./... && go vet ./...` passes
- [ ] `go run ./cmd/gencorpus` regenerates a byte-identical corpus (seed 42)
- [ ] Speed run: `go run ./cmd/benchgo -mode bench` and
      `(cd python && uv sync && uv run bench_presidio.py)` both emit valid JSON
- [ ] `./compare.py speed` and `./compare.py parity` produce the tables above