### PR TITLE
add: ner windowed inference for long texts and selectable ORT/XLA backends with GPU support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Local checkout used to build libpf (see pfilter/dist); never committed.
 /privacy-filter.cpp/
+
+# Local native libraries for ORT builds of the ner module (libtokenizers.a,
+# libonnxruntime); never committed.
+/.tmp-ort/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hoop.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ not a regex. The **`alcatraz/ner`** module runs an ONNX token-classification
 model in-process via [hugot](https://github.com/knights-analytics/hugot). Like
 `lookaround`, it is a *separate module*: importing it is the only way to pull
 in the model runtime, and the default backend is pure Go — no cgo, no shared
-libraries. (For maximum throughput, build with hugot's ONNX Runtime backend:
-`-tags ORT`.)
+libraries. (For maximum throughput, including GPU, see
+[Faster inference](#faster-inference-ort-xla-and-gpu) below.)
 
 ```bash
 go get github.com/hoophq/alcatraz/ner   # requires Go 1.26+
@@ -237,6 +237,42 @@ Design notes:
 - **Byte offsets, guaranteed.** Model spans are mapped back to byte offsets
   in the original text, so `text[r.Start:r.End] == r.Text` holds for NER
   results too, including multi-byte input.
+
+### Faster inference: ORT, XLA and GPU
+
+The pure-Go backend is the zero-friction default, not the speed ceiling.
+`ner.Config.Backend` selects one of hugot's faster backends, and
+`ner.Config.Accelerator` adds a GPU execution provider on top:
+
+| `Config.Backend` | Build tags | Runtime dependency | Accelerators |
+|------------------|-----------|--------------------|--------------|
+| `"go"` (default) | none — pure Go, cross-compiles | none | — |
+| `"ort"` | `-tags ORT` (cgo + [libtokenizers.a](https://github.com/daulet/tokenizers/releases) at link time) | `libonnxruntime.{so,dylib}` ([releases](https://github.com/microsoft/onnxruntime/releases)) | `coreml` (Apple GPU/ANE), `cuda`, `directml` |
+| `"xla"` | `-tags XLA` (cgo) | PJRT plugin | `cuda` |
+
+```go
+cfg := ner.DefaultConfig()
+cfg.Backend = ner.BackendORT            // needs a -tags ORT build
+cfg.Accelerator = ner.AcceleratorCoreML // optional: Apple GPU/Neural Engine
+nlp, err := ner.New(ctx, cfg)
+```
+
+```bash
+# macOS: brew install onnxruntime — found automatically. Otherwise point
+# Config.ORTLibraryPath at the library (file or directory).
+CGO_LDFLAGS="-L/path/to/libtokenizers" go build -tags ORT .
+```
+
+The whole pipeline — windowing, batching, span merging — behaves identically
+on every backend, and a backend that is not compiled in fails `ner.New` with
+an error naming the missing build tag rather than degrading silently.
+Indicatively, ORT on CPU is ~5–10x faster than the pure-Go backend on batch
+workloads; CoreML/CUDA go beyond that. To compare on your hardware:
+
+```bash
+cd ner && ALCATRAZ_NER_LIVE=1 go test -bench LiveProcessTexts -benchtime 1x -run xxx .
+# and the same with ALCATRAZ_NER_BACKEND=ort under a -tags ORT build
+```
 
 ### Alternative backend: privacy-filter.cpp (`pfilter`)
 

--- a/ner/backend.go
+++ b/ner/backend.go
@@ -1,0 +1,197 @@
+package ner
+
+// This file selects and configures the hugot inference backend. The default
+// is hugot's pure-Go backend, which works in every build; the ORT and XLA
+// backends trade portability for speed and are compiled in only under their
+// hugot build tags ("-tags ORT", "-tags XLA" — both imply cgo). Selecting a
+// backend that is not compiled in fails at construction with hugot's
+// instructive error rather than at inference time.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/options"
+)
+
+// newBackendSession validates cfg's backend/accelerator combination,
+// assembles the hugot session options and constructs the session for the
+// selected backend.
+func newBackendSession(ctx context.Context, cfg Config) (*hugot.Session, error) {
+	backend := strings.ToLower(cfg.Backend)
+	if backend == "" {
+		backend = BackendGo
+	}
+
+	opts, err := sessionOptions(backend, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	switch backend {
+	case BackendGo:
+		return hugot.NewGoSession(ctx, opts...)
+	case BackendORT:
+		return hugot.NewORTSession(ctx, opts...)
+	case BackendXLA:
+		return hugot.NewXLASession(ctx, opts...)
+	default:
+		return nil, fmt.Errorf("unknown backend %q (want %q, %q or %q)",
+			cfg.Backend, BackendGo, BackendORT, BackendXLA)
+	}
+}
+
+// sessionOptions builds the hugot session options implied by cfg for the
+// given (normalized) backend. cfg.SessionOptions are appended last so they
+// can override anything derived here.
+func sessionOptions(backend string, cfg Config) ([]options.WithOption, error) {
+	var opts []options.WithOption
+
+	// Shape bucketing exists to bound JIT compilation, a gomlx concept: it
+	// applies to the Go and XLA backends only. ORT handles dynamic shapes
+	// natively, and hugot rejects the bucketing options on it.
+	if backend != BackendORT && len(cfg.BatchBuckets) > 0 && len(cfg.SequenceBuckets) > 0 {
+		opts = append(opts,
+			options.WithGoMLXBatchBuckets(cfg.BatchBuckets),
+			options.WithGoMLXSequenceBuckets(cfg.SequenceBuckets),
+		)
+	}
+
+	if backend == BackendORT {
+		if cfg.ORTLibraryPath != "" {
+			opts = append(opts, withORTLibrary(cfg.ORTLibraryPath))
+		} else if lib := probeORTLibrary(); lib != "" {
+			opts = append(opts, withORTLibrary(lib))
+		}
+	}
+
+	accelOpt, err := acceleratorOption(backend, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if accelOpt != nil {
+		opts = append(opts, accelOpt)
+	}
+
+	return append(opts, cfg.SessionOptions...), nil
+}
+
+// acceleratorOption maps cfg.Accelerator to the hugot execution-provider
+// option, validating that the selected backend supports it. A nil option
+// with nil error means CPU (no accelerator requested).
+func acceleratorOption(backend string, cfg Config) (options.WithOption, error) {
+	accel := strings.ToLower(cfg.Accelerator)
+	if accel == "" {
+		return nil, nil
+	}
+
+	// hugot treats a nil provider-option map as "provider not requested",
+	// so an explicit accelerator always passes a non-nil map.
+	flags := cfg.AcceleratorOptions
+	if flags == nil {
+		flags = map[string]string{}
+	}
+
+	switch accel {
+	case AcceleratorCoreML:
+		if backend != BackendORT {
+			return nil, acceleratorBackendError(accel, backend, BackendORT)
+		}
+		return options.WithCoreML(flags), nil
+	case AcceleratorCUDA:
+		if backend != BackendORT && backend != BackendXLA {
+			return nil, acceleratorBackendError(accel, backend, BackendORT, BackendXLA)
+		}
+		return options.WithCuda(flags), nil
+	case AcceleratorDirectML:
+		if backend != BackendORT {
+			return nil, acceleratorBackendError(accel, backend, BackendORT)
+		}
+		device := 0
+		if raw, ok := flags["device_id"]; ok {
+			d, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("accelerator %q: invalid device_id %q", accel, raw)
+			}
+			device = d
+		}
+		return options.WithDirectML(device), nil
+	default:
+		return nil, fmt.Errorf("unknown accelerator %q (want %q, %q or %q)",
+			cfg.Accelerator, AcceleratorCoreML, AcceleratorCUDA, AcceleratorDirectML)
+	}
+}
+
+func acceleratorBackendError(accel, backend string, want ...string) error {
+	quoted := make([]string, len(want))
+	for i, w := range want {
+		quoted[i] = strconv.Quote(w)
+	}
+	return fmt.Errorf("accelerator %q requires backend %s (Backend is %q)",
+		accel, strings.Join(quoted, " or "), backend)
+}
+
+// withORTLibrary points hugot's ORT backend at the ONNX Runtime shared
+// library. Unlike hugot's WithOnnxLibraryPath it accepts either the library
+// file itself or the directory containing it, and validates existence up
+// front so a wrong path fails with a path error instead of a dlopen failure.
+func withORTLibrary(path string) options.WithOption {
+	return func(o *options.Options) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("ONNX Runtime library: %w", err)
+		}
+		lib, dir := path, filepath.Dir(path)
+		if info.IsDir() {
+			lib, dir = filepath.Join(path, ortLibraryName()), path
+			if _, err := os.Stat(lib); err != nil {
+				return fmt.Errorf("ONNX Runtime library: %w", err)
+			}
+		}
+		o.ORTOptions.LibraryPath = &lib
+		o.ORTOptions.LibraryDir = &dir
+		return nil
+	}
+}
+
+// probeORTLibrary looks for the ONNX Runtime shared library in conventional
+// install locations beyond hugot's single platform default — notably the
+// Homebrew prefix on Apple Silicon, where "brew install onnxruntime" puts
+// it. Empty means not found; hugot then applies its own default path (and
+// its clear error when that is missing too).
+func probeORTLibrary() string {
+	var dirs []string
+	switch runtime.GOOS {
+	case "darwin":
+		dirs = []string{"/opt/homebrew/lib", "/usr/local/lib"}
+	case "windows":
+		return "" // hugot's default (the working directory) is the convention
+	default:
+		dirs = []string{"/usr/local/lib", "/usr/lib"}
+	}
+	for _, dir := range dirs {
+		lib := filepath.Join(dir, ortLibraryName())
+		if _, err := os.Stat(lib); err == nil {
+			return lib
+		}
+	}
+	return ""
+}
+
+// ortLibraryName is the platform's ONNX Runtime shared library file name.
+func ortLibraryName() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "onnxruntime.dll"
+	case "darwin":
+		return "libonnxruntime.dylib"
+	default:
+		return "libonnxruntime.so"
+	}
+}

--- a/ner/backend_test.go
+++ b/ner/backend_test.go
@@ -1,0 +1,202 @@
+package ner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/knights-analytics/hugot/options"
+)
+
+// apply runs the assembled options against a fresh hugot options struct for
+// the given (hugot-normalized, uppercase) backend, mirroring what hugot's
+// newSession does.
+func apply(t *testing.T, backend string, opts []options.WithOption) *options.Options {
+	t.Helper()
+	o := options.Defaults()
+	o.Backend = backend
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			t.Fatalf("applying option: %v", err)
+		}
+	}
+	return o
+}
+
+func TestSessionOptionsBucketing(t *testing.T) {
+	cfg := DefaultConfig()
+
+	t.Run("go backend gets bucketing options", func(t *testing.T) {
+		opts, err := sessionOptions(BackendGo, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := apply(t, "GO", opts)
+		if len(o.GoMLXOptions.BatchBuckets) == 0 || len(o.GoMLXOptions.SequenceBuckets) == 0 {
+			t.Fatalf("bucketing not applied: %+v", o.GoMLXOptions)
+		}
+	})
+
+	t.Run("ort backend skips bucketing options", func(t *testing.T) {
+		opts, err := sessionOptions(BackendORT, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Applying to an ORT options struct must not fail: hugot rejects
+		// the gomlx bucketing options on ORT, so they must be absent.
+		o := apply(t, "ORT", opts)
+		if len(o.GoMLXOptions.BatchBuckets) != 0 {
+			t.Fatalf("bucketing applied on ORT: %+v", o.GoMLXOptions)
+		}
+	})
+}
+
+func TestAcceleratorOption(t *testing.T) {
+	t.Run("empty accelerator is a no-op", func(t *testing.T) {
+		opt, err := acceleratorOption(BackendGo, Config{})
+		if err != nil || opt != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", opt, err)
+		}
+	})
+
+	t.Run("coreml requires ort", func(t *testing.T) {
+		if _, err := acceleratorOption(BackendGo, Config{Accelerator: AcceleratorCoreML}); err == nil {
+			t.Fatal("want error for coreml on go backend")
+		}
+		opt, err := acceleratorOption(BackendORT, Config{Accelerator: AcceleratorCoreML})
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := apply(t, "ORT", []options.WithOption{opt})
+		if o.ORTOptions.CoreMLOptions == nil {
+			t.Fatal("CoreMLOptions not set: a nil map means 'not requested' to hugot")
+		}
+	})
+
+	t.Run("cuda works on ort and xla, not go", func(t *testing.T) {
+		if _, err := acceleratorOption(BackendGo, Config{Accelerator: AcceleratorCUDA}); err == nil {
+			t.Fatal("want error for cuda on go backend")
+		}
+		opt, err := acceleratorOption(BackendXLA, Config{Accelerator: AcceleratorCUDA})
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := apply(t, "XLA", []options.WithOption{opt})
+		if !o.GoMLXOptions.Cuda {
+			t.Fatal("XLA cuda flag not set")
+		}
+		opt, err = acceleratorOption(BackendORT, Config{Accelerator: AcceleratorCUDA})
+		if err != nil {
+			t.Fatal(err)
+		}
+		o = apply(t, "ORT", []options.WithOption{opt})
+		if o.ORTOptions.CudaOptions == nil {
+			t.Fatal("CudaOptions not set")
+		}
+	})
+
+	t.Run("directml parses device_id", func(t *testing.T) {
+		opt, err := acceleratorOption(BackendORT, Config{
+			Accelerator:        AcceleratorDirectML,
+			AcceleratorOptions: map[string]string{"device_id": "2"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := apply(t, "ORT", []options.WithOption{opt})
+		if o.ORTOptions.DirectMLOptions == nil || *o.ORTOptions.DirectMLOptions != 2 {
+			t.Fatalf("DirectMLOptions = %v, want 2", o.ORTOptions.DirectMLOptions)
+		}
+
+		if _, err := acceleratorOption(BackendORT, Config{
+			Accelerator:        AcceleratorDirectML,
+			AcceleratorOptions: map[string]string{"device_id": "gpu0"},
+		}); err == nil {
+			t.Fatal("want error for non-numeric device_id")
+		}
+	})
+
+	t.Run("accelerator name is case-insensitive", func(t *testing.T) {
+		if _, err := acceleratorOption(BackendORT, Config{Accelerator: "CoreML"}); err != nil {
+			t.Fatalf("mixed-case accelerator rejected: %v", err)
+		}
+	})
+
+	t.Run("unknown accelerator errors", func(t *testing.T) {
+		if _, err := acceleratorOption(BackendORT, Config{Accelerator: "warp-drive"}); err == nil {
+			t.Fatal("want error for unknown accelerator")
+		}
+	})
+}
+
+func TestWithORTLibrary(t *testing.T) {
+	dir := t.TempDir()
+	lib := filepath.Join(dir, ortLibraryName())
+	if err := os.WriteFile(lib, []byte("not a real library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("file path", func(t *testing.T) {
+		o := options.Defaults()
+		if err := withORTLibrary(lib)(o); err != nil {
+			t.Fatal(err)
+		}
+		if *o.ORTOptions.LibraryPath != lib || *o.ORTOptions.LibraryDir != dir {
+			t.Fatalf("got (%s, %s)", *o.ORTOptions.LibraryPath, *o.ORTOptions.LibraryDir)
+		}
+	})
+
+	t.Run("directory path resolves the platform library name", func(t *testing.T) {
+		o := options.Defaults()
+		if err := withORTLibrary(dir)(o); err != nil {
+			t.Fatal(err)
+		}
+		if *o.ORTOptions.LibraryPath != lib || *o.ORTOptions.LibraryDir != dir {
+			t.Fatalf("got (%s, %s)", *o.ORTOptions.LibraryPath, *o.ORTOptions.LibraryDir)
+		}
+	})
+
+	t.Run("missing path errors", func(t *testing.T) {
+		if err := withORTLibrary(filepath.Join(dir, "nope"))(options.Defaults()); err == nil {
+			t.Fatal("want error for missing library")
+		}
+	})
+
+	t.Run("directory without the library errors", func(t *testing.T) {
+		if err := withORTLibrary(t.TempDir())(options.Defaults()); err == nil {
+			t.Fatal("want error for directory without library")
+		}
+	})
+}
+
+func TestNewBackendValidation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unknown backend fails fast", func(t *testing.T) {
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), Backend: "banana"})
+		if err == nil || !strings.Contains(err.Error(), "unknown backend") {
+			t.Fatalf("err = %v, want unknown backend error", err)
+		}
+	})
+
+	t.Run("accelerator on wrong backend fails fast", func(t *testing.T) {
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), Accelerator: AcceleratorCoreML})
+		if err == nil || !strings.Contains(err.Error(), "requires backend") {
+			t.Fatalf("err = %v, want accelerator/backend mismatch error", err)
+		}
+	})
+
+	t.Run("ort backend never falls back silently", func(t *testing.T) {
+		// The failure mode depends on the build: hugot's stub reports the
+		// missing ORT build tag, a -tags ORT binary without the shared
+		// library reports the missing library, and a fully ORT-capable
+		// binary fails on the empty model directory. In every case New
+		// must return an error rather than degrade to another backend.
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), Backend: BackendORT})
+		if err == nil {
+			t.Fatal("want error: empty model dir can never yield a working ORT engine")
+		}
+	})
+}

--- a/ner/bench_test.go
+++ b/ner/bench_test.go
@@ -1,0 +1,68 @@
+package ner
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// BenchmarkLiveProcessTexts measures end-to-end batched inference throughput
+// (tokenization, windowing, model, span mapping) over a synthetic message
+// corpus. Like TestLiveNER it needs the real model, so it is gated behind
+// ALCATRAZ_NER_LIVE=1 and configured by the same environment variables,
+// which makes backend comparisons one-liners:
+//
+//	ALCATRAZ_NER_LIVE=1 go test -bench LiveProcessTexts -benchtime 1x -run xxx .
+//	ALCATRAZ_NER_LIVE=1 ALCATRAZ_NER_BACKEND=ort CGO_LDFLAGS=-L/path/to/libtokenizers \
+//	  go test -tags ORT -bench LiveProcessTexts -benchtime 1x -run xxx .
+//
+// ALCATRAZ_NER_BENCH_BYTES sets the corpus size (default 300000). Reported
+// MB/s is corpus bytes per wall-clock second, single inference stream.
+func BenchmarkLiveProcessTexts(b *testing.B) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		b.Skip("set ALCATRAZ_NER_LIVE=1 to run the live benchmark")
+	}
+	cfg := DefaultConfig()
+	cfg.Backend = os.Getenv("ALCATRAZ_NER_BACKEND")
+	cfg.ORTLibraryPath = os.Getenv("ALCATRAZ_NER_ORT_LIB")
+	cfg.Accelerator = os.Getenv("ALCATRAZ_NER_ACCELERATOR")
+
+	corpusBytes := 300_000
+	if v := os.Getenv("ALCATRAZ_NER_BENCH_BYTES"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			b.Fatalf("ALCATRAZ_NER_BENCH_BYTES: %v", err)
+		}
+		corpusBytes = n
+	}
+
+	// Message-like prose with entities, in varied lengths (1-7 paragraphs)
+	// so batching sees a realistic mix of short rows and windowed rows.
+	const para = "Yesterday John Smith from Berlin deployed the payment service " +
+		"and emailed maria.silva@example.com about the incident in Sao Paulo. " +
+		"The on-call engineer, Alice Johnson, reviewed the production logs and " +
+		"confirmed the fix before the Tuesday retrospective. "
+	var texts []string
+	total := 0
+	for i := 0; total < corpusBytes; i++ {
+		msg := strings.Repeat(para, 1+i%7)
+		texts = append(texts, msg)
+		total += len(msg)
+	}
+
+	nlp, err := New(context.Background(), cfg)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	defer nlp.Close()
+
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := nlp.ProcessTexts(texts, "en"); err != nil {
+			b.Fatalf("ProcessTexts: %v", err)
+		}
+	}
+}

--- a/ner/config.go
+++ b/ner/config.go
@@ -4,6 +4,23 @@ import (
 	"sort"
 
 	"github.com/hoophq/alcatraz/entities"
+	"github.com/knights-analytics/hugot/options"
+)
+
+// Inference backends selectable via Config.Backend. The zero value means
+// BackendGo.
+const (
+	BackendGo  = "go"
+	BackendORT = "ort"
+	BackendXLA = "xla"
+)
+
+// Hardware execution providers selectable via Config.Accelerator. The zero
+// value means CPU.
+const (
+	AcceleratorCoreML   = "coreml"
+	AcceleratorCUDA     = "cuda"
+	AcceleratorDirectML = "directml"
 )
 
 // Config configures the NER engine: which model to run and how its labels
@@ -28,6 +45,46 @@ type Config struct {
 	// more than one. Empty means the single .onnx file in the repository.
 	OnnxFilename string
 
+	// Backend selects the hugot inference backend (see the package
+	// documentation for the build matrix):
+	//
+	//   - BackendGo (default): pure Go, no cgo, no shared libraries. Works
+	//     in every build; the slowest option.
+	//   - BackendORT: ONNX Runtime via cgo. Typically 5-10x faster than the
+	//     Go backend on CPU, and the gateway to GPU acceleration (see
+	//     Accelerator). The binary must be built with "-tags ORT" and an
+	//     ONNX Runtime shared library must be present at runtime; selecting
+	//     it in a build without the tag makes New fail with a clear error.
+	//   - BackendXLA: gomlx over XLA/PJRT plugins. Requires "-tags XLA" and
+	//     a PJRT plugin at runtime.
+	Backend string
+	// ORTLibraryPath locates the ONNX Runtime shared library for
+	// BackendORT: either the library file itself (libonnxruntime.dylib,
+	// libonnxruntime.so, onnxruntime.dll) or the directory containing it.
+	// Empty falls back to hugot's platform default (/usr/local/lib on
+	// macOS, /usr/lib on Linux). Ignored by other backends.
+	ORTLibraryPath string
+	// Accelerator requests a hardware execution provider on top of the
+	// selected backend. Empty means CPU. Supported values:
+	//
+	//   - AcceleratorCoreML: Apple GPU / Neural Engine (BackendORT, macOS).
+	//   - AcceleratorCUDA: NVIDIA GPU (BackendORT or BackendXLA).
+	//   - AcceleratorDirectML: DirectX 12 GPU (BackendORT, Windows).
+	//
+	// Selecting an accelerator the backend does not support makes New fail
+	// fast rather than silently running on CPU.
+	Accelerator string
+	// AcceleratorOptions passes provider-specific flags through to the
+	// execution provider, e.g. CoreML's "ModelFormat"/"MLComputeUnits" or
+	// CUDA's "device_id". For AcceleratorDirectML the "device_id" entry
+	// selects the GPU (default 0). Nil means provider defaults.
+	AcceleratorOptions map[string]string
+	// SessionOptions appends raw hugot session options after the ones
+	// derived from this Config, as an escape hatch for tuning knobs not
+	// modeled here (thread counts, graph optimization level, ...). Most
+	// callers leave it nil.
+	SessionOptions []options.WithOption
+
 	// LabelMapping maps model labels (after BIO-prefix stripping, so "PER"
 	// not "B-PER") to canonical entity names. Unmapped labels are kept
 	// as-is, mirroring Presidio's keep-but-warn behavior; add them to
@@ -43,6 +100,25 @@ type Config struct {
 	// LowScoreMultiplier is the factor applied to LowScoreEntities scores.
 	// Zero disables the adjustment.
 	LowScoreMultiplier float64
+
+	// BatchBuckets and SequenceBuckets bound the set of input shapes the
+	// runtime JIT-compiles: inputs are padded up to the nearest bucket, so
+	// at most len(BatchBuckets) × len(SequenceBuckets) programs are ever
+	// compiled instead of one per distinct input shape — on varied corpora
+	// that turns hundreds of expensive graph compilations into a handful.
+	// Nil means DefaultConfig's buckets; an explicit empty slice disables
+	// bucketing (exact shapes, unbounded compilation cache).
+	//
+	// The largest BatchBuckets entry is also the engine's inference
+	// sub-batch size, and the largest SequenceBuckets entry caps the
+	// windowed-inference window size (clamped to the model's own token
+	// limit), so texts of any length are analyzed in full. Those two roles
+	// apply on every backend; the shape-padding role is specific to
+	// BackendGo and BackendXLA (BackendORT handles dynamic shapes natively
+	// and ignores bucketing).
+	BatchBuckets []int
+	// SequenceBuckets is documented with BatchBuckets.
+	SequenceBuckets []int
 }
 
 // DefaultConfig returns a configuration matching Presidio's default NER
@@ -68,6 +144,15 @@ func DefaultConfig() Config {
 		},
 		LabelsToIgnore:     []string{"ORGANIZATION", "MISC"},
 		LowScoreMultiplier: 0.4,
+		// Shapes are padded to (batch bucket, sequence bucket) pairs: fine
+		// enough that short texts don't pay for long ones, coarse enough
+		// that at most 6 × 8 programs are compiled. The 256 cap is well
+		// under the model's 512-token position limit on purpose: BERT-family
+		// NER recall degrades sharply as sequences approach the limit
+		// (entities late in a near-limit window are missed outright), and
+		// shorter windows are also cheaper to run.
+		BatchBuckets:    []int{1, 2, 4, 8, 16, 32},
+		SequenceBuckets: []int{16, 32, 48, 64, 96, 128, 192, 256},
 	}
 }
 

--- a/ner/config.go
+++ b/ner/config.go
@@ -107,7 +107,8 @@ type Config struct {
 	// compiled instead of one per distinct input shape — on varied corpora
 	// that turns hundreds of expensive graph compilations into a handful.
 	// Nil means DefaultConfig's buckets; an explicit empty slice disables
-	// bucketing (exact shapes, unbounded compilation cache).
+	// bucketing (exact shapes, unbounded compilation cache). Entries must
+	// be positive; New rejects zero or negative values.
 	//
 	// The largest BatchBuckets entry is also the engine's inference
 	// sub-batch size, and the largest SequenceBuckets entry caps the

--- a/ner/go.mod
+++ b/ner/go.mod
@@ -7,6 +7,7 @@ go 1.26
 require github.com/hoophq/alcatraz v0.0.0
 
 require (
+	github.com/gomlx/go-huggingface v0.3.5
 	github.com/knights-analytics/hugot v0.7.5
 	golang.org/x/text v0.37.0
 )
@@ -18,7 +19,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gomlx/exceptions v0.0.3 // indirect
-	github.com/gomlx/go-huggingface v0.3.5 // indirect
 	github.com/gomlx/go-xla v0.2.2 // indirect
 	github.com/gomlx/gomlx v0.27.3 // indirect
 	github.com/gomlx/onnx-gomlx v0.4.2 // indirect

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -3,11 +3,43 @@
 // recognizers cannot express, using an ONNX token-classification model run
 // in-process via hugot.
 //
+// Texts of any length are supported: input beyond the model's token limit is
+// split into overlapping windows that are batched through the model and
+// merged back (see windows.go), so entities deep inside large texts are
+// detected instead of being truncated away. Inference shapes are padded to a
+// small set of buckets (Config.BatchBuckets/SequenceBuckets), bounding JIT
+// compilation to a few dozen programs regardless of corpus variety.
+//
 // It lives in a separate module on purpose (mirroring alcatraz/lookaround):
 // importing it is the only way to pull in the model runtime, so the alcatraz
 // core stays dependency-free. The default hugot backend is pure Go — no cgo,
-// no shared libraries. For higher throughput, build with hugot's ORT backend
-// ("-tags ORT") and an ONNX Runtime shared library.
+// no shared libraries.
+//
+// # Faster inference
+//
+// The pure-Go backend is the portability floor, not the speed ceiling. For
+// large corpora, Config.Backend selects a faster hugot backend and
+// Config.Accelerator adds a GPU execution provider on top:
+//
+//	Backend      build tags   runtime dependency          speed (indicative)
+//	"go"         none         none                        1x (baseline)
+//	"ort"        -tags ORT    libonnxruntime.{so,dylib}   ~5-10x on CPU
+//	"ort"+accel  -tags ORT    + CoreML / CUDA / DirectML  beyond that
+//	"xla"        -tags XLA    PJRT plugin (CPU/CUDA/TPU)  similar to ORT
+//
+//	cfg := ner.DefaultConfig()
+//	cfg.Backend = ner.BackendORT          // requires a -tags ORT build
+//	cfg.Accelerator = ner.AcceleratorCoreML // Apple GPU/Neural Engine
+//	nlp, err := ner.New(ctx, cfg)
+//
+// The ORT and XLA build tags imply cgo, so accelerated binaries cannot be
+// cross-compiled the way pure-Go ones can, and they load a native shared
+// library at runtime (on macOS, "brew install onnxruntime" is found
+// automatically; elsewhere set Config.ORTLibraryPath). Selecting a backend
+// that is not compiled in makes New fail with an error saying which build
+// tag is missing, so a pure-Go binary degrades loudly, not silently. The
+// whole pipeline — windowing, batching, span merging — behaves identically
+// on every backend.
 //
 // The Engine implements analyzer.NlpEngine, so an analyzer.Engine configured
 // with SetNlpEngine runs the model once per Analyze call and shares the
@@ -30,6 +62,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/hoophq/alcatraz/analyzer"
@@ -51,6 +84,15 @@ type Engine struct {
 	session  *hugot.Session
 	pipeline *pipelines.TokenClassificationPipeline
 	cfg      Config
+
+	// tokenBudget is the maximum tokens (special tokens included) a single
+	// inference row may hold: the smaller of the largest sequence bucket
+	// and the model's position limit. Longer texts are split into
+	// overlapping windows of at most this many tokens (see windows.go).
+	tokenBudget int
+	// maxBatch is the inference sub-batch size: the largest batch bucket.
+	// ProcessTexts never sends more rows than this in one model call.
+	maxBatch int
 }
 
 // New loads (downloading first if needed) the configured model and fails
@@ -70,6 +112,14 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 			cfg.LabelsToIgnore = def.LabelsToIgnore
 		}
 	}
+	if cfg.BatchBuckets == nil {
+		cfg.BatchBuckets = def.BatchBuckets
+	}
+	if cfg.SequenceBuckets == nil {
+		cfg.SequenceBuckets = def.SequenceBuckets
+	}
+	sort.Ints(cfg.BatchBuckets)
+	sort.Ints(cfg.SequenceBuckets)
 
 	modelPath := cfg.ModelPath
 	if modelPath == "" {
@@ -84,7 +134,7 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	// inference, so it must not inherit the caller's cancellation either —
 	// only the model download above is bound to the construction ctx.
 	runCtx := context.WithoutCancel(ctx)
-	session, err := hugot.NewGoSession(runCtx)
+	session, err := newBackendSession(runCtx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("ner: creating hugot session: %w", err)
 	}
@@ -103,7 +153,30 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 		return nil, fmt.Errorf("ner: creating token classification pipeline: %w", err)
 	}
 
-	return &Engine{runCtx: runCtx, session: session, pipeline: pipeline, cfg: cfg}, nil
+	tokenBudget := 0
+	if len(cfg.SequenceBuckets) > 0 {
+		tokenBudget = cfg.SequenceBuckets[len(cfg.SequenceBuckets)-1]
+	}
+	if m := pipeline.Model.MaxPositionEmbeddings; m > 0 && (tokenBudget == 0 || m < tokenBudget) {
+		tokenBudget = m
+	}
+	if tokenBudget == 0 {
+		// No bucket and no model limit declared: BERT-family default.
+		tokenBudget = 512
+	}
+	maxBatch := 32
+	if len(cfg.BatchBuckets) > 0 {
+		maxBatch = cfg.BatchBuckets[len(cfg.BatchBuckets)-1]
+	}
+
+	return &Engine{
+		runCtx:      runCtx,
+		session:     session,
+		pipeline:    pipeline,
+		cfg:         cfg,
+		tokenBudget: tokenBudget,
+		maxBatch:    maxBatch,
+	}, nil
 }
 
 // ensureModel returns the local path of cfg.Model, downloading it from
@@ -152,10 +225,14 @@ func (e *Engine) ProcessText(text, language string) (*analyzer.NlpArtifacts, err
 }
 
 // ProcessTexts implements analyzer.BatchNlpEngine: it runs the model over all
-// texts in one inference call and returns one NlpArtifacts per text, in input
-// order. Batching amortizes the per-call tokenization and graph overhead, so
-// it is substantially faster than calling ProcessText in a loop; the spans of
-// each text carry the same byte-offset guarantee as ProcessText.
+// texts in batched inference calls and returns one NlpArtifacts per text, in
+// input order. Batching amortizes the per-call tokenization and graph
+// overhead, so it is substantially faster than calling ProcessText in a loop;
+// the spans of each text carry the same byte-offset guarantee as ProcessText.
+//
+// Texts longer than the model's token limit are split into overlapping
+// windows (see windows.go) and their spans merged, so entities anywhere in a
+// text of any length are detected — they are never truncated away.
 func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpArtifacts, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -165,24 +242,64 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 	for i, text := range texts {
 		folded[i], foldOffsets[i] = foldASCII(text)
 	}
-	out, err := e.pipeline.RunPipeline(e.runCtx, folded)
-	if err != nil {
-		return nil, err
+
+	// One inference row per window. Short texts (the common case) produce
+	// exactly one row covering the whole text.
+	type inferenceRow struct {
+		textIdx int
+		offset  int // window start, in folded-text bytes
+		body    string
 	}
+	var rows []inferenceRow
+	for i := range texts {
+		for _, w := range e.windows(folded[i]) {
+			rows = append(rows, inferenceRow{i, w.start, folded[i][w.start:w.end]})
+		}
+	}
+
 	artifacts := make([]*analyzer.NlpArtifacts, len(texts))
 	for i := range texts {
 		artifacts[i] = &analyzer.NlpArtifacts{}
 	}
-	for i, ents := range out.Entities {
-		if i >= len(texts) {
-			break
+	windowed := make([]bool, len(texts))
+
+	for c := 0; c < len(rows); c += e.maxBatch {
+		chunk := rows[c:min(c+e.maxBatch, len(rows))]
+		bodies := make([]string, len(chunk))
+		for j, r := range chunk {
+			bodies[j] = r.body
 		}
-		for _, ent := range ents {
-			span, ok := e.toNerSpan(texts[i], foldOffsets[i], ent)
-			if !ok {
-				continue
+		out, err := e.pipeline.RunPipeline(e.runCtx, bodies)
+		if err != nil {
+			return nil, err
+		}
+		for j, ents := range out.Entities {
+			if j >= len(chunk) {
+				break
 			}
-			artifacts[i].Ents = append(artifacts[i].Ents, span)
+			row := chunk[j]
+			if row.offset > 0 {
+				windowed[row.textIdx] = true
+			}
+			for _, ent := range ents {
+				// Window-relative offsets → folded-text offsets; toNerSpan
+				// then remaps folded → original text.
+				ent.Start += uint(row.offset)
+				ent.End += uint(row.offset)
+				span, ok := e.toNerSpan(texts[row.textIdx], foldOffsets[row.textIdx], ent)
+				if !ok {
+					continue
+				}
+				artifacts[row.textIdx].Ents = append(artifacts[row.textIdx].Ents, span)
+			}
+		}
+	}
+
+	// Overlapping windows can report the same entity twice; single-window
+	// texts need no merge.
+	for i, a := range artifacts {
+		if windowed[i] {
+			a.Ents = mergeSpans(a.Ents)
 		}
 	}
 	return artifacts, nil

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -65,6 +65,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gomlx/go-huggingface/tokenizers/api"
 	"github.com/hoophq/alcatraz/analyzer"
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/pipelines"
@@ -84,6 +85,12 @@ type Engine struct {
 	session  *hugot.Session
 	pipeline *pipelines.TokenClassificationPipeline
 	cfg      Config
+
+	// winTok is the tokenizer used to size inference windows (see
+	// windows.go): the pipeline's own pure-Go tokenizer, or a standalone
+	// one loaded from the model's tokenizer.json on rust-tokenizer builds.
+	// Nil only if neither could be resolved (byte-window fallback).
+	winTok api.Tokenizer
 
 	// tokenBudget is the maximum tokens (special tokens included) a single
 	// inference row may hold: the smaller of the largest sequence bucket
@@ -184,6 +191,7 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 		session:     session,
 		pipeline:    pipeline,
 		cfg:         cfg,
+		winTok:      windowTokenizer(pipeline, modelPath),
 		tokenBudget: tokenBudget,
 		maxBatch:    maxBatch,
 	}, nil

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -120,6 +120,16 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	}
 	sort.Ints(cfg.BatchBuckets)
 	sort.Ints(cfg.SequenceBuckets)
+	// The buckets feed padding shapes, the inference sub-batch size and the
+	// window token budget, all of which must be positive — a non-positive
+	// batch bucket would stall ProcessTexts' batching loop outright. The
+	// slices are sorted, so checking the first entry covers them all.
+	if len(cfg.BatchBuckets) > 0 && cfg.BatchBuckets[0] <= 0 {
+		return nil, fmt.Errorf("ner: BatchBuckets entries must be positive, got %v", cfg.BatchBuckets)
+	}
+	if len(cfg.SequenceBuckets) > 0 && cfg.SequenceBuckets[0] <= 0 {
+		return nil, fmt.Errorf("ner: SequenceBuckets entries must be positive, got %v", cfg.SequenceBuckets)
+	}
 
 	modelPath := cfg.ModelPath
 	if modelPath == "" {

--- a/ner/ner_test.go
+++ b/ner/ner_test.go
@@ -3,6 +3,7 @@ package ner
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hoophq/alcatraz/analyzer"
@@ -190,16 +191,25 @@ func TestRecognizerWithArtifacts(t *testing.T) {
 
 // TestLiveNER downloads the default model (~250MB on first run) and checks
 // the full pipeline end to end. Gated behind ALCATRAZ_NER_LIVE=1.
+//
+// The backend is selectable so the same assertions verify every backend:
+// ALCATRAZ_NER_BACKEND=ort (with a -tags ORT build), ALCATRAZ_NER_ORT_LIB
+// pointing at the ONNX Runtime library if it is not in a standard location,
+// and ALCATRAZ_NER_ACCELERATOR=coreml/cuda for GPU execution providers.
 func TestLiveNER(t *testing.T) {
 	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
 		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
 	}
+	cfg := DefaultConfig()
+	cfg.Backend = os.Getenv("ALCATRAZ_NER_BACKEND")
+	cfg.ORTLibraryPath = os.Getenv("ALCATRAZ_NER_ORT_LIB")
+	cfg.Accelerator = os.Getenv("ALCATRAZ_NER_ACCELERATOR")
 
 	// Construct with a cancellable ctx and cancel it right after New: the
 	// ctx bounds construction only, so inference below must be unaffected
 	// (the engine's lifetime is governed by Close, not the ctx).
 	ctx, cancel := context.WithCancel(context.Background())
-	nlp, err := New(ctx, DefaultConfig())
+	nlp, err := New(ctx, cfg)
 	cancel()
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -237,5 +247,25 @@ func TestLiveNER(t *testing.T) {
 			t.Errorf("offset invariant broken: [%d:%d] = %q, Text = %q",
 				r.Start, r.End, utf8Text[r.Start:r.End], r.Text)
 		}
+	}
+
+	// Windowed inference: a text far beyond the model's 512-token limit
+	// must still be analyzed in full — entities near the end used to be
+	// unreachable (inference failed outright on over-long input).
+	filler := strings.Repeat("the deployment pipeline ran and produced output logs without issues. ", 300)
+	long := filler + "Finally John Smith arrived in Berlin."
+	longArts, err := nlp.ProcessText(long, "en")
+	if err != nil {
+		t.Fatalf("ProcessText on long text: %v", err)
+	}
+	found := map[string]bool{}
+	for _, span := range longArts.Ents {
+		found[span.EntityType+":"+long[span.Start:span.End]] = true
+	}
+	if !found[entities.Person+":John Smith"] {
+		t.Errorf("long text: PERSON 'John Smith' not found (got %v)", found)
+	}
+	if !found[entities.Location+":Berlin"] {
+		t.Errorf("long text: LOCATION 'Berlin' not found (got %v)", found)
 	}
 }

--- a/ner/ner_test.go
+++ b/ner/ner_test.go
@@ -189,6 +189,35 @@ func TestRecognizerWithArtifacts(t *testing.T) {
 	})
 }
 
+// TestNewRejectsNonPositiveBuckets guards ProcessTexts' batching loop, which
+// advances by the largest batch bucket: a non-positive value would make it
+// loop forever, and a non-positive sequence bucket would corrupt the window
+// token budget. New must reject both up front.
+func TestNewRejectsNonPositiveBuckets(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("zero batch bucket", func(t *testing.T) {
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), BatchBuckets: []int{0}})
+		if err == nil || !strings.Contains(err.Error(), "BatchBuckets") {
+			t.Fatalf("err = %v, want BatchBuckets validation error", err)
+		}
+	})
+
+	t.Run("negative batch bucket among valid ones", func(t *testing.T) {
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), BatchBuckets: []int{8, -1, 32}})
+		if err == nil || !strings.Contains(err.Error(), "BatchBuckets") {
+			t.Fatalf("err = %v, want BatchBuckets validation error", err)
+		}
+	})
+
+	t.Run("non-positive sequence bucket", func(t *testing.T) {
+		_, err := New(ctx, Config{ModelPath: t.TempDir(), SequenceBuckets: []int{-16, 128}})
+		if err == nil || !strings.Contains(err.Error(), "SequenceBuckets") {
+			t.Fatalf("err = %v, want SequenceBuckets validation error", err)
+		}
+	})
+}
+
 // TestLiveNER downloads the default model (~250MB on first run) and checks
 // the full pipeline end to end. Gated behind ALCATRAZ_NER_LIVE=1.
 //

--- a/ner/windows.go
+++ b/ner/windows.go
@@ -1,0 +1,185 @@
+package ner
+
+// This file implements windowed inference: texts whose token count exceeds
+// the model's sequence limit are split into overlapping model-sized windows,
+// each window is analyzed independently (batched with everything else), and
+// the per-window spans are merged back. Without it, texts beyond the limit
+// either fail inference outright (the pure-Go tokenizer applies no
+// truncation for token-classification pipelines) or are silently truncated
+// (the rust tokenizer), losing every entity past ~2KB of text.
+
+import (
+	"sort"
+
+	"github.com/gomlx/go-huggingface/tokenizers/api"
+	"github.com/hoophq/alcatraz/analyzer"
+)
+
+const (
+	// windowOverlapTokens is how many content tokens consecutive windows
+	// share. An entity that straddles a window boundary is cut in one
+	// window but appears whole in the next as long as it is shorter than
+	// the overlap; mergeSpans then drops the cut fragment.
+	windowOverlapTokens = 32
+
+	// fallbackBytesPerToken sizes byte-based windows when the tokenizer is
+	// not introspectable (rust tokenizer builds). Three bytes per token is
+	// conservative for prose (~4.5) without exploding the window count;
+	// the rust tokenizer truncates over-long windows instead of failing,
+	// so an underestimate degrades gracefully.
+	fallbackBytesPerToken = 3
+)
+
+// textWindow is one model-sized slice of a folded text: byte offsets
+// [start, end) into the folded string.
+type textWindow struct {
+	start, end int
+}
+
+// windows splits a folded text into inference-ready windows. Texts within
+// the model's token budget yield a single window covering the whole text.
+func (e *Engine) windows(folded string) []textWindow {
+	tk := e.goTokenizer()
+	if tk == nil {
+		size := e.tokenBudget * fallbackBytesPerToken
+		return byteWindows(len(folded), size, windowOverlapTokens*fallbackBytesPerToken)
+	}
+	return tokenWindows(tk, folded, e.tokenBudget)
+}
+
+// goTokenizer returns the pipeline's tokenizer when it is the pure-Go
+// implementation (the default backend). Rust tokenizer builds return nil and
+// fall back to byte-estimate windows.
+func (e *Engine) goTokenizer() api.Tokenizer {
+	tk := e.pipeline.Model.Tokenizer
+	if tk == nil || tk.GoTokenizer == nil {
+		return nil
+	}
+	return tk.GoTokenizer.Tokenizer
+}
+
+// tokenWindows builds windows by tokenizing the text once and slicing the
+// content-token stream into runs that re-encode within totalBudget tokens
+// (special tokens included). Each candidate window is verified by re-encoding
+// its substring — cutting mid-word can inflate the token count, so the run is
+// shrunk until it provably fits. Windows are built sequentially and each next
+// window starts windowOverlapTokens before the previous one's actual end, so
+// shrinking never opens a gap.
+func tokenWindows(tk api.Tokenizer, folded string, totalBudget int) []textWindow {
+	enc := tk.EncodeWithAnnotations(folded)
+	spans := contentSpans(enc)
+	if len(enc.IDs) <= totalBudget || len(spans) == 0 {
+		return []textWindow{{0, len(folded)}}
+	}
+	// Special tokens ([CLS]/[SEP], model-dependent) occupy part of the
+	// budget in every window.
+	specials := len(enc.IDs) - len(spans)
+	contentBudget := totalBudget - specials
+	if contentBudget < 1 {
+		contentBudget = 1
+	}
+
+	var wins []textWindow
+	start := 0
+	for start < len(spans) {
+		take := min(contentBudget, len(spans)-start)
+		for take > 1 {
+			w := textWindow{spans[start].Start, spans[start+take-1].End}
+			excess := len(tk.Encode(folded[w.start:w.end])) - totalBudget
+			if excess <= 0 {
+				break
+			}
+			take -= max(1, excess)
+		}
+		if take < 1 {
+			take = 1
+		}
+		wins = append(wins, textWindow{spans[start].Start, spans[start+take-1].End})
+		if start+take >= len(spans) {
+			break
+		}
+		start += max(1, take-windowOverlapTokens)
+	}
+	return wins
+}
+
+// contentSpans returns the byte spans of non-special tokens, in text order.
+// Special tokens are identified by the tokenizer's mask when present, and by
+// their empty span otherwise.
+func contentSpans(enc api.AnnotatedEncoding) []api.TokenSpan {
+	spans := make([]api.TokenSpan, 0, len(enc.Spans))
+	for i, s := range enc.Spans {
+		if len(enc.SpecialTokensMask) == len(enc.Spans) && enc.SpecialTokensMask[i] == 1 {
+			continue
+		}
+		if s.End <= s.Start {
+			continue
+		}
+		spans = append(spans, s)
+	}
+	return spans
+}
+
+// byteWindows splits [0, n) into fixed-size windows with the given overlap.
+// The folded text is always single-byte-per-rune ASCII, so any byte offset
+// is a valid cut point.
+func byteWindows(n, size, overlap int) []textWindow {
+	if size < 1 {
+		size = 1
+	}
+	if n <= size {
+		return []textWindow{{0, n}}
+	}
+	step := size - overlap
+	if step < 1 {
+		step = 1
+	}
+	var wins []textWindow
+	for s := 0; ; s += step {
+		e := min(s+size, n)
+		wins = append(wins, textWindow{s, e})
+		if e == n {
+			return wins
+		}
+	}
+}
+
+// mergeSpans resolves the duplicates that overlapping windows produce: exact
+// duplicates collapse keeping the highest score, and a span contained within
+// a wider span of the same entity type (a fragment cut at a window boundary)
+// is dropped. The result is sorted by Start, then End.
+func mergeSpans(spans []analyzer.NerSpan) []analyzer.NerSpan {
+	if len(spans) < 2 {
+		return spans
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].Start != spans[j].Start {
+			return spans[i].Start < spans[j].Start
+		}
+		return spans[i].End > spans[j].End
+	})
+	// widest[type] is the largest End among kept spans of that type; since
+	// spans are visited in ascending Start order, a span with End within it
+	// is fully contained in an earlier, wider span.
+	widest := map[string]int{}
+	out := spans[:0]
+	for _, s := range spans {
+		if len(out) > 0 {
+			last := &out[len(out)-1]
+			if last.EntityType == s.EntityType && last.Start == s.Start && last.End == s.End {
+				if s.Score > last.Score {
+					last.Score = s.Score
+				}
+				continue
+			}
+		}
+		if end, ok := widest[s.EntityType]; ok && s.End <= end {
+			continue
+		}
+		out = append(out, s)
+		if s.End > widest[s.EntityType] {
+			widest[s.EntityType] = s.End
+		}
+	}
+	return out
+}

--- a/ner/windows.go
+++ b/ner/windows.go
@@ -7,12 +7,24 @@ package ner
 // either fail inference outright (the pure-Go tokenizer applies no
 // truncation for token-classification pipelines) or are silently truncated
 // (the rust tokenizer), losing every entity past ~2KB of text.
+//
+// Window boundaries always come from a real tokenizer so every window
+// provably fits the token budget: the pipeline's own tokenizer on the
+// pure-Go backend, or a standalone pure-Go tokenizer loaded from the same
+// tokenizer.json on the rust-tokenizer backends (ORT/XLA), where the
+// pipeline's tokenizer cannot be introspected. Only if that load fails does
+// windowing fall back to byte-sized windows — sized so they cannot exceed
+// the budget either (see windows).
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/gomlx/go-huggingface/tokenizers/api"
+	"github.com/gomlx/go-huggingface/tokenizers/hftokenizer"
 	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/knights-analytics/hugot/pipelines"
 )
 
 const (
@@ -22,12 +34,12 @@ const (
 	// the overlap; mergeSpans then drops the cut fragment.
 	windowOverlapTokens = 32
 
-	// fallbackBytesPerToken sizes byte-based windows when the tokenizer is
-	// not introspectable (rust tokenizer builds). Three bytes per token is
-	// conservative for prose (~4.5) without exploding the window count;
-	// the rust tokenizer truncates over-long windows instead of failing,
-	// so an underestimate degrades gracefully.
-	fallbackBytesPerToken = 3
+	// fallbackSpecialsSlack is how many tokens of the budget byte-fallback
+	// windows reserve for special tokens ([CLS]/[SEP] and friends).
+	fallbackSpecialsSlack = 8
+
+	// fallbackOverlapBytes is the overlap of byte-fallback windows.
+	fallbackOverlapBytes = 96
 )
 
 // textWindow is one model-sized slice of a folded text: byte offsets
@@ -39,23 +51,55 @@ type textWindow struct {
 // windows splits a folded text into inference-ready windows. Texts within
 // the model's token budget yield a single window covering the whole text.
 func (e *Engine) windows(folded string) []textWindow {
-	tk := e.goTokenizer()
-	if tk == nil {
-		size := e.tokenBudget * fallbackBytesPerToken
-		return byteWindows(len(folded), size, windowOverlapTokens*fallbackBytesPerToken)
+	if e.winTok != nil {
+		return tokenWindows(e.winTok, folded, e.tokenBudget)
 	}
-	return tokenWindows(tk, folded, e.tokenBudget)
+	// Last resort, when no windowing tokenizer could be loaded. Every
+	// non-special token covers at least one byte of text (token spans are
+	// non-empty and non-overlapping), so a window of tokenBudget-minus-
+	// slack *bytes* can never encode past the token budget. That hard
+	// guarantee costs efficiency — prose runs ~4.5 bytes per token, so
+	// these windows are ~4x smaller than necessary — which is why the
+	// tokenizer paths above are preferred.
+	size := e.tokenBudget - fallbackSpecialsSlack
+	return byteWindows(len(folded), size, fallbackOverlapBytes)
 }
 
-// goTokenizer returns the pipeline's tokenizer when it is the pure-Go
-// implementation (the default backend). Rust tokenizer builds return nil and
-// fall back to byte-estimate windows.
-func (e *Engine) goTokenizer() api.Tokenizer {
-	tk := e.pipeline.Model.Tokenizer
-	if tk == nil || tk.GoTokenizer == nil {
+// windowTokenizer resolves the tokenizer used to size windows: the
+// pipeline's tokenizer when it is the pure-Go implementation (the default
+// backend), otherwise — rust-tokenizer builds (ORT/XLA) — a standalone
+// pure-Go tokenizer loaded from the model's own tokenizer.json, which yields
+// the same token counts as the rust one (same tokenizer spec). Nil means no
+// tokenizer could be resolved; callers must fall back to byte windows.
+func windowTokenizer(pipeline *pipelines.TokenClassificationPipeline, modelPath string) api.Tokenizer {
+	if tk := pipeline.Model.Tokenizer; tk != nil && tk.GoTokenizer != nil {
+		return tk.GoTokenizer.Tokenizer
+	}
+	return loadWindowTokenizer(modelPath)
+}
+
+// loadWindowTokenizer loads a pure-Go tokenizer from the model directory's
+// tokenizer.json, configured like hugot configures its own Go tokenizer:
+// specials count against the budget, and tokenWindows needs spans plus the
+// special-tokens mask to separate content tokens from specials. Nil on any
+// failure.
+func loadWindowTokenizer(modelPath string) api.Tokenizer {
+	content, err := os.ReadFile(filepath.Join(modelPath, "tokenizer.json"))
+	if err != nil {
 		return nil
 	}
-	return tk.GoTokenizer.Tokenizer
+	tk, err := hftokenizer.NewFromContent(nil, content)
+	if err != nil {
+		return nil
+	}
+	if err := tk.With(api.EncodeOptions{
+		AddSpecialTokens:         true,
+		IncludeSpans:             true,
+		IncludeSpecialTokensMask: true,
+	}); err != nil {
+		return nil
+	}
+	return tk
 }
 
 // tokenWindows builds windows by tokenizing the text once and slicing the

--- a/ner/windows_test.go
+++ b/ner/windows_test.go
@@ -1,6 +1,8 @@
 package ner
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -109,6 +111,116 @@ func TestTokenWindows(t *testing.T) {
 			}
 		}
 	})
+}
+
+// testTokenizerJSON is a minimal BERT-style WordPiece tokenizer: one token
+// per known word, [CLS]/[SEP] added by the post-processor.
+var testTokenizerJSON = []byte(`{
+  "version": "1.0",
+  "added_tokens": [
+    {"id": 0, "content": "[PAD]", "special": true},
+    {"id": 1, "content": "[UNK]", "special": true},
+    {"id": 2, "content": "[CLS]", "special": true},
+    {"id": 3, "content": "[SEP]", "special": true}
+  ],
+  "normalizer": {"type": "BertNormalizer", "lowercase": true},
+  "pre_tokenizer": {"type": "BertPreTokenizer"},
+  "post_processor": {"type": "BertProcessing", "sep": ["[SEP]", 3], "cls": ["[CLS]", 2]},
+  "decoder": {"type": "WordPiece", "prefix": "##"},
+  "model": {
+    "type": "WordPiece",
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": "##",
+    "max_input_chars_per_word": 100,
+    "vocab": {"[PAD]": 0, "[UNK]": 1, "[CLS]": 2, "[SEP]": 3, "hello": 4, "world": 5}
+  }
+}`)
+
+// TestLoadWindowTokenizer verifies the standalone windowing tokenizer used
+// on rust-tokenizer builds (ORT/XLA): loaded from tokenizer.json with
+// specials, spans and the special-tokens mask enabled, it must drive
+// tokenWindows to budget-respecting windows exactly like the pipeline's own
+// Go tokenizer does.
+func TestLoadWindowTokenizer(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), testTokenizerJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tk := loadWindowTokenizer(dir)
+	if tk == nil {
+		t.Fatal("loadWindowTokenizer returned nil for a valid tokenizer.json")
+	}
+
+	// The encode options must match what tokenWindows relies on: specials
+	// included in the count, spans and mask exposed.
+	enc := tk.EncodeWithAnnotations("hello world")
+	if len(enc.IDs) != 4 { // [CLS] hello world [SEP]
+		t.Fatalf("IDs = %v, want 4 tokens including specials", enc.IDs)
+	}
+	if len(enc.Spans) != 4 || len(enc.SpecialTokensMask) != 4 {
+		t.Fatalf("spans/mask missing: %d spans, %d mask", len(enc.Spans), len(enc.SpecialTokensMask))
+	}
+
+	// End to end through the real windowing code: every window re-encodes
+	// within budget and the windows cover the whole text without gaps.
+	text := strings.TrimSpace(strings.Repeat("hello world ", 200))
+	wins := tokenWindows(tk, text, 64)
+	if len(wins) < 2 {
+		t.Fatalf("want multiple windows, got %+v", wins)
+	}
+	if wins[0].start != 0 || wins[len(wins)-1].end != len(text) {
+		t.Errorf("coverage broken: %+v", wins)
+	}
+	for i, w := range wins {
+		if n := len(tk.Encode(text[w.start:w.end])); n > 64 {
+			t.Errorf("window %d encodes to %d tokens > budget 64", i, n)
+		}
+		if i > 0 && w.start >= wins[i-1].end {
+			t.Errorf("gap between windows %d and %d", i-1, i)
+		}
+	}
+}
+
+func TestLoadWindowTokenizerFailure(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		if tk := loadWindowTokenizer(t.TempDir()); tk != nil {
+			t.Fatal("want nil for a directory without tokenizer.json")
+		}
+	})
+
+	t.Run("corrupt file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte("{"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if tk := loadWindowTokenizer(dir); tk != nil {
+			t.Fatal("want nil for corrupt tokenizer.json")
+		}
+	})
+}
+
+// TestWindowsByteFallback pins the guarantee of the last-resort path (no
+// windowing tokenizer at all): windows are capped at tokenBudget minus the
+// specials slack in *bytes*, and since every non-special token covers at
+// least one byte, no window can encode past the token budget.
+func TestWindowsByteFallback(t *testing.T) {
+	e := &Engine{tokenBudget: 256} // winTok nil
+	folded := strings.Repeat("a", 2000)
+	wins := e.windows(folded)
+	if len(wins) < 2 {
+		t.Fatalf("want multiple windows, got %+v", wins)
+	}
+	if wins[0].start != 0 || wins[len(wins)-1].end != len(folded) {
+		t.Errorf("coverage broken: %+v", wins)
+	}
+	for i, w := range wins {
+		if w.end-w.start > 256-fallbackSpecialsSlack {
+			t.Errorf("window %d is %d bytes, above the %d-byte cap", i, w.end-w.start, 256-fallbackSpecialsSlack)
+		}
+		if i > 0 && w.start >= wins[i-1].end {
+			t.Errorf("gap between windows %d and %d", i-1, i)
+		}
+	}
 }
 
 func TestByteWindows(t *testing.T) {

--- a/ner/windows_test.go
+++ b/ner/windows_test.go
@@ -1,0 +1,185 @@
+package ner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gomlx/go-huggingface/tokenizers/api"
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+// fakeTokenizer tokenizes on whitespace (one token per word) and adds two
+// special tokens, mimicking a [CLS] ... [SEP] encoding. It implements just
+// enough of api.Tokenizer for the windowing code.
+type fakeTokenizer struct{}
+
+func (fakeTokenizer) Encode(text string) []int {
+	return make([]int, len(strings.Fields(text))+2)
+}
+
+func (fakeTokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
+	var spans []api.TokenSpan
+	i := 0
+	for i < len(text) {
+		if text[i] == ' ' || text[i] == '\n' || text[i] == '\t' {
+			i++
+			continue
+		}
+		start := i
+		for i < len(text) && text[i] != ' ' && text[i] != '\n' && text[i] != '\t' {
+			i++
+		}
+		spans = append(spans, api.TokenSpan{Start: start, End: i})
+	}
+	enc := api.AnnotatedEncoding{
+		IDs:               make([]int, len(spans)+2),
+		Spans:             make([]api.TokenSpan, 0, len(spans)+2),
+		SpecialTokensMask: make([]int, 0, len(spans)+2),
+	}
+	enc.Spans = append(enc.Spans, api.TokenSpan{})
+	enc.SpecialTokensMask = append(enc.SpecialTokensMask, 1)
+	for _, s := range spans {
+		enc.Spans = append(enc.Spans, s)
+		enc.SpecialTokensMask = append(enc.SpecialTokensMask, 0)
+	}
+	enc.Spans = append(enc.Spans, api.TokenSpan{})
+	enc.SpecialTokensMask = append(enc.SpecialTokensMask, 1)
+	return enc
+}
+
+func (fakeTokenizer) With(api.EncodeOptions) error                 { return nil }
+func (fakeTokenizer) Decode([]int) string                          { return "" }
+func (fakeTokenizer) SpecialTokenID(api.SpecialToken) (int, error) { return 0, api.ErrNotImplemented }
+func (fakeTokenizer) Normalize(s string) string                    { return s }
+func (fakeTokenizer) VocabSize() int                               { return 0 }
+func (fakeTokenizer) Config() *api.Config                          { return nil }
+
+func words(n int) string {
+	w := make([]string, n)
+	for i := range w {
+		w[i] = "word"
+	}
+	return strings.Join(w, " ")
+}
+
+func TestTokenWindows(t *testing.T) {
+	tk := fakeTokenizer{}
+
+	t.Run("short text is a single full window", func(t *testing.T) {
+		text := words(10)
+		wins := tokenWindows(tk, text, 512)
+		if len(wins) != 1 || wins[0].start != 0 || wins[0].end != len(text) {
+			t.Fatalf("wins = %+v, want single window over full text", wins)
+		}
+	})
+
+	t.Run("long text splits into overlapping windows covering everything", func(t *testing.T) {
+		// 1000 words, budget 512 tokens (510 content after 2 specials).
+		text := words(1000)
+		wins := tokenWindows(tk, text, 512)
+		if len(wins) < 2 {
+			t.Fatalf("want multiple windows, got %+v", wins)
+		}
+		if wins[0].start != 0 {
+			t.Errorf("first window starts at %d, want 0", wins[0].start)
+		}
+		if wins[len(wins)-1].end != len(text) {
+			t.Errorf("last window ends at %d, want %d", wins[len(wins)-1].end, len(text))
+		}
+		for i, w := range wins {
+			total := len(tk.Encode(text[w.start:w.end]))
+			if total > 512 {
+				t.Errorf("window %d re-encodes to %d tokens > 512", i, total)
+			}
+			if i > 0 && w.start >= wins[i-1].end {
+				t.Errorf("gap between window %d (end %d) and %d (start %d)",
+					i-1, wins[i-1].end, i, w.start)
+			}
+		}
+	})
+
+	t.Run("windows never cut words", func(t *testing.T) {
+		text := words(600)
+		for _, w := range tokenWindows(tk, text, 512) {
+			body := text[w.start:w.end]
+			if strings.HasPrefix(body, " ") || strings.HasSuffix(body, " ") ||
+				len(body)%5 != 4 { // "word" repeated joins to length 5k+4
+				t.Fatalf("window %+v does not align to word boundaries: %q…", w, body[:10])
+			}
+		}
+	})
+}
+
+func TestByteWindows(t *testing.T) {
+	t.Run("fits in one window", func(t *testing.T) {
+		wins := byteWindows(100, 200, 20)
+		if len(wins) != 1 || wins[0] != (textWindow{0, 100}) {
+			t.Fatalf("wins = %+v", wins)
+		}
+	})
+
+	t.Run("splits with overlap and full coverage", func(t *testing.T) {
+		wins := byteWindows(1000, 300, 50)
+		if wins[0].start != 0 || wins[len(wins)-1].end != 1000 {
+			t.Fatalf("coverage broken: %+v", wins)
+		}
+		for i := 1; i < len(wins); i++ {
+			if wins[i].start != wins[i-1].start+250 {
+				t.Fatalf("step wrong at %d: %+v", i, wins)
+			}
+			if wins[i].start >= wins[i-1].end {
+				t.Fatalf("gap at %d: %+v", i, wins)
+			}
+		}
+	})
+
+	t.Run("degenerate sizes never loop forever", func(t *testing.T) {
+		wins := byteWindows(10, 1, 5)
+		if wins[len(wins)-1].end != 10 {
+			t.Fatalf("coverage broken: %+v", wins)
+		}
+	})
+}
+
+func TestMergeSpans(t *testing.T) {
+	t.Run("exact duplicate keeps max score", func(t *testing.T) {
+		got := mergeSpans([]analyzer.NerSpan{
+			{EntityType: entities.Person, Start: 10, End: 20, Score: 0.7},
+			{EntityType: entities.Person, Start: 10, End: 20, Score: 0.9},
+		})
+		if len(got) != 1 || got[0].Score != 0.9 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("fragment contained in wider same-type span is dropped", func(t *testing.T) {
+		got := mergeSpans([]analyzer.NerSpan{
+			{EntityType: entities.Person, Start: 15, End: 20, Score: 0.9},
+			{EntityType: entities.Person, Start: 10, End: 20, Score: 0.8},
+		})
+		if len(got) != 1 || got[0].Start != 10 || got[0].End != 20 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("contained span of a different type is kept", func(t *testing.T) {
+		got := mergeSpans([]analyzer.NerSpan{
+			{EntityType: entities.Person, Start: 10, End: 30, Score: 0.9},
+			{EntityType: entities.Location, Start: 15, End: 20, Score: 0.8},
+		})
+		if len(got) != 2 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("disjoint spans pass through sorted", func(t *testing.T) {
+		got := mergeSpans([]analyzer.NerSpan{
+			{EntityType: entities.Person, Start: 50, End: 60, Score: 0.9},
+			{EntityType: entities.Person, Start: 10, End: 20, Score: 0.8},
+		})
+		if len(got) != 2 || got[0].Start != 10 || got[1].Start != 50 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two upgrades to the `ner` module, both invisible to existing callers: texts of
any length are now analyzed in full, and the inference backend is selectable —
up to ONNX Runtime with a GPU execution provider.

### Windowed inference for long texts (`ner/windows.go`)
- Texts beyond the model's token limit previously failed inference outright
  (pure-Go tokenizer) or were silently truncated (rust tokenizer), losing
  every entity past ~2 KB. They are now split into overlapping model-sized
  windows, batched through the model with everything else, and the per-window
  spans merged back (exact duplicates keep the highest score; fragments cut at
  a window boundary are dropped in favor of the whole span).
- Window boundaries come from the tokenizer itself (token-aligned, verified by
  re-encoding, never cutting mid-word); rust-tokenizer builds (ORT/XLA) fall
  back to byte-estimate windows since that tokenizer is not introspectable.

### Shape bucketing (`Config.BatchBuckets` / `Config.SequenceBuckets`)
- Inference shapes are padded to a small set of buckets, bounding gomlx JIT
  compilation to a few dozen programs regardless of corpus variety (previously
  one compilation per distinct input shape — hundreds on varied corpora).
- The largest buckets also define the inference sub-batch size (32) and the
  window cap (256 tokens — deliberately under the model's 512 limit: BERT-family
  NER recall degrades sharply near the position limit, and shorter windows are
  cheaper).

### Selectable backends: `Config.Backend` (`go` | `ort` | `xla`)
- The hugot session constructor is no longer hardcoded to the pure-Go backend.
  `"go"` stays the default (pure Go, no cgo, works in every build); `"ort"`
  (ONNX Runtime, `-tags ORT`) measured **~12.6x faster on CPU** on a 300 KB
  corpus (154 s → 12 s); `"xla"` (`-tags XLA`) is also wired.
- `Config.Accelerator` adds a GPU execution provider on top: `coreml` (Apple
  GPU/ANE), `cuda` (ORT or XLA), `directml` (Windows), with
  `Config.AcceleratorOptions` for provider flags and `Config.SessionOptions`
  as a raw-hugot escape hatch.
- `Config.ORTLibraryPath` locates `libonnxruntime` (file or directory);
  conventional install locations are auto-probed, so on macOS
  `brew install onnxruntime` just works.
- Everything fails fast and loudly: unknown backends, accelerator/backend
  mismatches, and backends not compiled in all error at `ner.New` (hugot's
  stubs name the missing build tag) — never a silent CPU/pure-Go fallback.
- Bucketing options are applied only on go/xla (ORT handles dynamic shapes
  natively); windowing, batching, and span merging behave identically on
  every backend.

### Docs & tests
- README gains a "Faster inference: ORT, XLA and GPU" section with the build
  matrix; the package docs mirror it.
- New unit tests (option assembly, validation, library resolution — no model
  needed). `TestLiveNER` and a new `BenchmarkLiveProcessTexts` are
  backend-configurable via `ALCATRAZ_NER_BACKEND` / `ALCATRAZ_NER_ORT_LIB` /
  `ALCATRAZ_NER_ACCELERATOR`, so the same assertions verify every backend.
- Verified live: Go, ORT CPU, and ORT+CoreML all pass end to end; module
  compiles under `-tags ORT`, `-tags XLA`, and `-tags ALL`.

## Test plan
- [ ] `cd ner && go test ./...` (unit tests, no model)
- [ ] `cd ner && go build -tags ORT ./... && go build -tags XLA ./...`
- [ ] `ALCATRAZ_NER_LIVE=1 go test -run TestLiveNER .` (pure Go, incl. long-text windowing)
- [ ] Same with `ALCATRAZ_NER_BACKEND=ort` under a `-tags ORT` build (needs
      `libtokenizers.a` at link time and `libonnxruntime` at runtime)
- [ ] `ALCATRAZ_NER_LIVE=1 go test -bench LiveProcessTexts -benchtime 1x -run xxx .`
      to compare backends on your hardware