### PR TITLE
Add the alcatraz CLI: scan files, stdin, or diffs for PII (ATR-114)

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -148,7 +148,12 @@ jobs:
           EOF
           cat dist/alcatraz.rb
 
+      - name: Tap publish skipped (no HOMEBREW_TAP_TOKEN)
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN == '' }}
+        run: echo "::warning::HOMEBREW_TAP_TOKEN is not set — release assets are published, but Formula/alcatraz.rb was not pushed to hoophq/homebrew-tap."
+
       - name: Check out the tap
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
           # A cross-repo push needs a token with write access to the tap; the
@@ -159,6 +164,7 @@ jobs:
           path: tap
 
       - name: Update and push the formula
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,0 +1,182 @@
+name: Binary Release
+
+# Auto Release creates the vX.Y.Z tag/release with GITHUB_TOKEN, and a tag
+# pushed by GITHUB_TOKEN cannot start a `push: tags` workflow. So this chains
+# off Auto Release's completion: it builds the alcatraz CLI (cmd/alcatraz)
+# for darwin/linux, uploads the archives and checksums to that release, and
+# publishes the Homebrew formula to hoophq/homebrew-tap (the shared tap), so
+# users can `brew install hoophq/tap/alcatraz`.
+on:
+  workflow_run:
+    workflows: ["Auto Release"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+# Serialize runs: back-to-back releases would otherwise race on pushing the
+# formula commit to the tap.
+concurrency:
+  group: binary-release
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    # Auto Release runs on every push to main; act only on successful runs.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      publish: ${{ steps.tag.outputs.publish }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The exact commit Auto Release ran on. fetch-depth: 0 brings the
+          # tags so we can read the version tag it created at that commit.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Find the release tag at this commit
+        id: tag
+        run: |
+          set -euo pipefail
+          # Auto Release tags the released commit vX.Y.Z, or tags nothing for
+          # a skip-release PR or a direct push. Bind the published version to
+          # that tag so source and version always match; skip when absent.
+          TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -z "$TAG" ]; then
+            echo "No release tag at ${{ github.event.workflow_run.head_sha }}; nothing to publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "Publishing ${TAG}"
+          fi
+
+  binaries:
+    name: Build archives & update tap
+    needs: resolve
+    if: ${{ needs.resolve.outputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Cross-compile and package archives
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for os in darwin linux; do
+            for arch in amd64 arm64; do
+              stage="dist/stage_${os}_${arch}"
+              mkdir -p "$stage"
+              CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+                go build -trimpath -ldflags "-s -w -X main.version=v${VERSION}" \
+                -o "$stage/alcatraz" ./cmd/alcatraz
+              cp README.md LICENSE "$stage/"
+              tar -czf "dist/alcatraz_${VERSION}_${os}_${arch}.tar.gz" \
+                -C "$stage" alcatraz README.md LICENSE
+            done
+          done
+          # Bare globs (no ./ prefix): installers grep checksums.txt for the
+          # exact archive name.
+          (cd dist && sha256sum -- *.tar.gz > checksums.txt && cat checksums.txt)
+
+      - name: Attach archives to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          # --clobber lets a re-run replace assets instead of failing on
+          # "asset already exists". checksums.txt is consumed by installers.
+          gh release upload "$TAG" dist/*.tar.gz dist/checksums.txt \
+            --clobber --repo "${{ github.repository }}"
+
+      - name: Render the Homebrew formula
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          sha() { grep "alcatraz_${VERSION}_$1.tar.gz" dist/checksums.txt | awk '{print $1}'; }
+          base="https://github.com/${{ github.repository }}/releases/download/v${VERSION}"
+          cat > dist/alcatraz.rb <<EOF
+          class Alcatraz < Formula
+            desc "Known-pattern PII detection CLI - in-process, no service, no network"
+            homepage "https://github.com/hoophq/alcatraz"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "${base}/alcatraz_${VERSION}_darwin_arm64.tar.gz"
+                sha256 "$(sha darwin_arm64)"
+              end
+              on_intel do
+                url "${base}/alcatraz_${VERSION}_darwin_amd64.tar.gz"
+                sha256 "$(sha darwin_amd64)"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "${base}/alcatraz_${VERSION}_linux_arm64.tar.gz"
+                sha256 "$(sha linux_arm64)"
+              end
+              on_intel do
+                url "${base}/alcatraz_${VERSION}_linux_amd64.tar.gz"
+                sha256 "$(sha linux_amd64)"
+              end
+            end
+
+            def install
+              bin.install "alcatraz"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/alcatraz version")
+            end
+          end
+          EOF
+          cat dist/alcatraz.rb
+
+      - name: Check out the tap
+        uses: actions/checkout@v4
+        with:
+          # A cross-repo push needs a token with write access to the tap; the
+          # default GITHUB_TOKEN is scoped to this repo only. Same secret the
+          # other hoop tools use for their tap publishes.
+          repository: hoophq/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Update and push the formula
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+          cp dist/alcatraz.rb tap/Formula/alcatraz.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/alcatraz.rb
+          # A re-run produces identical archives and checksums, so there may
+          # be nothing to commit.
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for v${VERSION}; nothing to push."
+          else
+            git commit -m "alcatraz ${VERSION}"
+            # The tap may have moved since checkout (another tool releasing);
+            # rebase our formula commit on top instead of failing.
+            git pull --rebase origin main
+            git push origin main
+          fi

--- a/README.md
+++ b/README.md
@@ -65,6 +65,36 @@ go get github.com/hoophq/alcatraz
 
 Requires Go 1.24+. The standard library is the only dependency.
 
+## The CLI
+
+The library also ships as a small command-line scanner — same engine, same
+zero-network posture. Scan files, stdin, or a unified diff; detected values
+are always masked in the output.
+
+```bash
+# Homebrew (macOS & Linux)
+brew install hoophq/tap/alcatraz
+
+# or grab a checksum-verified binary from GitHub releases, or build from source
+go install github.com/hoophq/alcatraz/cmd/alcatraz@latest
+```
+
+```bash
+alcatraz scan secrets.log app.log      # scan files line by line
+git diff | alcatraz diff               # scan only the lines a diff adds
+pbpaste | alcatraz scan                # scan pasted text from stdin
+alcatraz scan -json report.log         # machine-readable output (masked too)
+```
+
+Exit codes are grep-style: `0` clean, `1` findings, `2` error. Flags:
+`-threshold` (default 0.4), `-entities`, `-ignore` (default `DATE_TIME,URL`),
+`-allowlist-file` (one allowed value per line, `#` comments), and `-exclude`
+(diff mode, glob patterns of paths to skip).
+
+The CLI powers the [Hoop plugin for Claude Code](https://github.com/hoophq/claude-marketplace)'s
+`/hoop:pii-scan` command and pairs with
+[alcatraz-action](https://github.com/hoophq/alcatraz-action) for CI.
+
 ## Quickstart
 
 ```go

--- a/cmd/alcatraz/main.go
+++ b/cmd/alcatraz/main.go
@@ -87,7 +87,7 @@ func run(args []string) (int, error) {
 	if *jsonOut {
 		err = writeJSON(os.Stdout, findings)
 	} else {
-		writeFindings(os.Stdout, findings)
+		err = writeFindings(os.Stdout, findings)
 	}
 	if err != nil {
 		return 0, err

--- a/cmd/alcatraz/main.go
+++ b/cmd/alcatraz/main.go
@@ -1,0 +1,112 @@
+// Command alcatraz scans files, stdin text, or a unified diff for PII and
+// secrets using the alcatraz library — entirely in-process, no service, no
+// network calls.
+//
+// Usage:
+//
+//	alcatraz scan [flags] [path ...]   scan files line by line (no paths: read stdin)
+//	alcatraz diff [flags]              read a unified diff on stdin, scan added lines
+//	alcatraz version                   print the version
+//
+// Exit codes: 0 = no findings, 1 = findings detected, 2 = error. Detected
+// values are always masked in the output — the raw values never leave the
+// scan.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// version is stamped by release builds via -ldflags "-X main.version=...".
+var version = "dev"
+
+func main() {
+	code, err := run(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "alcatraz:", err)
+		os.Exit(2)
+	}
+	os.Exit(code)
+}
+
+func run(args []string) (int, error) {
+	if len(args) == 0 {
+		return 0, fmt.Errorf("usage: alcatraz <scan|diff|version> [flags] [path ...]")
+	}
+	cmd, rest := args[0], args[1:]
+	switch cmd {
+	case "version", "-version", "--version":
+		fmt.Println(version)
+		return 0, nil
+	case "scan", "diff":
+	default:
+		return 0, fmt.Errorf("unknown command %q (want scan, diff, or version)", cmd)
+	}
+
+	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
+	threshold := fs.Float64("threshold", 0.4, "minimum confidence score in [0,1]")
+	entities := fs.String("entities", "", "comma-separated entity types to restrict to (empty = all)")
+	ignore := fs.String("ignore", "DATE_TIME,URL", "comma-separated entity types to drop as noise")
+	allowlistFile := fs.String("allowlist-file", "", "file with allowed values, one per line (# comments ok)")
+	jsonOut := fs.Bool("json", false, "emit the findings as JSON instead of text")
+	exclude := fs.String("exclude", "", "comma-separated glob patterns of diff paths to skip (diff only)")
+	if err := fs.Parse(rest); err != nil {
+		return 0, err
+	}
+
+	allowList, err := readAllowlist(*allowlistFile)
+	if err != nil {
+		return 0, err
+	}
+	s := newScanner(*threshold, splitList(*entities), splitList(*ignore), allowList)
+	s.exclude = splitList(*exclude)
+
+	var findings []Finding
+	switch cmd {
+	case "diff":
+		findings, err = s.scanDiff(os.Stdin)
+	case "scan":
+		if fs.NArg() == 0 {
+			findings, err = s.scanText(os.Stdin)
+		} else {
+			for _, path := range fs.Args() {
+				fileFindings, ferr := s.scanFile(path)
+				if ferr != nil {
+					return 0, ferr
+				}
+				findings = append(findings, fileFindings...)
+			}
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	if *jsonOut {
+		err = writeJSON(os.Stdout, findings)
+	} else {
+		writeFindings(os.Stdout, findings)
+	}
+	if err != nil {
+		return 0, err
+	}
+	if len(findings) > 0 {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// readAllowlist loads one allowed value per line, skipping blanks and
+// #-comments.
+func readAllowlist(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("allowlist: %w", err)
+	}
+	return parseAllowlist(string(data)), nil
+}

--- a/cmd/alcatraz/report.go
+++ b/cmd/alcatraz/report.go
@@ -39,11 +39,17 @@ func (f Finding) location() string {
 //
 //	user.go:11  CREDIT_CARD  45************66  0.92
 //	alcatraz: 1 finding(s)
-func writeFindings(w io.Writer, findings []Finding) {
+//
+// Write errors are returned so a failed stdout (e.g. broken pipe) surfaces
+// as exit code 2, per the CLI contract.
+func writeFindings(w io.Writer, findings []Finding) error {
 	for _, f := range findings {
-		fmt.Fprintf(w, "%s  %s  %s  %.2f\n", f.location(), f.EntityType, mask(f.Value), f.Score)
+		if _, err := fmt.Fprintf(w, "%s  %s  %s  %.2f\n", f.location(), f.EntityType, mask(f.Value), f.Score); err != nil {
+			return err
+		}
 	}
-	fmt.Fprintf(w, "alcatraz: %d finding(s)\n", len(findings))
+	_, err := fmt.Fprintf(w, "alcatraz: %d finding(s)\n", len(findings))
+	return err
 }
 
 // jsonFinding is the machine-readable shape of one finding. Values are

--- a/cmd/alcatraz/report.go
+++ b/cmd/alcatraz/report.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// mask redacts a detected value so output never re-publishes the PII it
+// flagged. It keeps at most the first and last two characters.
+func mask(s string) string {
+	runes := []rune(s)
+	n := len(runes)
+	if n <= 4 {
+		return strings.Repeat("*", n)
+	}
+	masked := n - 4
+	if masked > 12 {
+		masked = 12
+	}
+	return string(runes[:2]) + strings.Repeat("*", masked) + string(runes[n-2:])
+}
+
+// location renders where a finding was seen: "path:line", "line N" for
+// file-less text input, or "-" when unknown.
+func (f Finding) location() string {
+	switch {
+	case f.File != "":
+		return fmt.Sprintf("%s:%d", f.File, f.Line)
+	case f.Line > 0:
+		return fmt.Sprintf("line %d", f.Line)
+	default:
+		return "-"
+	}
+}
+
+// writeFindings prints one line per finding and a trailing count:
+//
+//	user.go:11  CREDIT_CARD  45************66  0.92
+//	alcatraz: 1 finding(s)
+func writeFindings(w io.Writer, findings []Finding) {
+	for _, f := range findings {
+		fmt.Fprintf(w, "%s  %s  %s  %.2f\n", f.location(), f.EntityType, mask(f.Value), f.Score)
+	}
+	fmt.Fprintf(w, "alcatraz: %d finding(s)\n", len(findings))
+}
+
+// jsonFinding is the machine-readable shape of one finding. Values are
+// masked here too — JSON output is no less public than text output.
+type jsonFinding struct {
+	File        string  `json:"file,omitempty"`
+	Line        int     `json:"line"`
+	EntityType  string  `json:"entity_type"`
+	ValueMasked string  `json:"value_masked"`
+	Score       float64 `json:"score"`
+}
+
+func writeJSON(w io.Writer, findings []Finding) error {
+	out := struct {
+		Findings []jsonFinding `json:"findings"`
+		Total    int           `json:"total"`
+	}{Findings: make([]jsonFinding, 0, len(findings)), Total: len(findings)}
+	for _, f := range findings {
+		out.Findings = append(out.Findings, jsonFinding{
+			File:        f.File,
+			Line:        f.Line,
+			EntityType:  f.EntityType,
+			ValueMasked: mask(f.Value),
+			Score:       f.Score,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// parseAllowlist extracts allowed values from file content, one per line,
+// skipping blanks and #-comments.
+func parseAllowlist(content string) []string {
+	var values []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		values = append(values, line)
+	}
+	return values
+}
+
+func splitList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, v := range strings.Split(s, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/cmd/alcatraz/report_test.go
+++ b/cmd/alcatraz/report_test.go
@@ -22,9 +22,12 @@ func TestMask(t *testing.T) {
 
 func TestWriteFindingsMasksValues(t *testing.T) {
 	var b strings.Builder
-	writeFindings(&b, []Finding{
+	err := writeFindings(&b, []Finding{
 		{File: "user.go", Line: 11, EntityType: "CREDIT_CARD", Value: "4532015112830366", Score: 0.92},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	out := b.String()
 	if strings.Contains(out, "4532015112830366") {
 		t.Errorf("raw value leaked into output:\n%s", out)

--- a/cmd/alcatraz/report_test.go
+++ b/cmd/alcatraz/report_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMask(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"abcd", "****"},
+		{"jane@example.com", "ja************om"},
+		{"4532015112830366", "45************66"},
+		{"a-very-long-secret-value-that-keeps-going", "a-************ng"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := mask(tt.in); got != tt.want {
+			t.Errorf("mask(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestWriteFindingsMasksValues(t *testing.T) {
+	var b strings.Builder
+	writeFindings(&b, []Finding{
+		{File: "user.go", Line: 11, EntityType: "CREDIT_CARD", Value: "4532015112830366", Score: 0.92},
+	})
+	out := b.String()
+	if strings.Contains(out, "4532015112830366") {
+		t.Errorf("raw value leaked into output:\n%s", out)
+	}
+	for _, want := range []string{"user.go:11", "CREDIT_CARD", "45************66", "1 finding(s)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteJSONMasksValues(t *testing.T) {
+	var b strings.Builder
+	err := writeJSON(&b, []Finding{
+		{Line: 2, EntityType: "EMAIL_ADDRESS", Value: "jane@example.com", Score: 0.85},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if strings.Contains(out, "jane@example.com") {
+		t.Errorf("raw value leaked into JSON:\n%s", out)
+	}
+	for _, want := range []string{`"value_masked": "ja************om"`, `"total": 1`, `"entity_type": "EMAIL_ADDRESS"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("JSON missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteJSONEmpty(t *testing.T) {
+	var b strings.Builder
+	if err := writeJSON(&b, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// An empty scan must render findings as [], not null — consumers parse it.
+	if !strings.Contains(out, `"findings": []`) {
+		t.Errorf("empty findings not rendered as []:\n%s", out)
+	}
+}
+
+func TestParseAllowlist(t *testing.T) {
+	got := parseAllowlist("# comment\njane@example.com\n\n  spaced@x.io  \n")
+	want := []string{"jane@example.com", "spaced@x.io"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/alcatraz/scan.go
+++ b/cmd/alcatraz/scan.go
@@ -85,40 +85,53 @@ func (s *scanner) analyzeLine(file string, line int, content string, out []Findi
 	return out
 }
 
-// hunkRe extracts the new-file start line from a unified diff hunk header.
-var hunkRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)`)
+// hunkRe extracts the new-file start line and line count from a unified
+// diff hunk header.
+var hunkRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))?`)
 
 // scanDiff parses a unified diff and analyzes only added lines, tracking the
-// file and line number each added line lands on in the new version.
+// file and line number each added line lands on in the new version. Hunks
+// are consumed by their declared new-side line count, so an added line whose
+// content begins with "++ " (rendered "+++ " in the diff) is never mistaken
+// for a file header — headers are only recognized between hunks.
 func (s *scanner) scanDiff(r io.Reader) ([]Finding, error) {
 	var findings []Finding
 	var file string
 	line := 0
-	inHunk := false
+	remaining := 0 // new-side lines left in the current hunk
 
 	sc := newLineScanner(r)
 	for sc.Scan() {
 		l := sc.Text()
+		inHunk := remaining > 0
 		switch {
-		case strings.HasPrefix(l, "+++ "):
+		case strings.HasPrefix(l, "diff --git "):
+			// A new file section always closes the previous hunk, even in
+			// a truncated or malformed diff.
+			remaining = 0
+		case !inHunk && strings.HasPrefix(l, "+++ "):
 			file = strings.TrimPrefix(strings.TrimPrefix(l, "+++ "), "b/")
 			if file == "/dev/null" || s.excluded(file) {
 				file = ""
 			}
-			inHunk = false
 		case file == "":
 			// Deleted or excluded file: skip until the next file header.
 		case hunkRe.MatchString(l):
 			m := hunkRe.FindStringSubmatch(l)
 			line, _ = strconv.Atoi(m[1])
-			inHunk = true
+			remaining = 1
+			if m[2] != "" {
+				remaining, _ = strconv.Atoi(m[2])
+			}
 		case !inHunk:
-			// Skip diff headers (diff --git, index, ---, mode lines).
+			// Skip diff headers (index, ---, mode lines).
 		case strings.HasPrefix(l, "+"):
 			findings = s.analyzeLine(file, line, l[1:], findings)
 			line++
+			remaining--
 		case strings.HasPrefix(l, " "):
 			line++
+			remaining--
 		}
 	}
 	return findings, sc.Err()

--- a/cmd/alcatraz/scan.go
+++ b/cmd/alcatraz/scan.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hoophq/alcatraz"
+)
+
+// Finding is one PII detection mapped back to its location in the scanned
+// input. File is empty in text mode.
+type Finding struct {
+	File       string
+	Line       int
+	EntityType string
+	Value      string
+	Score      float64
+}
+
+// scanner wraps an alcatraz engine with the scan-time options shared by all
+// modes.
+type scanner struct {
+	engine  *alcatraz.Engine
+	opts    alcatraz.Options
+	ignored map[string]bool
+	// exclude holds glob patterns for diff paths to skip (e.g. "go.sum",
+	// "*.lock", "vendor/**").
+	exclude []string
+}
+
+func newScanner(threshold float64, entities, ignore, allowList []string) *scanner {
+	ignored := make(map[string]bool, len(ignore))
+	for _, e := range ignore {
+		ignored[e] = true
+	}
+	return &scanner{
+		engine: alcatraz.NewEngine(),
+		opts: alcatraz.Options{
+			Entities:  entities,
+			Threshold: &threshold,
+			AllowList: allowList,
+		},
+		ignored: ignored,
+	}
+}
+
+// excluded reports whether a diff path matches any exclude pattern. Patterns
+// match the full path or its basename; "dir/**" matches everything under dir.
+func (s *scanner) excluded(file string) bool {
+	for _, p := range s.exclude {
+		if dir, ok := strings.CutSuffix(p, "/**"); ok && strings.HasPrefix(file, dir+"/") {
+			return true
+		}
+		if ok, _ := path.Match(p, file); ok {
+			return true
+		}
+		if ok, _ := path.Match(p, path.Base(file)); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// analyzeLine runs the engine over one line of input and appends a Finding
+// per surviving detection.
+func (s *scanner) analyzeLine(file string, line int, content string, out []Finding) []Finding {
+	for _, r := range s.engine.Analyze(content, s.opts) {
+		if s.ignored[r.EntityType] {
+			continue
+		}
+		out = append(out, Finding{
+			File:       file,
+			Line:       line,
+			EntityType: r.EntityType,
+			Value:      r.Text,
+			Score:      r.Score,
+		})
+	}
+	return out
+}
+
+// hunkRe extracts the new-file start line from a unified diff hunk header.
+var hunkRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)`)
+
+// scanDiff parses a unified diff and analyzes only added lines, tracking the
+// file and line number each added line lands on in the new version.
+func (s *scanner) scanDiff(r io.Reader) ([]Finding, error) {
+	var findings []Finding
+	var file string
+	line := 0
+	inHunk := false
+
+	sc := newLineScanner(r)
+	for sc.Scan() {
+		l := sc.Text()
+		switch {
+		case strings.HasPrefix(l, "+++ "):
+			file = strings.TrimPrefix(strings.TrimPrefix(l, "+++ "), "b/")
+			if file == "/dev/null" || s.excluded(file) {
+				file = ""
+			}
+			inHunk = false
+		case file == "":
+			// Deleted or excluded file: skip until the next file header.
+		case hunkRe.MatchString(l):
+			m := hunkRe.FindStringSubmatch(l)
+			line, _ = strconv.Atoi(m[1])
+			inHunk = true
+		case !inHunk:
+			// Skip diff headers (diff --git, index, ---, mode lines).
+		case strings.HasPrefix(l, "+"):
+			findings = s.analyzeLine(file, line, l[1:], findings)
+			line++
+		case strings.HasPrefix(l, " "):
+			line++
+		}
+	}
+	return findings, sc.Err()
+}
+
+// scanFile analyzes every line of the file at path.
+func (s *scanner) scanFile(path string) ([]Finding, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var findings []Finding
+	sc := newLineScanner(f)
+	for line := 1; sc.Scan(); line++ {
+		findings = s.analyzeLine(path, line, sc.Text(), findings)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return findings, nil
+}
+
+// scanText analyzes free text (e.g. a PR comment or issue body) line by line.
+// Findings carry line numbers but no file.
+func (s *scanner) scanText(r io.Reader) ([]Finding, error) {
+	var findings []Finding
+	sc := newLineScanner(r)
+	for line := 1; sc.Scan(); line++ {
+		findings = s.analyzeLine("", line, sc.Text(), findings)
+	}
+	return findings, sc.Err()
+}
+
+// newLineScanner returns a bufio.Scanner sized for long log lines.
+func newLineScanner(r io.Reader) *bufio.Scanner {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	return sc
+}

--- a/cmd/alcatraz/scan_test.go
+++ b/cmd/alcatraz/scan_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleDiff adds one file with a real (Luhn-valid) card number and an email,
+// and touches a second file where the only PII-looking line is a removal.
+const sampleDiff = `diff --git a/user.go b/user.go
+index 111..222 100644
+--- a/user.go
++++ b/user.go
+@@ -10,2 +10,4 @@ func setup() {
+ 	ctx := context.Background()
++	log.Printf("card=4532015112830366")
++	admin := "jane@example.com"
+ 	return ctx
+diff --git a/old.go b/old.go
+index 333..444 100644
+--- a/old.go
++++ b/old.go
+@@ -5 +5 @@ func old() {
+-	ssn := "536-90-4399"
++	ssn := os.Getenv("SSN")
+`
+
+func defaultTestScanner(allow []string) *scanner {
+	return newScanner(0.4, nil, []string{"DATE_TIME", "URL"}, allow)
+}
+
+func TestScanDiff(t *testing.T) {
+	findings, err := defaultTestScanner(nil).scanDiff(strings.NewReader(sampleDiff))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("got %d findings, want 2: %+v", len(findings), findings)
+	}
+
+	card := findings[0]
+	if card.EntityType != "CREDIT_CARD" || card.File != "user.go" || card.Line != 11 {
+		t.Errorf("card finding = %+v, want CREDIT_CARD at user.go:11", card)
+	}
+	email := findings[1]
+	if email.EntityType != "EMAIL_ADDRESS" || email.File != "user.go" || email.Line != 12 {
+		t.Errorf("email finding = %+v, want EMAIL_ADDRESS at user.go:12", email)
+	}
+}
+
+func TestScanDiffIgnoresRemovedLines(t *testing.T) {
+	findings, err := defaultTestScanner(nil).scanDiff(strings.NewReader(sampleDiff))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.File == "old.go" {
+			t.Errorf("removed-line PII was flagged: %+v", f)
+		}
+	}
+}
+
+func TestScanDiffAllowlist(t *testing.T) {
+	findings, err := defaultTestScanner([]string{"jane@example.com"}).
+		scanDiff(strings.NewReader(sampleDiff))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range findings {
+		if f.EntityType == "EMAIL_ADDRESS" {
+			t.Errorf("allow-listed email was flagged: %+v", f)
+		}
+	}
+}
+
+func TestScanDiffExclude(t *testing.T) {
+	tests := []struct {
+		pattern string
+		want    int
+	}{
+		{"user.go", 0},   // exact path
+		{"*.go", 0},      // basename glob
+		{"user.*", 0},    // basename glob with wildcard ext
+		{"vendor/**", 2}, // unrelated directory: nothing excluded
+	}
+	for _, tt := range tests {
+		s := defaultTestScanner(nil)
+		s.exclude = []string{tt.pattern}
+		findings, err := s.scanDiff(strings.NewReader(sampleDiff))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(findings) != tt.want {
+			t.Errorf("exclude %q: got %d findings, want %d: %+v",
+				tt.pattern, len(findings), tt.want, findings)
+		}
+	}
+}
+
+func TestScanText(t *testing.T) {
+	body := "here are my logs:\nuser=jane@example.com logged in\nall good"
+	findings, err := defaultTestScanner(nil).scanText(strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+	}
+	if f := findings[0]; f.EntityType != "EMAIL_ADDRESS" || f.Line != 2 || f.File != "" {
+		t.Errorf("finding = %+v, want EMAIL_ADDRESS at line 2 with no file", f)
+	}
+}
+
+func TestScanFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.log")
+	content := "starting\ncard 4532015112830366 charged\ndone\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	findings, err := defaultTestScanner(nil).scanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+	}
+	if f := findings[0]; f.EntityType != "CREDIT_CARD" || f.File != path || f.Line != 2 {
+		t.Errorf("finding = %+v, want CREDIT_CARD at %s:2", f, path)
+	}
+}
+
+func TestThresholdDropsLowConfidence(t *testing.T) {
+	// A bare 8-digit run only triggers low-confidence recognizers
+	// (e.g. US_BANK_NUMBER at 0.05); threshold 0.4 must drop it.
+	findings, err := defaultTestScanner(nil).scanText(strings.NewReader("id 12345678 ok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("low-confidence match survived threshold: %+v", findings)
+	}
+}

--- a/cmd/alcatraz/scan_test.go
+++ b/cmd/alcatraz/scan_test.go
@@ -99,6 +99,57 @@ func TestScanDiffExclude(t *testing.T) {
 	}
 }
 
+func TestScanDiffPlusPlusContentLine(t *testing.T) {
+	// An added line whose content begins with "++ " is rendered "+++ " in
+	// the diff; it must scan as content, not be mistaken for a file header.
+	d := "diff --git a/notes.md b/notes.md\n" +
+		"--- a/notes.md\n" +
+		"+++ b/notes.md\n" +
+		"@@ -1 +1,3 @@\n" +
+		" intro\n" +
+		"+++ contact jane@example.com\n" +
+		"+card 4532015112830366\n"
+	findings, err := defaultTestScanner(nil).scanDiff(strings.NewReader(d))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("got %d findings, want 2: %+v", len(findings), findings)
+	}
+	if f := findings[0]; f.EntityType != "EMAIL_ADDRESS" || f.File != "notes.md" || f.Line != 2 {
+		t.Errorf("email finding = %+v, want EMAIL_ADDRESS at notes.md:2", f)
+	}
+	if f := findings[1]; f.EntityType != "CREDIT_CARD" || f.File != "notes.md" || f.Line != 3 {
+		t.Errorf("card finding = %+v, want CREDIT_CARD at notes.md:3", f)
+	}
+}
+
+func TestScanDiffPlainUnified(t *testing.T) {
+	// diff -u output has no "diff --git" separators; hunk line counts alone
+	// must delimit hunks so the second file's headers are recognized.
+	d := "--- a/a.txt\n" +
+		"+++ b/a.txt\n" +
+		"@@ -1 +1 @@\n" +
+		"+first jane@example.com\n" +
+		"--- a/b.txt\n" +
+		"+++ b/b.txt\n" +
+		"@@ -1 +1 @@\n" +
+		"+second 4532015112830366\n"
+	findings, err := defaultTestScanner(nil).scanDiff(strings.NewReader(d))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("got %d findings, want 2: %+v", len(findings), findings)
+	}
+	if f := findings[0]; f.File != "a.txt" || f.Line != 1 {
+		t.Errorf("first finding = %+v, want a.txt:1", f)
+	}
+	if f := findings[1]; f.File != "b.txt" || f.Line != 1 {
+		t.Errorf("second finding = %+v, want b.txt:1", f)
+	}
+}
+
 func TestScanText(t *testing.T) {
 	body := "here are my logs:\nuser=jane@example.com logged in\nall good"
 	findings, err := defaultTestScanner(nil).scanText(strings.NewReader(body))


### PR DESCRIPTION
Gives the library a first-class command-line surface — `cmd/alcatraz` — plus release automation so binaries ship with the next version tag.

## CLI

- `alcatraz scan [path ...]` — scan files line by line; with no paths, reads stdin (pasted text, piped logs)
- `alcatraz diff` — reads a unified diff on stdin, scans only added lines (ported from alcatraz-action's `pii-scan`, tests included)
- `alcatraz version`
- Flags: `-threshold` (0.4), `-entities`, `-ignore` (`DATE_TIME,URL`), `-allowlist-file`, `-exclude` (diff), `-json`
- Values are **always masked** in both text and JSON output; exit codes are grep-style (`0` clean, `1` findings, `2` error)
- Zero network: imports only the root engine (the `net`-using model download lives in the separate opt-in modules)

## Release automation

`binary-release.yml` chains off **Auto Release** via `workflow_run` (a tag created with `GITHUB_TOKEN` can't trigger `push: tags` workflows — same pattern as hoophq/rs): resolves the vX.Y.Z tag Auto Release created, cross-compiles darwin/linux × amd64/arm64 (CGO_ENABLED=0, version stamped via ldflags), uploads `alcatraz_<ver>_<os>_<arch>.tar.gz` + `checksums.txt` to the release, and pushes `Formula/alcatraz.rb` to hoophq/homebrew-tap.

Needs the `HOMEBREW_TAP_TOKEN` secret available to this repo (same one rs's brew-publish uses); if it's missing the release assets still publish and only the tap push fails.

This PR is labeled `minor` → merging auto-releases **v0.5.0 with binaries**, which the Hoop Claude Code plugin's `/hoop:pii-scan` (hoophq/claude-marketplace, ATR-114) installs via its checksum-verified flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012swVaZJCZnYqxmLaBmvGTf