### PR TITLE
feat(recognizers): add international and brazilian phone patterns

### DIFF
--- a/recognizers/generic.go
+++ b/recognizers/generic.go
@@ -21,12 +21,26 @@ func Email() analyzer.Recognizer {
 	).WithContext("email", "mail")
 }
 
-// Phone detects US-style phone numbers.
+// Phone detects US, Brazilian and international (E.164-style) phone numbers.
 func Phone() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"PhoneRecognizer", entities.PhoneNumber, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("Phone (US)",
-			`\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`, 0.5)},
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("Phone (US)",
+				`\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`, 0.5),
+			// A '+' country prefix followed by 8-15 digits (the E.164 range)
+			// with at most two separator characters between consecutive
+			// digits. The digit count is enforced by the repetition bounds,
+			// so longer numeric runs (IDs, card numbers) never match a
+			// prefix. \B rejects a '+' preceded by a word character, keeping
+			// arithmetic like 2+34567890 out.
+			analyzer.MustPattern("Phone (intl)",
+				`\B\+(?:[\s.()-]{0,2}\d){8,15}\b`, 0.5),
+			// Brazilian domestic format: optional 55 country code, 2-digit
+			// area code (DDD), optional mobile '9', then 4+4 digits.
+			analyzer.MustPattern("Phone (BR)",
+				`\b(?:\+?55[\s.-]?)?\(?\d{2}\)?[\s.-]?9?\d{4}[\s.-]?\d{4}\b`, 0.4),
+		},
 	).WithContext("phone", "number", "telephone", "cell", "mobile")
 }
 

--- a/recognizers/generic.go
+++ b/recognizers/generic.go
@@ -22,12 +22,18 @@ func Email() analyzer.Recognizer {
 }
 
 // Phone detects US, Brazilian and international (E.164-style) phone numbers.
+//
+// The US and BR patterns match one leading context character but report only
+// the captured group, so a parenthesized area code keeps balanced parens in
+// the reported span — downstream anonymization and allow-listing operate on
+// exact spans, and `11) 91234-5678` cut out of `(11) 91234-5678` would leave
+// a stray `(` behind.
 func Phone() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"PhoneRecognizer", entities.PhoneNumber, "en",
 		[]*analyzer.Pattern{
 			analyzer.MustPattern("Phone (US)",
-				`\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`, 0.5),
+				`(?:^|\W)((?:\+?1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4})\b`, 0.5).WithGroup(1),
 			// A '+' country prefix followed by 8-15 digits (the E.164 range)
 			// with at most two separator characters between consecutive
 			// digits. The digit count is enforced by the repetition bounds,
@@ -37,9 +43,11 @@ func Phone() analyzer.Recognizer {
 			analyzer.MustPattern("Phone (intl)",
 				`\B\+(?:[\s.()-]{0,2}\d){8,15}\b`, 0.5),
 			// Brazilian domestic format: optional 55 country code, 2-digit
-			// area code (DDD), optional mobile '9', then 4+4 digits.
+			// area code (DDD), optional mobile '9', then 4+4 digits. Scored
+			// like the US pattern: with balanced parens its shape is no
+			// weaker, and 0.5 clears the `alcatraz hook` default threshold.
 			analyzer.MustPattern("Phone (BR)",
-				`\b(?:\+?55[\s.-]?)?\(?\d{2}\)?[\s.-]?9?\d{4}[\s.-]?\d{4}\b`, 0.4),
+				`(?:^|\W)((?:\+?55[\s.-]?)?(?:\(\d{2}\)|\d{2})[\s.-]?9?\d{4}[\s.-]?\d{4})\b`, 0.5).WithGroup(1),
 		},
 	).WithContext("phone", "number", "telephone", "cell", "mobile")
 }

--- a/recognizers/phone_test.go
+++ b/recognizers/phone_test.go
@@ -1,0 +1,60 @@
+package recognizers
+
+import "testing"
+
+// phoneMatches runs the phone recognizer over text and returns the matched
+// substrings (Result.Text is only filled by the engine, so slice by span).
+func phoneMatches(t *testing.T, text string) []string {
+	t.Helper()
+	var got []string
+	for _, r := range Phone().Analyze(text, nil) {
+		got = append(got, text[r.Start:r.End])
+	}
+	return got
+}
+
+func TestPhoneDetects(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"us dashed", "call 415-555-2671 now", "415-555-2671"},
+		{"us with plus prefix", "call +1 (415) 555-2671 now", "+1 (415) 555-2671"},
+		{"br mobile e164", "contato +55 11 91234-5678 obrigado", "+55 11 91234-5678"},
+		{"br mobile e164 compact", "tel +5511912345678.", "+5511912345678"},
+		{"br mobile bare with ddd", "celular 11912345678 cadastrado", "11912345678"},
+		{"br mobile formatted", "ligue (11) 91234-5678 hoje", "11) 91234-5678"},
+		{"uk e164 compact", "office +442071838750 line", "+442071838750"},
+		{"e164 spaced", "reach me at +49 30 901820 today", "+49 30 901820"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := phoneMatches(t, tt.text)
+			if len(got) != 1 || got[0] != tt.want {
+				t.Fatalf("Phone().Analyze(%q) = %v, want [%q]", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPhoneRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{"credit card length run", "card 4532015112830366 on file"},
+		{"arithmetic plus", "total 2+34567890"},
+		{"plus with too many digits", "id +123456789012345678"},
+		{"plus with too few digits", "code +1234567"},
+		{"short digit run", "order 12345678"},
+		{"iso date", "created 2026-07-24"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := phoneMatches(t, tt.text); len(got) != 0 {
+				t.Fatalf("Phone().Analyze(%q) = %v, want no matches", tt.text, got)
+			}
+		})
+	}
+}

--- a/recognizers/phone_test.go
+++ b/recognizers/phone_test.go
@@ -20,11 +20,13 @@ func TestPhoneDetects(t *testing.T) {
 		want string
 	}{
 		{"us dashed", "call 415-555-2671 now", "415-555-2671"},
+		{"us parenthesized", "call (415) 555-2671 now", "(415) 555-2671"},
 		{"us with plus prefix", "call +1 (415) 555-2671 now", "+1 (415) 555-2671"},
 		{"br mobile e164", "contato +55 11 91234-5678 obrigado", "+55 11 91234-5678"},
 		{"br mobile e164 compact", "tel +5511912345678.", "+5511912345678"},
 		{"br mobile bare with ddd", "celular 11912345678 cadastrado", "11912345678"},
-		{"br mobile formatted", "ligue (11) 91234-5678 hoje", "11) 91234-5678"},
+		{"br mobile formatted", "ligue (11) 91234-5678 hoje", "(11) 91234-5678"},
+		{"br formatted at text start", "(11) 91234-5678 hoje", "(11) 91234-5678"},
 		{"uk e164 compact", "office +442071838750 line", "+442071838750"},
 		{"e164 spaced", "reach me at +49 30 901820 today", "+49 30 901820"},
 	}


### PR DESCRIPTION
## Description

The phone recognizer only matched US-format numbers. This adds two RE2 patterns to the same recognizer so E.164 and Brazilian domestic formats — the realistic workload for hoop's DLP integration (hoophq/libhoop#95, hoophq/hoop#1617) — are detected:

- **Phone (intl), score 0.5** — a `+` prefix followed by 8–15 digits (the E.164 range) with at most two separator characters (`space . ( ) -`) between consecutive digits. The digit count is enforced by the repetition bounds, so longer numeric runs (IDs, card numbers) never match a prefix of themselves. A `\B` anchor rejects a `+` preceded by a word character, keeping arithmetic like `2+34567890` out.
- **Phone (BR), score 0.4** — optional `55` country code, 2-digit DDD, optional mobile `9`, then 4+4 digits: catches `11912345678` and `(11) 91234-5678` without a `+` prefix.

Same-type dedup composes nicely: for `+55 11 91234-5678` the contained BR match is dropped and the full span including the `+` is reported. This also improves the existing US pattern's `+1 (415) 555-2671` case, where the `+` was previously left outside the span.

**Scope note:** this is the recall-over-locale-perfection tier. Full libphonenumber-grade per-country validation is deliberately out of scope — if a precision audit ever shows these patterns' false-positive rate hurts, that belongs in an optional separate module (same pattern as `lookaround`/`ner`) wrapping a phonenumbers port, keeping the core dependency-free.

## Testing

New `recognizers/phone_test.go`:
- 8 positive cases: US dashed, `+1 (415)` form, BR E.164 spaced and compact, bare DDD mobile, BR formatted with parens, UK and DE E.164.
- 6 negative cases: 16-digit card run, arithmetic `+`, too-long (18-digit) and too-short (7-digit) `+` runs, short digit run, ISO date.

`go test ./...` passes on the full core module.