### PR TITLE
feat(ner): add EnsureModel with pinned sha256 verification

### DIFF
--- a/.github/workflows/ml-live.yml
+++ b/.github/workflows/ml-live.yml
@@ -57,11 +57,16 @@ jobs:
             ~/Library/Caches/alcatraz/models
           key: ner-model-${{ runner.os }}-v1
 
+      # TestLiveNER runs against the cache restored above, so it exercises
+      # loading but never downloading. TestLiveEnsureModel writes to a temp
+      # dir instead, which makes it the only job here that fetches the pinned
+      # URLs and checks the recorded sizes and digests against what the hub
+      # actually serves — the case a warm cache hides.
       - name: Live model test
         working-directory: ner
         env:
           ALCATRAZ_NER_LIVE: "1"
-        run: go test -v -run TestLiveNER -timeout 25m ./...
+        run: go test -v -run 'TestLiveNER|TestLiveEnsureModel' -timeout 25m ./...
 
   # pfilter: needs libpf (built from the pinned privacy-filter.cpp revision
   # via the pfilter/dist CMake wrapper, cached) and a GGUF (cached).

--- a/ner/config.go
+++ b/ner/config.go
@@ -34,6 +34,11 @@ type Config struct {
 	// Model is a Hugging Face model id of an ONNX token-classification
 	// export, e.g. "KnightsAnalytics/distilbert-NER". It is downloaded into
 	// ModelsDir on first use. Ignored when ModelPath is set.
+	//
+	// Models listed by PinnedModels are fetched from a pinned commit and
+	// verified against pinned sha256s on every load; any other id is
+	// downloaded through hugot with no integrity check at all. Use
+	// EnsureModel to populate ModelsDir ahead of time.
 	Model string
 	// ModelPath is a local directory holding the model files (model.onnx,
 	// tokenizer.json, config.json). When set, no download happens.

--- a/ner/download.go
+++ b/ner/download.go
@@ -1,0 +1,218 @@
+package ner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// hubBaseURL is the Hugging Face origin the pinned artifacts are fetched
+// from. It is a var so tests can point it at a local server.
+var hubBaseURL = "https://huggingface.co"
+
+// modelFile is one file of a model repository, pinned by content hash.
+type modelFile struct {
+	// path is the file's path inside the repository. Downloads are
+	// flattened to its base name in the model directory, matching how
+	// hugot lays a downloaded model out.
+	path   string
+	sha256 string
+}
+
+// modelArtifact pins a model repository to an immutable revision and to the
+// exact set of files alcatraz downloads from it.
+type modelArtifact struct {
+	// revision is a commit sha, never a branch name: a branch would let
+	// the repository contents drift out from under the pinned checksums,
+	// so the first thing a mismatch would tell us is nothing useful.
+	revision string
+	// files is the complete set alcatraz needs to load the model. It
+	// mirrors what hugot's own downloader selects (the single .onnx file,
+	// the tokenizer and the config files), so a directory produced here is
+	// interchangeable with one produced by hugot.DownloadModel.
+	files []modelFile
+}
+
+// modelArtifacts holds every model EnsureModel can verify. Adding a model
+// means recording its commit sha and hashing each file at that revision:
+//
+//	rev=$(curl -sS https://huggingface.co/api/models/$REPO | jq -r .sha)
+//	curl -sSL https://huggingface.co/$REPO/resolve/$rev/$FILE | shasum -a 256
+var modelArtifacts = map[string]modelArtifact{
+	"KnightsAnalytics/distilbert-NER": {
+		revision: "13a742d5ea02349d17e18f3755301282c9ee33f7",
+		files: []modelFile{
+			{path: "config.json", sha256: "8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5"},
+			{path: "model.onnx", sha256: "4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160"},
+			{path: "special_tokens_map.json", sha256: "5d5b662e421ea9fac075174bb0688ee0d9431699900b90662acd44b2a350503a"},
+			{path: "tokenizer.json", sha256: "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34"},
+			{path: "tokenizer_config.json", sha256: "4391b0abb71cd639e50a333c5c642d3c8659ba34099cb12a83dba2efc26f5451"},
+			{path: "vocab.txt", sha256: "eeaa9875b23b04b4c54ef759d03db9d1ba1554838f8fb26c5d96fa551df93d02"},
+		},
+	},
+}
+
+// PinnedModels returns, sorted, the model ids EnsureModel can fetch and
+// verify. Other model ids still work through Config.Model, but nothing
+// checks what the hub serves for them.
+func PinnedModels() []string {
+	ids := make([]string, 0, len(modelArtifacts))
+	for id := range modelArtifacts {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// EnsureModel downloads model into the models directory New reads from and
+// returns the local directory holding it, so a warm cache makes New
+// network-free and the returned path can be handed straight to
+// Config.ModelPath.
+//
+// Every file is pinned to a sha256 and re-verified on each call, cache hits
+// included: a file that exists is not evidence that it is the file we asked
+// for. A mismatched file is deleted and fetched again. Re-hashing the whole
+// model costs roughly half a second for the 260MB default against a warm
+// page cache — small enough beside session setup that New verifies too,
+// rather than trusting the cache once it is populated.
+//
+// It is idempotent, and safe to call concurrently and from several
+// processes: each file is written to a temp file and renamed into place, so
+// a reader never observes a partial one.
+func EnsureModel(ctx context.Context, model string) (string, error) {
+	return EnsureModelIn(ctx, model, "")
+}
+
+// EnsureModelIn is EnsureModel writing into an explicit models directory,
+// for callers materialising a model outside the user cache — a Docker image
+// layer or a shared volume. An empty dir means the default.
+//
+// dir is the models directory, not the model directory: the model lands in a
+// subdirectory named after it, exactly as under the cache, so the layout is
+// the same wherever it is built.
+func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
+	art, ok := modelArtifacts[model]
+	if !ok {
+		return "", fmt.Errorf("ner: model %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
+			model, strings.Join(PinnedModels(), ", "))
+	}
+	dir, err := resolveModelsDir(dir)
+	if err != nil {
+		return "", err
+	}
+	modelPath := modelDir(dir, model)
+	if err := os.MkdirAll(modelPath, 0o755); err != nil {
+		return "", fmt.Errorf("ner: creating model directory: %w", err)
+	}
+	for _, f := range art.files {
+		// path.Base, not filepath.Base: repository paths are always
+		// slash-separated, whatever the host OS uses.
+		dest := filepath.Join(modelPath, path.Base(f.path))
+		if cachedFileValid(dest, f.sha256) {
+			continue
+		}
+		url := fmt.Sprintf("%s/%s/resolve/%s/%s", hubBaseURL, model, art.revision, f.path)
+		if err := download(ctx, url, dest, f.sha256, 0o644); err != nil {
+			return "", fmt.Errorf("ner: downloading %s for model %s: %w", f.path, model, err)
+		}
+	}
+	return modelPath, nil
+}
+
+// resolveModelsDir returns dir, or (creating it) the default models
+// directory when dir is empty: "alcatraz/models" under the user cache dir.
+func resolveModelsDir(dir string) (string, error) {
+	if dir != "" {
+		return dir, nil
+	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("ner: locating the user cache directory: %w", err)
+	}
+	dir = filepath.Join(cache, "alcatraz", "models")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("ner: creating the models directory: %w", err)
+	}
+	return dir, nil
+}
+
+// modelDir returns the directory a model occupies inside a models
+// directory. It reproduces hugot's naming so both downloaders agree on
+// where a model lives: the id with "/" replaced by "_", minus any ":suffix".
+func modelDir(modelsDir, model string) string {
+	if i := strings.Index(model, ":"); i >= 0 {
+		model = model[:i]
+	}
+	return filepath.Join(modelsDir, strings.ReplaceAll(model, "/", "_"))
+}
+
+// cachedFileValid reports whether path exists and still matches the pinned
+// sha256. A mismatched file is deleted so the caller's download replaces it
+// and no other code path can pick the bad copy up in the meantime.
+func cachedFileValid(path, wantSHA256 string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return false
+	}
+	if hex.EncodeToString(hasher.Sum(nil)) == wantSHA256 {
+		return true
+	}
+	os.Remove(path)
+	return false
+}
+
+// download fetches url into dest atomically: it streams to a temp file in
+// the destination directory, verifies the sha256, sets mode, and renames.
+// A failed or corrupt download never leaves a file at dest.
+func download(ctx context.Context, url, dest, wantSHA256 string, mode os.FileMode) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: unexpected status %s", url, resp.Status)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".partial-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(hasher.Sum(nil)); got != wantSHA256 {
+		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", url, got, wantSHA256)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), dest)
+}

--- a/ner/download.go
+++ b/ner/download.go
@@ -25,6 +25,13 @@ type modelFile struct {
 	// hugot lays a downloaded model out.
 	path   string
 	sha256 string
+	// size is the exact byte length. The digest is only conclusive once the
+	// response ends, so on its own it bounds integrity but not consumption:
+	// nothing stops an endpoint that streams until the disk is full. Capping
+	// the read one byte past the pin does, and rejecting a short read too
+	// turns a truncated response into an error that says so rather than an
+	// opaque digest mismatch.
+	size int64
 }
 
 // modelArtifact pins a model repository to an immutable revision and to the
@@ -42,20 +49,22 @@ type modelArtifact struct {
 }
 
 // modelArtifacts holds every model EnsureModel can verify. Adding a model
-// means recording its commit sha and hashing each file at that revision:
+// means recording its commit sha, then the digest and byte length of each
+// file at that revision:
 //
 //	rev=$(curl -sS https://huggingface.co/api/models/$REPO | jq -r .sha)
-//	curl -sSL https://huggingface.co/$REPO/resolve/$rev/$FILE | shasum -a 256
+//	curl -sSLo /tmp/f https://huggingface.co/$REPO/resolve/$rev/$FILE
+//	shasum -a 256 /tmp/f && wc -c < /tmp/f
 var modelArtifacts = map[string]modelArtifact{
 	"KnightsAnalytics/distilbert-NER": {
 		revision: "13a742d5ea02349d17e18f3755301282c9ee33f7",
 		files: []modelFile{
-			{path: "config.json", sha256: "8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5"},
-			{path: "model.onnx", sha256: "4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160"},
-			{path: "special_tokens_map.json", sha256: "5d5b662e421ea9fac075174bb0688ee0d9431699900b90662acd44b2a350503a"},
-			{path: "tokenizer.json", sha256: "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34"},
-			{path: "tokenizer_config.json", sha256: "4391b0abb71cd639e50a333c5c642d3c8659ba34099cb12a83dba2efc26f5451"},
-			{path: "vocab.txt", sha256: "eeaa9875b23b04b4c54ef759d03db9d1ba1554838f8fb26c5d96fa551df93d02"},
+			{path: "config.json", sha256: "8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5", size: 925},
+			{path: "model.onnx", sha256: "4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160", size: 260926482},
+			{path: "special_tokens_map.json", sha256: "5d5b662e421ea9fac075174bb0688ee0d9431699900b90662acd44b2a350503a", size: 695},
+			{path: "tokenizer.json", sha256: "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34", size: 669021},
+			{path: "tokenizer_config.json", sha256: "4391b0abb71cd639e50a333c5c642d3c8659ba34099cb12a83dba2efc26f5451", size: 1305},
+			{path: "vocab.txt", sha256: "eeaa9875b23b04b4c54ef759d03db9d1ba1554838f8fb26c5d96fa551df93d02", size: 213450},
 		},
 	},
 }
@@ -77,11 +86,11 @@ func PinnedModels() []string {
 // network-free and the returned path can be handed straight to
 // Config.ModelPath.
 //
-// Every file is pinned to a sha256 and re-verified on each call, cache hits
-// included: a file that exists is not evidence that it is the file we asked
-// for. A mismatched file is deleted and fetched again. Re-hashing the whole
-// model costs roughly half a second for the 260MB default against a warm
-// page cache — small enough beside session setup that New verifies too,
+// Every file is pinned to a sha256 and a byte length, re-verified on each
+// call, cache hits included: a file that exists is not evidence that it is
+// the file we asked for. A mismatched file is fetched again. Re-hashing the
+// whole model costs roughly half a second for the 260MB default against a
+// warm page cache — small enough beside session setup that New verifies too,
 // rather than trusting the cache once it is populated.
 //
 // It is idempotent, and safe to call concurrently and from several
@@ -120,7 +129,7 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 			continue
 		}
 		url := fmt.Sprintf("%s/%s/resolve/%s/%s", hubBaseURL, model, art.revision, f.path)
-		if err := download(ctx, url, dest, f.sha256, 0o644); err != nil {
+		if err := download(ctx, url, dest, f.sha256, f.size, 0o644); err != nil {
 			return "", fmt.Errorf("ner: downloading %s for model %s: %w", f.path, model, err)
 		}
 	}
@@ -155,8 +164,14 @@ func modelDir(modelsDir, model string) string {
 }
 
 // cachedFileValid reports whether path exists and still matches the pinned
-// sha256. A mismatched file is deleted so the caller's download replaces it
-// and no other code path can pick the bad copy up in the meantime.
+// sha256.
+//
+// A mismatched file is left where it is rather than unlinked: download
+// replaces it by renaming over it, which is atomic, and unlinking here is
+// not. Two callers that find the same corrupt file both hold handles to it,
+// and the slower one would unlink the pathname after the faster one had
+// already installed a verified replacement under it — deleting a good file
+// that its caller had been told was ready.
 func cachedFileValid(path, wantSHA256 string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -168,17 +183,14 @@ func cachedFileValid(path, wantSHA256 string) bool {
 	if _, err := io.Copy(hasher, f); err != nil {
 		return false
 	}
-	if hex.EncodeToString(hasher.Sum(nil)) == wantSHA256 {
-		return true
-	}
-	os.Remove(path)
-	return false
+	return hex.EncodeToString(hasher.Sum(nil)) == wantSHA256
 }
 
 // download fetches url into dest atomically: it streams to a temp file in
-// the destination directory, verifies the sha256, sets mode, and renames.
-// A failed or corrupt download never leaves a file at dest.
-func download(ctx context.Context, url, dest, wantSHA256 string, mode os.FileMode) error {
+// the destination directory, verifies the byte length and the sha256, sets
+// mode, and renames. A failed, corrupt, truncated or oversized download never
+// leaves a file at dest.
+func download(ctx context.Context, url, dest, wantSHA256 string, wantSize int64, mode os.FileMode) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -202,8 +214,16 @@ func download(ctx context.Context, url, dest, wantSHA256 string, mode os.FileMod
 	}()
 
 	hasher := sha256.New()
-	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+	// Bounded one byte past the pin, so an endpoint that never stops
+	// sending is cut off rather than filling the disk before the digest
+	// gets a chance to reject anything. The bound is on bytes actually
+	// read, not on Content-Length, which the endpoint also controls.
+	n, err := io.Copy(io.MultiWriter(tmp, hasher), io.LimitReader(resp.Body, wantSize+1))
+	if err != nil {
 		return err
+	}
+	if n != wantSize {
+		return fmt.Errorf("size mismatch for %s: got %d bytes, want %d", url, n, wantSize)
 	}
 	if got := hex.EncodeToString(hasher.Sum(nil)); got != wantSHA256 {
 		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", url, got, wantSHA256)

--- a/ner/download_test.go
+++ b/ner/download_test.go
@@ -362,6 +362,25 @@ func TestEnsureModelInConcurrent(t *testing.T) {
 	}
 }
 
+// TestCachedFileValidLeavesMismatchInPlace pins the decision that makes
+// repair safe under concurrency: validation reports, it does not clean up.
+// Unlinking here is not atomic against the rename that replaces the file, so
+// a slow validator could remove a pathname after a faster caller had already
+// installed a verified copy under it. The mismatched file stays until
+// download renames over it.
+func TestCachedFileValidLeavesMismatchInPlace(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "model.onnx")
+	if err := os.WriteFile(p, []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if cachedFileValid(p, sum([]byte("pinned"))) {
+		t.Fatal("cachedFileValid accepted a file that does not match the pin")
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Errorf("mismatched file was removed: %v", err)
+	}
+}
+
 // TestEnsureModelInConcurrentRepair points several callers at the same
 // corrupt cache file at once. Each one has to end up with the pinned bytes
 // readable at the pathname it was handed: repair replaces the file by

--- a/ner/download_test.go
+++ b/ner/download_test.go
@@ -1,0 +1,400 @@
+package ner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func sum(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// fakeHub serves a pinned test model and counts the requests it gets, so a
+// test can assert that a warm cache costs no network at all.
+type fakeHub struct {
+	*httptest.Server
+	mu    sync.Mutex
+	hits  map[string]int
+	files map[string][]byte
+}
+
+func newFakeHub(t *testing.T, files map[string][]byte) *fakeHub {
+	t.Helper()
+	h := &fakeHub{hits: map[string]int{}, files: files}
+	h.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.mu.Lock()
+		h.hits[r.URL.Path]++
+		h.mu.Unlock()
+
+		body, ok := h.files[fileOfURL(r.URL.Path)]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(body)
+	}))
+	t.Cleanup(h.Close)
+	return h
+}
+
+func (h *fakeHub) totalHits() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, c := range h.hits {
+		n += c
+	}
+	return n
+}
+
+// fileOfURL pulls the file path out of /{org}/{repo}/resolve/{rev}/{file}.
+func fileOfURL(p string) string {
+	parts := strings.SplitN(strings.TrimPrefix(p, "/"), "/", 5)
+	if len(parts) < 5 {
+		return ""
+	}
+	return parts[4]
+}
+
+// pinTestModel registers a model served by hub for the duration of the test
+// and points the downloader at it.
+func pinTestModel(t *testing.T, hub *fakeHub, id string, art modelArtifact) {
+	t.Helper()
+	if _, exists := modelArtifacts[id]; exists {
+		t.Fatalf("test model id %q collides with a real pinned model", id)
+	}
+	modelArtifacts[id] = art
+	prev := hubBaseURL
+	hubBaseURL = hub.URL
+	t.Cleanup(func() {
+		delete(modelArtifacts, id)
+		hubBaseURL = prev
+	})
+}
+
+// testModel is a two-file stand-in for a real model directory.
+func testModel(t *testing.T) (id string, files map[string][]byte, art modelArtifact) {
+	t.Helper()
+	files = map[string][]byte{
+		"tokenizer.json": []byte(`{"tokenizer":"test"}`),
+		"model.onnx":     []byte("not really onnx, but hashed the same way"),
+	}
+	return "alcatraz-test/fixture-NER", files, modelArtifact{
+		revision: "0000000000000000000000000000000000000000",
+		files: []modelFile{
+			{path: "tokenizer.json", sha256: sum(files["tokenizer.json"])},
+			{path: "model.onnx", sha256: sum(files["model.onnx"])},
+		},
+	}
+}
+
+func TestEnsureModelInDownloadsAndVerifies(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	got, err := EnsureModelIn(context.Background(), id, dir)
+	if err != nil {
+		t.Fatalf("EnsureModelIn: %v", err)
+	}
+
+	want := filepath.Join(dir, "alcatraz-test_fixture-NER")
+	if got != want {
+		t.Fatalf("model dir = %q, want %q", got, want)
+	}
+	for name, body := range files {
+		p := filepath.Join(got, name)
+		onDisk, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		if string(onDisk) != string(body) {
+			t.Errorf("%s = %q, want %q", name, onDisk, body)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o644 {
+			t.Errorf("%s mode = %v, want 0644", name, info.Mode().Perm())
+		}
+	}
+	// Nothing but the pinned files, so no .partial-* survives a success.
+	entries, err := os.ReadDir(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != len(files) {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("model dir holds %v, want exactly the %d pinned files", names, len(files))
+	}
+}
+
+func TestEnsureModelInWarmCacheSkipsNetwork(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
+		t.Fatalf("first EnsureModelIn: %v", err)
+	}
+	after := hub.totalHits()
+	if after != len(files) {
+		t.Fatalf("cold cache made %d requests, want %d", after, len(files))
+	}
+
+	if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
+		t.Fatalf("second EnsureModelIn: %v", err)
+	}
+	if hub.totalHits() != after {
+		t.Errorf("warm cache made %d extra requests, want 0", hub.totalHits()-after)
+	}
+}
+
+func TestEnsureModelInRepairsTamperedCache(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath, err := EnsureModelIn(context.Background(), id, dir)
+	if err != nil {
+		t.Fatalf("EnsureModelIn: %v", err)
+	}
+
+	// A file that exists is not evidence it is the file we pinned.
+	tampered := filepath.Join(modelPath, "model.onnx")
+	if err := os.WriteFile(tampered, []byte("malicious"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := hub.totalHits()
+
+	if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
+		t.Fatalf("EnsureModelIn after tampering: %v", err)
+	}
+	if hub.totalHits() != before+1 {
+		t.Errorf("made %d requests to repair, want 1", hub.totalHits()-before)
+	}
+	repaired, err := os.ReadFile(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(repaired) != string(files["model.onnx"]) {
+		t.Errorf("model.onnx = %q, want the pinned content restored", repaired)
+	}
+}
+
+func TestEnsureModelInRejectsChecksumMismatch(t *testing.T) {
+	id, files, art := testModel(t)
+	// The hub serves something other than what we pinned.
+	files["model.onnx"] = []byte("swapped out from under the pin")
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	_, err := EnsureModelIn(context.Background(), id, dir)
+	if err == nil {
+		t.Fatal("EnsureModelIn succeeded, want a sha256 mismatch error")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error = %v, want it to name the sha256 mismatch", err)
+	}
+	// A rejected download leaves nothing usable behind — not the bad file,
+	// not a .partial-* temp file.
+	entries, err := os.ReadDir(modelDir(dir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() == "model.onnx" || strings.Contains(e.Name(), ".partial-") {
+			t.Errorf("leftover file %q after a rejected download", e.Name())
+		}
+	}
+}
+
+func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
+	id, files, art := testModel(t)
+	delete(files, "model.onnx") // hub 404s for it
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	_, err := EnsureModelIn(context.Background(), id, dir)
+	if err == nil {
+		t.Fatal("EnsureModelIn succeeded, want an error for the missing file")
+	}
+	if !strings.Contains(err.Error(), "model.onnx") {
+		t.Errorf("error = %v, want it to name the file that failed", err)
+	}
+	entries, err := os.ReadDir(modelDir(dir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".partial-") {
+			t.Errorf("leftover temp file %q after a failed download", e.Name())
+		}
+	}
+}
+
+func TestEnsureModelUnpinnedModel(t *testing.T) {
+	_, err := EnsureModel(context.Background(), "some-org/unpinned-model")
+	if err == nil {
+		t.Fatal("EnsureModel succeeded for an unpinned model, want an error")
+	}
+	// The message has to be actionable: which ids can be verified.
+	for _, want := range []string{"some-org/unpinned-model", "KnightsAnalytics/distilbert-NER"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestEnsureModelInCancelledContext(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := EnsureModelIn(ctx, id, t.TempDir())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+}
+
+func TestEnsureModelInConcurrent(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = EnsureModelIn(context.Background(), id, dir)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+	// Whoever won each rename, the result must be the pinned bytes and
+	// nothing else — no torn file, no surviving temp file.
+	entries, err := os.ReadDir(modelDir(dir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != len(files) {
+		t.Errorf("model dir holds %d entries, want %d", len(entries), len(files))
+	}
+	for name, body := range files {
+		got, err := os.ReadFile(filepath.Join(modelDir(dir, id), name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(body) {
+			t.Errorf("%s = %q, want %q", name, got, body)
+		}
+	}
+}
+
+func TestModelDir(t *testing.T) {
+	cases := []struct{ model, want string }{
+		{"KnightsAnalytics/distilbert-NER", "KnightsAnalytics_distilbert-NER"},
+		{"bert-base-NER", "bert-base-NER"},
+		// hugot drops a ":variant" suffix; we must land in the same place.
+		{"org/model:quantized", "org_model"},
+	}
+	for _, c := range cases {
+		if got := modelDir("/models", c.model); got != filepath.Join("/models", c.want) {
+			t.Errorf("modelDir(%q) = %q, want .../%s", c.model, got, c.want)
+		}
+	}
+}
+
+// TestPinnedArtifactsWellFormed guards the pin table itself: a branch name
+// where a commit sha belongs would let the upstream repository change
+// underneath the checksums, which is the whole thing pinning prevents.
+func TestPinnedArtifactsWellFormed(t *testing.T) {
+	commit := regexp.MustCompile(`^[0-9a-f]{40}$`)
+	digest := regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+	for id, art := range modelArtifacts {
+		if !commit.MatchString(art.revision) {
+			t.Errorf("%s: revision %q is not a 40-hex commit sha", id, art.revision)
+		}
+		seen := map[string]bool{}
+		for _, f := range art.files {
+			if !digest.MatchString(f.sha256) {
+				t.Errorf("%s: %s has a malformed sha256 %q", id, f.path, f.sha256)
+			}
+			if seen[f.path] {
+				t.Errorf("%s: %s is pinned twice", id, f.path)
+			}
+			seen[f.path] = true
+		}
+		// hugot's pipeline loader needs all three to build a session.
+		for _, required := range []string{"model.onnx", "tokenizer.json", "config.json"} {
+			if !seen[required] {
+				t.Errorf("%s: %s is not pinned", id, required)
+			}
+		}
+	}
+}
+
+func TestDefaultModelIsPinned(t *testing.T) {
+	if _, ok := modelArtifacts[DefaultConfig().Model]; !ok {
+		t.Errorf("default model %q is not pinned, so New downloads it unverified",
+			DefaultConfig().Model)
+	}
+}
+
+// TestLiveEnsureModel downloads the real default model from Hugging Face and
+// verifies it against the pinned checksums. It is gated like the other live
+// tests because it pulls ~260MB:
+//
+//	ALCATRAZ_NER_LIVE=1 go test -run LiveEnsureModel .
+func TestLiveEnsureModel(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live download test")
+	}
+	model := DefaultConfig().Model
+	dir := os.Getenv("ALCATRAZ_NER_MODELS_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	path, err := EnsureModelIn(context.Background(), model, dir)
+	if err != nil {
+		t.Fatalf("EnsureModelIn(%s): %v", model, err)
+	}
+	for _, f := range modelArtifacts[model].files {
+		if !cachedFileValid(filepath.Join(path, f.path), f.sha256) {
+			t.Errorf("%s did not verify after download", f.path)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "verified %s at %s\n", model, path)
+}

--- a/ner/download_test.go
+++ b/ner/download_test.go
@@ -95,9 +95,24 @@ func testModel(t *testing.T) (id string, files map[string][]byte, art modelArtif
 	return "alcatraz-test/fixture-NER", files, modelArtifact{
 		revision: "0000000000000000000000000000000000000000",
 		files: []modelFile{
-			{path: "tokenizer.json", sha256: sum(files["tokenizer.json"])},
-			{path: "model.onnx", sha256: sum(files["model.onnx"])},
+			{path: "tokenizer.json", sha256: sum(files["tokenizer.json"]), size: int64(len(files["tokenizer.json"]))},
+			{path: "model.onnx", sha256: sum(files["model.onnx"]), size: int64(len(files["model.onnx"]))},
 		},
+	}
+}
+
+// assertNoLeftovers checks that a rejected download for name left nothing
+// usable in dir: neither the file itself nor a .partial-* temp file.
+func assertNoLeftovers(t *testing.T, dir, name string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() == name || strings.Contains(e.Name(), ".partial-") {
+			t.Errorf("leftover file %q after a rejected download", e.Name())
+		}
 	}
 }
 
@@ -204,8 +219,9 @@ func TestEnsureModelInRepairsTamperedCache(t *testing.T) {
 
 func TestEnsureModelInRejectsChecksumMismatch(t *testing.T) {
 	id, files, art := testModel(t)
-	// The hub serves something other than what we pinned.
-	files["model.onnx"] = []byte("swapped out from under the pin")
+	// The hub serves something other than what we pinned, at exactly the
+	// pinned length: the digest has to be what rejects it, not the size.
+	files["model.onnx"] = []byte(strings.Repeat("z", len(files["model.onnx"])))
 	hub := newFakeHub(t, files)
 	pinTestModel(t, hub, id, art)
 
@@ -217,17 +233,49 @@ func TestEnsureModelInRejectsChecksumMismatch(t *testing.T) {
 	if !strings.Contains(err.Error(), "sha256 mismatch") {
 		t.Errorf("error = %v, want it to name the sha256 mismatch", err)
 	}
-	// A rejected download leaves nothing usable behind — not the bad file,
-	// not a .partial-* temp file.
-	entries, err := os.ReadDir(modelDir(dir, id))
-	if err != nil {
-		t.Fatal(err)
+	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+}
+
+// TestEnsureModelInRejectsOversizedResponse covers the case the digest alone
+// cannot: a response that never ends. The read is bounded one byte past the
+// pin, so an endpoint streaming far more than the pinned length is cut off
+// and rejected rather than filling the disk while the hash waits for EOF.
+func TestEnsureModelInRejectsOversizedResponse(t *testing.T) {
+	id, files, art := testModel(t)
+	pinned := len(files["model.onnx"])
+	files["model.onnx"] = []byte(strings.Repeat("x", 100*pinned))
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	_, err := EnsureModelIn(context.Background(), id, dir)
+	if err == nil {
+		t.Fatal("EnsureModelIn succeeded, want a size mismatch error")
 	}
-	for _, e := range entries {
-		if e.Name() == "model.onnx" || strings.Contains(e.Name(), ".partial-") {
-			t.Errorf("leftover file %q after a rejected download", e.Name())
-		}
+	if !strings.Contains(err.Error(), "size mismatch") {
+		t.Errorf("error = %v, want it to name the size mismatch", err)
 	}
+	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+}
+
+// TestEnsureModelInRejectsTruncatedResponse checks that a short read fails as
+// a truncation rather than as an opaque digest mismatch, so the error says
+// what actually went wrong.
+func TestEnsureModelInRejectsTruncatedResponse(t *testing.T) {
+	id, files, art := testModel(t)
+	files["model.onnx"] = files["model.onnx"][:5]
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	_, err := EnsureModelIn(context.Background(), id, dir)
+	if err == nil {
+		t.Fatal("EnsureModelIn succeeded, want a size mismatch error")
+	}
+	if !strings.Contains(err.Error(), "size mismatch") {
+		t.Errorf("error = %v, want it to name the size mismatch", err)
+	}
+	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
 }
 
 func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
@@ -244,15 +292,7 @@ func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
 	if !strings.Contains(err.Error(), "model.onnx") {
 		t.Errorf("error = %v, want it to name the file that failed", err)
 	}
-	entries, err := os.ReadDir(modelDir(dir, id))
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if strings.Contains(e.Name(), ".partial-") {
-			t.Errorf("leftover temp file %q after a failed download", e.Name())
-		}
-	}
+	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
 }
 
 func TestEnsureModelUnpinnedModel(t *testing.T) {
@@ -322,6 +362,55 @@ func TestEnsureModelInConcurrent(t *testing.T) {
 	}
 }
 
+// TestEnsureModelInConcurrentRepair points several callers at the same
+// corrupt cache file at once. Each one has to end up with the pinned bytes
+// readable at the pathname it was handed: repair replaces the file by
+// renaming over it, so a caller that finished later must never remove what an
+// earlier one already installed and reported as ready.
+//
+// Interleavings are not deterministic, so this exercises the path rather than
+// proving it; -race and -count make it worth its runtime.
+func TestEnsureModelInConcurrentRepair(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
+		t.Fatalf("seeding the cache: %v", err)
+	}
+	tampered := filepath.Join(modelDir(dir, id), "model.onnx")
+	if err := os.WriteFile(tampered, []byte("malicious"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	got := make([][]byte, len(errs))
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
+				errs[i] = err
+				return
+			}
+			// Read through the pathname the caller was told is ready.
+			got[i], errs[i] = os.ReadFile(tampered)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+			continue
+		}
+		if string(got[i]) != string(files["model.onnx"]) {
+			t.Errorf("goroutine %d read %q, want the pinned content", i, got[i])
+		}
+	}
+}
+
 func TestModelDir(t *testing.T) {
 	cases := []struct{ model, want string }{
 		{"KnightsAnalytics/distilbert-NER", "KnightsAnalytics_distilbert-NER"},
@@ -351,6 +440,11 @@ func TestPinnedArtifactsWellFormed(t *testing.T) {
 		for _, f := range art.files {
 			if !digest.MatchString(f.sha256) {
 				t.Errorf("%s: %s has a malformed sha256 %q", id, f.path, f.sha256)
+			}
+			// A zero size would cap every read at one byte, so a missing
+			// size has to fail here rather than at download time.
+			if f.size <= 0 {
+				t.Errorf("%s: %s has a non-positive size %d", id, f.path, f.size)
 			}
 			if seen[f.path] {
 				t.Errorf("%s: %s is pinned twice", id, f.path)

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -41,6 +41,26 @@
 // whole pipeline — windowing, batching, span merging — behaves identically
 // on every backend.
 //
+// # Getting the model
+//
+// New downloads the model on first use, which is convenient on a laptop and
+// unhelpful in a build pipeline or a network-restricted deployment.
+// EnsureModel fetches it up front instead, into the same directory New reads
+// from, so New finds a warm cache and touches the network not at all:
+//
+//	// In an image build or an init container.
+//	dir, err := ner.EnsureModelIn(ctx, "KnightsAnalytics/distilbert-NER", "/opt/alcatraz/models")
+//
+//	// At runtime, pointed at what was built above.
+//	cfg := ner.DefaultConfig()
+//	cfg.ModelsDir = "/opt/alcatraz/models"
+//
+// Every file of a model listed by PinnedModels is fetched from a pinned
+// commit and checked against a pinned sha256 — on download and again on
+// every load, since a cached file that exists is not evidence that it is the
+// file we pinned. Models outside that list still work, but nothing verifies
+// what the hub serves for them.
+//
 // The Engine implements analyzer.NlpEngine, so an analyzer.Engine configured
 // with SetNlpEngine runs the model once per Analyze call and shares the
 // artifacts with every artifact-aware recognizer:
@@ -63,7 +83,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/gomlx/go-huggingface/tokenizers/api"
 	"github.com/hoophq/alcatraz/analyzer"
@@ -200,17 +219,20 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 // ensureModel returns the local path of cfg.Model, downloading it from
 // Hugging Face into the models directory on first use.
 func ensureModel(ctx context.Context, cfg Config) (string, error) {
-	dir := cfg.ModelsDir
-	if dir == "" {
-		cache, err := os.UserCacheDir()
-		if err != nil {
-			return "", err
-		}
-		dir = filepath.Join(cache, "alcatraz", "models")
+	dir, err := resolveModelsDir(cfg.ModelsDir)
+	if err != nil {
+		return "", err
 	}
-	// DownloadModel stores the model under this derived path; when it is
-	// already populated, skip the network entirely.
-	modelPath := filepath.Join(dir, strings.ReplaceAll(cfg.Model, "/", "_"))
+	// Pinned models take the verified path: every file is checked against
+	// its sha256, so a cache hit is a hit only if the bytes still match
+	// and what New loads is what we pinned, not merely what the hub last
+	// served (see download.go).
+	if _, pinned := modelArtifacts[cfg.Model]; pinned {
+		return EnsureModelIn(ctx, cfg.Model, dir)
+	}
+	// Any other model id keeps working, unverified: hugot's cache check is
+	// presence-only, and so is ours.
+	modelPath := modelDir(dir, cfg.Model)
 	if _, err := os.Stat(filepath.Join(modelPath, "tokenizer.json")); err == nil {
 		return modelPath, nil
 	}


### PR DESCRIPTION
Refs ATR-190.

## What this fixes

`ner` downloaded its ONNX model through `hugot.DownloadModel` from inside `New`, on first use. Two problems fell out of that:

1. **No pre-fetch.** There was no way to seed the cache ahead of time, so a deployment with no internet egress could not use the NER module at all.
2. **No integrity check.** Whatever bytes `huggingface.co` returned were written to disk and then executed as a model. That affects every deployment, air-gapped or not.

## What's added

| | |
|---|---|
| `EnsureModel(ctx, model)` | fetch + verify into the default models dir; returns the model directory |
| `EnsureModelIn(ctx, model, dir)` | same, into an explicit dir — an image layer, a shared volume |
| `PinnedModels()` | the ids that can be verified |

The returned path is the same directory `New` reads from, so a warm cache makes `New` network-free, and the path can also be handed straight to `Config.ModelPath`:

```go
// In an image build or an init container.
dir, err := ner.EnsureModelIn(ctx, "KnightsAnalytics/distilbert-NER", "/opt/alcatraz/models")

// At runtime, pointed at what was built above.
cfg := ner.DefaultConfig()
cfg.ModelsDir = "/opt/alcatraz/models"
```

## Decisions worth a look

**Pinning is per file, plus a commit sha.** The issue says "a pinned sha256 per supported model", which assumes one artifact — that's the shape `pfilter` has, where the model is a single GGUF file. An ONNX NER model is a directory of six files, so the pin became a revision plus a `sha256` and a byte length for each file. Deliberate divergence from the issue text, not an oversight.

**The revision is a commit sha, never a branch.** Pinned to `main`, upstream can push at any time, and a checksum failure stops distinguishing "upstream updated" from "someone tampered with this" — the failure becomes ambiguous exactly when it matters. Pinned to a commit it has one meaning. `TestPinnedArtifactsWellFormed` enforces 40-hex.

**`hugot.DownloadModel` is bypassed on purpose.** `ValidateDownloadedHFModel` picks its file set by listing the repository at run time, so the caller cannot control the set and therefore cannot pin it. This fetches the pinned URLs directly. The output layout is identical, and `modelDir` reproduces hugot's naming (`strings.ReplaceAll(id, "/", "_")`, minus any `:suffix`) so both downloaders agree on where a model lives.

**Verification runs on every load, not just on download.** A cached file that exists is not evidence it is the file we pinned. Re-hashing the 260MB default measures ~0.45s against a warm page cache, next to ~6s of ONNX session setup — ~7% of a once-per-process cost, so `New` verifies too rather than trusting the cache once it's populated. A mismatched file is refetched, and left in place until the replacement renames over it — unlinking it here would race the rename and could delete a good file a concurrent caller had already been told was ready.

**Unpinned ids are unchanged.** Anything outside `PinnedModels()` still goes through hugot with no verification, as before. `EnsureModel` refuses it with an error naming the pinned set, rather than downloading something it cannot check.

**Downloads are atomic, and bounded.** Stream to a `.partial-*` temp file in the destination directory, hash while streaming, chmod, `os.Rename`. A crashed or corrupt download never leaves a file at the destination; concurrent callers never see a partial one. The read is capped one byte past the pinned length, because a digest is only conclusive at EOF and so bounds integrity but not consumption — without a cap, an endpoint that never stops sending fills the disk before anything rejects it. The cap counts bytes actually read rather than trusting `Content-Length`, and a short read is rejected as a truncation rather than surfacing as an opaque digest mismatch.

## Testing

14 unit tests, all offline against an `httptest` server with a fake pinned model injected into `modelArtifacts` and `hubBaseURL` swapped, both undone via `t.Cleanup`. They cover: download + content + `0644` perms + no leftover temp files, warm cache making zero requests, a tampered cache file being repaired with exactly one refetch, a checksum mismatch erroring and leaving nothing on disk, an oversized response and a truncated one both rejected on length, a 404 leaving no partial, the unpinned-model error, context cancellation, 8 concurrent callers, 8 concurrent callers repairing the same corrupt file, `modelDir` naming, pin well-formedness, and that `DefaultConfig().Model` is pinned.

`go test -race ./...` passes in both modules; `gofmt` and `go vet` clean.

Also verified against the real hub once, behind `ALCATRAZ_NER_LIVE=1`: all six checksums matched, and `TestLiveNER` then loaded the model through the new verified path on a warm cache.

## Not in this PR

- `alcatraz models download` and the offline-install docs — ATR-191.
- `Config.Offline`, for a hard guarantee that no network call is attempted — ATR-192.
- Documentation lives only in the doc comments for now; the README section belongs with ATR-191, and the wider docs restructure is ATR-193.

