### PR TITLE
ci(release): tag the ner and pfilter submodules too

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -125,28 +125,36 @@ jobs:
           gh release create "$NEXT" "${ARGS[@]}"
           echo "Released github.com/${{ github.repository }}@${NEXT}"
 
-      - name: Release lookaround submodule
+      - name: Release submodules
         if: steps.pr.outputs.skip == 'false'
         env:
           NEXT: ${{ steps.version.outputs.next }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # The lookaround module uses a local `replace` for development, which
-          # is ignored by consumers and would leave `require ...alcatraz v0.0.0`
+          # Each submodule uses a local `replace` for development, which is
+          # ignored by consumers and would leave `require ...alcatraz v0.0.0`
           # unresolvable. Publish a corrected go.mod on a throwaway commit that
           # is referenced ONLY by the tag: strip the replace and pin the parent
           # to the version we just released. The commit is never pushed to a
           # branch, so main stays untouched and this workflow is not retriggered
           # (it only runs on branch pushes, not tag pushes).
-          git checkout --detach "$SHA"
-          go mod edit -dropreplace=github.com/hoophq/alcatraz lookaround/go.mod
-          go mod edit -require=github.com/hoophq/alcatraz@"$NEXT" lookaround/go.mod
-          git add lookaround/go.mod
-          git \
-            -c user.name='github-actions[bot]' \
-            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-            commit -m "release(lookaround): require alcatraz ${NEXT}"
-          git tag "lookaround/${NEXT}"
-          git push origin "lookaround/${NEXT}"
-          echo "Released github.com/${{ github.repository }}/lookaround@${NEXT} (requires alcatraz ${NEXT})"
+          #
+          # bench is deliberately absent: it is an internal benchmark harness
+          # with no consumers, so tagging it would publish an API we do not
+          # intend to support.
+          for mod in lookaround ner pfilter; do
+            # Re-detach each round so every tag is built from the merge commit
+            # alone. The previous iteration's commit survives via its pushed tag.
+            git checkout --detach "$SHA"
+            go mod edit -dropreplace=github.com/hoophq/alcatraz "${mod}/go.mod"
+            go mod edit -require=github.com/hoophq/alcatraz@"$NEXT" "${mod}/go.mod"
+            git add "${mod}/go.mod"
+            git \
+              -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "release(${mod}): require alcatraz ${NEXT}"
+            git tag "${mod}/${NEXT}"
+            git push origin "${mod}/${NEXT}"
+            echo "Released github.com/${{ github.repository }}/${mod}@${NEXT} (requires alcatraz ${NEXT})"
+          done

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -143,9 +143,19 @@ jobs:
           # bench is deliberately absent: it is an internal benchmark harness
           # with no consumers, so tagging it would publish an API we do not
           # intend to support.
+          #
+          # Build every tag locally first, then publish them in one atomic
+          # push. Tagging three modules instead of one means three chances to
+          # fail mid-way, and a half-tagged release cannot be repaired by a
+          # rerun: the next run reads the release we just created and computes
+          # a *higher* version, so the missing tags would stay missing at this
+          # one. --atomic makes the remote accept all the tags or none, which
+          # keeps that from happening.
+          tags=()
           for mod in lookaround ner pfilter; do
             # Re-detach each round so every tag is built from the merge commit
-            # alone. The previous iteration's commit survives via its pushed tag.
+            # alone. The previous round's commit is kept alive by its local tag
+            # until the push below.
             git checkout --detach "$SHA"
             go mod edit -dropreplace=github.com/hoophq/alcatraz "${mod}/go.mod"
             go mod edit -require=github.com/hoophq/alcatraz@"$NEXT" "${mod}/go.mod"
@@ -155,6 +165,9 @@ jobs:
               -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
               commit -m "release(${mod}): require alcatraz ${NEXT}"
             git tag "${mod}/${NEXT}"
-            git push origin "${mod}/${NEXT}"
+            tags+=("${mod}/${NEXT}")
+          done
+          git push --atomic origin "${tags[@]}"
+          for mod in lookaround ner pfilter; do
             echo "Released github.com/${{ github.repository }}/${mod}@${NEXT} (requires alcatraz ${NEXT})"
           done


### PR DESCRIPTION
## Problem

`auto-release.yml` publishes the root module and `lookaround`. But `ner`, `pfilter` and `bench` all carry the same shape:

```
require github.com/hoophq/alcatraz v0.0.0
replace github.com/hoophq/alcatraz => ../
```

The `replace` is development-only — consumers ignore it — so the `v0.0.0` is what they actually see. That is exactly the problem the `lookaround` step was written to solve, and the other three never got the same treatment. No `ner/*` or `pfilter/*` tag has ever existed.

Reproduced against a scratch module, importing only `ner`:

```
$ go get github.com/hoophq/alcatraz/ner@07475a38
go: github.com/hoophq/alcatraz/ner imports
    github.com/hoophq/alcatraz/analyzer: reading github.com/hoophq/alcatraz/go.mod
    at revision v0.0.0: unknown revision v0.0.0
```

It only works today for a consumer that *also* requires the core module at a real version — which libhoop does, so this has been masked. `lookaround`, which does get the treatment, resolves standalone:

```
$ go get github.com/hoophq/alcatraz/lookaround@v0.8.0
go: added github.com/hoophq/alcatraz v0.8.0
go: added github.com/hoophq/alcatraz/lookaround v0.8.0
```

## Change

Turn the single `lookaround` step into a loop over `lookaround`, `ner`, `pfilter`. The body is unchanged: re-detach from the merge commit, drop the replace, pin the parent to the version just released, tag, push.

`bench` is left out on purpose — internal benchmark harness, no consumers, and tagging it would publish an API we do not intend to support.

## Verification

Simulated the loop against a local clone with `NEXT=v9.9.9`:

```
=== cada tag aponta pra um commit distinto? ===
lookaround   7c4629e
ner          82849eb
pfilter      37cc1f9

=== cada tag mexe SO no proprio go.mod? ===
lookaround   -> lookaround/go.mod | 5 +----
ner          -> ner/go.mod | 5 +----
pfilter      -> pfilter/go.mod | 5 +----

=== go.mod publicado em cada tag ===
--- lookaround ---  require github.com/hoophq/alcatraz v9.9.9
--- ner ---         require github.com/hoophq/alcatraz v9.9.9
--- pfilter ---     require github.com/hoophq/alcatraz v9.9.9

=== main ficou intocada? ===
9972fc3 Merge pull request #19 ...
```

Each tag is built from the merge commit alone; the re-detach means iteration N does not inherit iteration N-1's throwaway commit, which survives via its pushed tag.

## Label

`skip-release` — this is a CI-only change, so it cuts no tag of its own and `ner`/`pfilter` get their first tags on the next releasing PR.

Nothing is blocked in the meantime: a consumer that also requires the core module at a real version — which libhoop does — already resolves `ner` by pseudo-version, `go build` and `go mod tidy` both clean. The gap this fixes only bites a consumer that imports a submodule *without* the core.

## Not covered

The loop is verified locally, not in CI — nothing exercises `auto-release.yml` before a merge to `main`. The first real run is the merge of this PR.

Partial-failure behaviour is worth stating plainly: if the step dies midway, the modules already tagged stay tagged, and a re-run **aborts at the first of them** — `git tag` on an existing tag is `fatal: tag 'X' already exists`, and `set -euo pipefail` turns that into a failed step. Recovering means deleting the partial tags or tagging the remaining modules by hand. That matches the existing stance in the root release step, which also refuses to proceed when the release already exists rather than trying to be clever.
