### PR TITLE
feat(cli): add models download subcommand and offline-install docs (ATR-191)

### DIFF
--- a/.github/workflows/ml-live.yml
+++ b/.github/workflows/ml-live.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "ner/**"
       - "pfilter/**"
+      # The pin table lives here: a revision or digest bump must be proved
+      # against what the hub actually serves before it lands.
+      - "models/**"
       - "analyzer/nlp*.go"
       - ".github/workflows/ml-live.yml"
   schedule:
@@ -51,22 +54,30 @@ jobs:
       - name: Cache NER model
         uses: actions/cache@v4
         with:
-          # ner.ensureModel stores models under the user cache dir.
+          # models.ResolveDir stores models under the user cache dir.
           path: |
             ~/.cache/alcatraz/models
             ~/Library/Caches/alcatraz/models
           key: ner-model-${{ runner.os }}-v1
 
+      # Two modules, so two steps. TestLiveEnsureModel now lives in the root
+      # module's models package; it writes to a temp dir, which makes it the
+      # only job here that fetches the pinned URLs and checks the recorded
+      # sizes and digests against what the hub actually serves — the case a
+      # warm cache hides. Running it separately is not cosmetic: folded into
+      # the ner step it would simply stop running, silently.
+      - name: Live model download test
+        env:
+          ALCATRAZ_NER_LIVE: "1"
+        run: go test -v -run TestLiveEnsureModel -timeout 25m ./models/
+
       # TestLiveNER runs against the cache restored above, so it exercises
-      # loading but never downloading. TestLiveEnsureModel writes to a temp
-      # dir instead, which makes it the only job here that fetches the pinned
-      # URLs and checks the recorded sizes and digests against what the hub
-      # actually serves — the case a warm cache hides.
+      # loading but never downloading.
       - name: Live model test
         working-directory: ner
         env:
           ALCATRAZ_NER_LIVE: "1"
-        run: go test -v -run 'TestLiveNER|TestLiveEnsureModel' -timeout 25m ./...
+        run: go test -v -run TestLiveNER -timeout 25m ./...
 
   # pfilter: needs libpf (built from the pinned privacy-filter.cpp revision
   # via the pfilter/dist CMake wrapper, cached) and a GGUF (cached).

--- a/README.md
+++ b/README.md
@@ -309,8 +309,9 @@ ModelPath: /opt/alcatraz/models/KnightsAnalytics_distilbert-NER
 ```
 
 Every file is pinned to a commit revision and checked against a known sha256
-and byte size; a mismatch fails the command with a non-zero exit and installs
-nothing. Re-running is cheap and offline — files already present are
+and byte size; a mismatch fails the command with a non-zero exit, and the
+bytes that failed are never installed. Files verified earlier in the same run
+are kept, which is what makes re-running cheap and offline — they are
 re-verified, not re-fetched. Note that the command lives in the **root**
 module, so the plain `alcatraz` binary (Homebrew, `go install`, or a release
 download) can fetch the model without the ONNX runtime being anywhere near it.
@@ -342,7 +343,11 @@ spec:
   initContainers:
     - name: fetch-ner-model
       image: your-registry/alcatraz:latest # any image carrying the alcatraz binary
-      args: ["models", "download", "--dest", "/models"]
+      # command:, not args: — args replaces the image's CMD but inherits its
+      # ENTRYPOINT, so it only works when that entrypoint is alcatraz itself.
+      # On an image that merely carries the binary, args makes Kubernetes try
+      # to exec "models", and the init container crash-loops.
+      command: ["alcatraz", "models", "download", "--dest", "/models"]
       volumeMounts:
         - { name: alcatraz-models, mountPath: /models }
   containers:

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Requires Go 1.24+. The standard library is the only dependency.
 ## The CLI
 
 The library also ships as a small command-line scanner — same engine, same
-zero-network posture. Scan files, stdin, or a unified diff; detected values
-are always masked in the output.
+zero-network scan. Scan files, stdin, or a unified diff; detected values are
+always masked in the output.
 
 ```bash
 # Homebrew (macOS & Linux)
@@ -90,6 +90,11 @@ Exit codes are grep-style: `0` clean, `1` findings, `2` error. Flags:
 `-threshold` (default 0.4), `-entities`, `-ignore` (default `DATE_TIME,URL`),
 `-allowlist-file` (one allowed value per line, `#` comments), and `-exclude`
 (diff mode, glob patterns of paths to skip).
+
+Scanning never touches the network — no telemetry, no lookups, nothing leaves
+the process. The single exception is `alcatraz models download`, which fetches
+the optional NER model from pinned, checksum-verified URLs when you ask it to;
+see [Running NER without internet access](#running-ner-without-internet-access).
 
 The CLI powers the [Hoop plugin for Claude Code](https://github.com/hoophq/claude-marketplace)'s
 `/hoop:pii-scan` command and pairs with
@@ -274,6 +279,104 @@ Design notes:
 - **Byte offsets, guaranteed.** Model spans are mapped back to byte offsets
   in the original text, so `text[r.Start:r.End] == r.Text` holds for NER
   results too, including multi-byte input.
+
+### Running NER without internet access
+
+By default `ner.New` downloads the model on first use — ~250 MiB from
+huggingface.co, at the worst possible moment: the first request that needs a
+`PERSON`. In a restricted or air-gapped network that is not a slow start, it
+is a hard failure. Fetch the model deliberately instead, as a build or deploy
+step:
+
+```bash
+alcatraz models download                      # warm the cache ner.New reads from
+alcatraz models download --dest /opt/alcatraz/models   # or a self-contained directory
+```
+
+```
+KnightsAnalytics/distilbert-NER @ 13a742d5
+fetching 6 files, 249.7 MiB total (cached files are verified, not re-fetched):
+  config.json                   925 B
+  model.onnx                248.8 MiB
+  ...
+verified:
+  config.json              8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5
+  model.onnx               4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160
+  ...
+
+ModelsDir: /opt/alcatraz/models
+ModelPath: /opt/alcatraz/models/KnightsAnalytics_distilbert-NER
+```
+
+Every file is pinned to a commit revision and checked against a known sha256
+and byte size; a mismatch fails the command with a non-zero exit and installs
+nothing. Re-running is cheap and offline — files already present are
+re-verified, not re-fetched. Note that the command lives in the **root**
+module, so the plain `alcatraz` binary (Homebrew, `go install`, or a release
+download) can fetch the model without the ONNX runtime being anywhere near it.
+
+**Bake it into an image** — no runtime network at all, at the cost of ~250 MiB
+of image:
+
+```dockerfile
+# Fetch and verify the model in a build stage.
+FROM golang:1.24 AS models
+RUN go install github.com/hoophq/alcatraz/cmd/alcatraz@latest
+RUN alcatraz models download --dest /opt/alcatraz/models
+
+FROM your-app-base
+COPY --from=models /opt/alcatraz/models /opt/alcatraz/models
+```
+
+**Or prime a shared volume** — an init container fetches once, the app
+container mounts the result:
+
+```yaml
+spec:
+  volumes:
+    - name: alcatraz-models
+      # emptyDir re-fetches per pod; a ReadWriteMany PVC fetches once for the
+      # cluster and every later start is a local re-verify.
+      persistentVolumeClaim:
+        claimName: alcatraz-models
+  initContainers:
+    - name: fetch-ner-model
+      image: your-registry/alcatraz:latest # any image carrying the alcatraz binary
+      args: ["models", "download", "--dest", "/models"]
+      volumeMounts:
+        - { name: alcatraz-models, mountPath: /models }
+  containers:
+    - name: app
+      volumeMounts:
+        - { name: alcatraz-models, mountPath: /models }
+```
+
+**Wiring the result into the config.** The command prints two paths one
+directory apart, and they are not interchangeable — picking the wrong one is
+the usual way this gets misconfigured:
+
+| Printed path | Config field | Downloads on load | Verifies on load |
+|--------------|--------------|-------------------|------------------|
+| `ModelsDir:` — the parent holding every model | `ner.Config.ModelsDir` | only files missing or failing verification | yes, every pinned file |
+| `ModelPath:` — this model's own directory | `ner.Config.ModelPath` | never | no — the directory is trusted as-is |
+
+`ModelsDir` is the better default for a mounted volume: it needs no network
+when the files are intact, and it still catches a truncated or tampered-with
+model instead of loading it. `ModelPath` is the escape hatch for a directory
+alcatraz did not produce.
+
+```go
+cfg := ner.DefaultConfig()
+cfg.ModelsDir = "/opt/alcatraz/models" // the ModelsDir: line, not ModelPath:
+nlp, err := ner.New(ctx, cfg)
+```
+
+From Go, the same fetch is [`ner.EnsureModelIn`](https://pkg.go.dev/github.com/hoophq/alcatraz/ner#EnsureModelIn)
+(or `ner.EnsureModel` for the default cache), which returns the `ModelPath`
+form. Neither `ner` nor `models` reads environment variables — the path is
+always a config field — so a host application decides how to surface it as a
+deployment knob. Hoop's agent, for instance, maps `ALCATRAZ_NER_MODEL_PATH`
+onto `Config.ModelPath`.
 
 ### Faster inference: ORT, XLA and GPU
 
@@ -511,6 +614,9 @@ analyzer/          Framework: Result, dedup, Recognizer, Pattern, Matcher,
                    NLP seam (NlpEngine, NlpArtifacts, ArtifactRecognizer).
 anonymizer/        Mask/replace/redact detected spans (Operator, Config).
 recognizers/       The 45 built-in recognizers, checksum helpers, loader.
+models/            Pinned model manifests and checksum-verified downloads for
+                   the optional NER backends. In the root module, stdlib only,
+                   so the CLI fetches models without the model runtime.
 lookaround/        Optional, separate module: regexp2-backed Matcher for
                    lookahead/lookbehind in user-configured patterns.
 ner/               Optional, separate module: statistical NER (PERSON,
@@ -524,7 +630,8 @@ bench/             Separate module: reproducible speed + parity benchmarks
 ## Tests
 
 ```bash
-go test ./...                    # core
+go test ./...                    # core (incl. the models pin table, no network)
+ALCATRAZ_NER_LIVE=1 go test -run TestLiveEnsureModel ./models/   # + real download
 cd lookaround && go test ./...   # lookaround module
 cd ner && go test ./...          # ner module (unit tests, no model needed)
 cd ner && ALCATRAZ_NER_LIVE=1 go test ./...   # + end-to-end (downloads model)

--- a/cmd/alcatraz/main.go
+++ b/cmd/alcatraz/main.go
@@ -8,7 +8,13 @@
 //	alcatraz diff [flags]              read a unified diff on stdin, scan added lines
 //	alcatraz hook <claude-post|claude-prompt> [flags]
 //	                                   Claude Code hook processors (see hook.go)
+//	alcatraz models download [flags]   fetch a verified NER model (see models.go)
 //	alcatraz version                   print the version
+//
+// Scanning is the network-free part, and it is the whole product: no
+// telemetry, no lookups, nothing leaves the process. "models download" is the
+// single exception, and it exists so a deployment can fetch the optional NER
+// model deliberately, from pinned URLs, instead of on first use.
 //
 // Exit codes: 0 = no findings, 1 = findings detected, 2 = error. Hook mode
 // always exits 0 — findings are handled via hook output, never exit codes.
@@ -36,7 +42,7 @@ func main() {
 
 func run(args []string) (int, error) {
 	if len(args) == 0 {
-		return 0, fmt.Errorf("usage: alcatraz <scan|diff|version> [flags] [path ...]")
+		return 0, fmt.Errorf("usage: alcatraz <scan|diff|hook|models|version> [flags] [path ...]")
 	}
 	cmd, rest := args[0], args[1:]
 	switch cmd {
@@ -45,9 +51,11 @@ func run(args []string) (int, error) {
 		return 0, nil
 	case "hook":
 		return runHook(rest)
+	case "models":
+		return runModels(rest)
 	case "scan", "diff":
 	default:
-		return 0, fmt.Errorf("unknown command %q (want scan, diff, hook, or version)", cmd)
+		return 0, fmt.Errorf("unknown command %q (want scan, diff, hook, models, or version)", cmd)
 	}
 
 	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -6,9 +6,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/hoophq/alcatraz/models"
 )
@@ -50,7 +53,17 @@ func runModels(args []string) (int, error) {
 	if fs.NArg() > 0 {
 		return 0, fmt.Errorf("models download: unexpected argument %q", fs.Arg(0))
 	}
-	return download(context.Background(), os.Stdout, *model, *dest)
+	// Cancel on a signal rather than dying where we stand. The download
+	// streams to a temp file it removes on the way out, and that cleanup is a
+	// defer — which a signalled process never reaches, stranding up to 250MB
+	// under a ".partial-*" name that no later run reclaims. Being evicted or
+	// rescheduled mid-fetch is routine for the init container this command is
+	// documented to run as, and there the leak lands on a volume that outlives
+	// the pod. SIGKILL is still unrecoverable, but in Kubernetes it only
+	// follows SIGTERM and the grace period.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return download(ctx, os.Stdout, *model, *dest)
 }
 
 func download(ctx context.Context, out io.Writer, model, dest string) (int, error) {
@@ -92,15 +105,30 @@ func download(ctx context.Context, out io.Writer, model, dest string) (int, erro
 
 // hintFor turns a download failure into something the operator can act on.
 // The underlying error says what broke; this says what to do about it.
+//
+// A failure that already explains itself gets nothing. The destination being
+// unwritable, or the disk full, is the likeliest failure in the deployment
+// this command is built for — a non-root container writing a mounted volume —
+// and answering it with a note about proxies sends the operator off to debug
+// egress that was never involved.
 func hintFor(err error) string {
+	var urlErr *url.Error
 	switch msg := err.Error(); {
 	case strings.Contains(msg, "sha256 mismatch"), strings.Contains(msg, "size mismatch"):
 		return "\n  the bytes served do not match the pinned checksums — the transfer was corrupted," +
-			"\n  intercepted, or the cached copy was modified. Nothing was installed; re-run to fetch again."
+			"\n  intercepted, or the cached copy was modified. The mismatched file was not installed;" +
+			"\n  re-run to fetch it again — files already verified are kept, not fetched twice."
+	// Before the *url.Error arm: a cancelled request surfaces as a *url.Error
+	// wrapping context.Canceled, and the interruption is the useful half.
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return "\n  the download was interrupted; re-run to resume (verified files are not re-fetched)."
-	default:
+	case errors.As(err, &urlErr):
 		return "\n  only huggingface.co is contacted; behind a proxy, set HTTPS_PROXY."
+	case strings.Contains(msg, "unexpected status"):
+		return "\n  huggingface.co answered but would not serve the file; the pinned revision may have" +
+			"\n  been withdrawn, or the request was rate limited."
+	default:
+		return ""
 	}
 }
 

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoophq/alcatraz/models"
+)
+
+// The model downloader for the optional NER backend, exposed so a model can
+// be materialised as a build or deploy step rather than on first use:
+//
+//	alcatraz models download [-dest dir] [-model id]
+//
+// This is the one alcatraz command that touches the network, and it only
+// fetches the pinned URLs. Scanning never does.
+//
+// The heavy lifting is [models.EnsureModelIn], which lives in the root
+// module precisely so this command costs the CLI no dependencies: the ONNX
+// runtime stays behind the ner module.
+
+// ensureModelIn is the download entry point, indirected so tests can run the
+// command without a network. The models package hides its hub URL, so the
+// seam has to be here.
+var ensureModelIn = models.EnsureModelIn
+
+func runModels(args []string) (int, error) {
+	if len(args) == 0 {
+		modelsUsage(os.Stderr)
+		return 0, errors.New("models: expected a subcommand")
+	}
+	sub, rest := args[0], args[1:]
+	if sub != "download" {
+		modelsUsage(os.Stderr)
+		return 0, fmt.Errorf("models: unknown subcommand %q (want download)", sub)
+	}
+
+	fs := flag.NewFlagSet("models download", flag.ContinueOnError)
+	dest := fs.String("dest", "", "directory to write the model into (empty = the cache ner reads from)")
+	model := fs.String("model", models.DefaultModel, "model id to download")
+	if err := fs.Parse(rest); err != nil {
+		return 0, err
+	}
+	if fs.NArg() > 0 {
+		return 0, fmt.Errorf("models download: unexpected argument %q", fs.Arg(0))
+	}
+	return download(context.Background(), os.Stdout, *model, *dest)
+}
+
+func download(ctx context.Context, out io.Writer, model, dest string) (int, error) {
+	files := models.PinnedFiles(model)
+	if files == nil {
+		return 0, fmt.Errorf("models download: %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
+			model, strings.Join(models.PinnedModels(), ", "))
+	}
+
+	// The manifest goes out before the first byte is fetched: 250MB over a
+	// slow link is a long silence to sit through without knowing what was
+	// asked for, and a warm cache turns the same list into a receipt.
+	var total int64
+	for _, f := range files {
+		total += f.Size
+	}
+	fmt.Fprintf(out, "%s @ %s\n", model, shortRev(models.Revision(model)))
+	fmt.Fprintf(out, "fetching %d files, %s total (cached files are verified, not re-fetched):\n", len(files), humanSize(total))
+	for _, f := range files {
+		fmt.Fprintf(out, "  %-24s %10s\n", f.Name, humanSize(f.Size))
+	}
+
+	modelPath, err := ensureModelIn(ctx, model, dest)
+	if err != nil {
+		return 0, fmt.Errorf("models download: %w%s", err, hintFor(err))
+	}
+
+	fmt.Fprintln(out, "verified:")
+	for _, f := range files {
+		fmt.Fprintf(out, "  %-24s %s\n", f.Name, f.SHA256)
+	}
+	// Both directories, because they are one level apart and picking the
+	// wrong one is the likeliest way to misconfigure this: ModelsDir is the
+	// parent that holds every model, ModelPath is this model's own directory.
+	fmt.Fprintf(out, "\nModelsDir: %s\n", filepath.Dir(modelPath))
+	fmt.Fprintf(out, "ModelPath: %s\n", modelPath)
+	return 0, nil
+}
+
+// hintFor turns a download failure into something the operator can act on.
+// The underlying error says what broke; this says what to do about it.
+func hintFor(err error) string {
+	switch msg := err.Error(); {
+	case strings.Contains(msg, "sha256 mismatch"), strings.Contains(msg, "size mismatch"):
+		return "\n  the bytes served do not match the pinned checksums — the transfer was corrupted," +
+			"\n  intercepted, or the cached copy was modified. Nothing was installed; re-run to fetch again."
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "\n  the download was interrupted; re-run to resume (verified files are not re-fetched)."
+	default:
+		return "\n  only huggingface.co is contacted; behind a proxy, set HTTPS_PROXY."
+	}
+}
+
+// shortRev abbreviates a commit sha for display, leaving anything that is not
+// one alone.
+func shortRev(rev string) string {
+	if len(rev) > 8 {
+		return rev[:8]
+	}
+	return rev
+}
+
+// humanSize renders a byte count in the units an operator sizing an image
+// layer or a volume thinks in.
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for size := n / unit; size >= unit; size /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGT"[exp])
+}
+
+func modelsUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id]")
+	fmt.Fprintln(w, "\nDownloads a NER model and verifies every file against its pinned sha256.")
+	fmt.Fprintln(w, "Without -dest it warms the cache ner.New reads from; with -dest it writes a")
+	fmt.Fprintln(w, "self-contained directory to copy into an image or a shared volume.")
+	fmt.Fprintln(w, "\nverifiable models:")
+	for _, id := range models.PinnedModels() {
+		fmt.Fprintf(w, "  %s\n", id)
+	}
+}

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/alcatraz/models"
+)
+
+// stubEnsure swaps the downloader for the duration of a test, so the command
+// is exercised without touching the network. It records the arguments it was
+// called with, since flag handling is most of what these tests check.
+func stubEnsure(t *testing.T, ret string, err error) *struct{ model, dest string } {
+	t.Helper()
+	got := &struct{ model, dest string }{}
+	prev := ensureModelIn
+	ensureModelIn = func(_ context.Context, model, dest string) (string, error) {
+		got.model, got.dest = model, dest
+		return ret, err
+	}
+	t.Cleanup(func() { ensureModelIn = prev })
+	return got
+}
+
+func TestModelsDownloadDefaults(t *testing.T) {
+	// An empty -dest is passed through as empty: that is what makes a bare
+	// invocation warm the same cache ner.New reads from.
+	got := stubEnsure(t, "/cache/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	code, err := runModels([]string{"download"})
+	if err != nil || code != 0 {
+		t.Fatalf("runModels = (%d, %v), want (0, nil)", code, err)
+	}
+	if got.model != models.DefaultModel {
+		t.Errorf("model = %q, want the default %q", got.model, models.DefaultModel)
+	}
+	if got.dest != "" {
+		t.Errorf("dest = %q, want empty so the default cache is used", got.dest)
+	}
+}
+
+func TestModelsDownloadDestIsHonoured(t *testing.T) {
+	got := stubEnsure(t, "/opt/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	// Go's flag package accepts both spellings; the issue and the docs use
+	// the double dash, so pin that it works.
+	if _, err := runModels([]string{"download", "--dest", "/opt/alcatraz/models"}); err != nil {
+		t.Fatalf("runModels: %v", err)
+	}
+	if got.dest != "/opt/alcatraz/models" {
+		t.Errorf("dest = %q, want /opt/alcatraz/models", got.dest)
+	}
+}
+
+func TestModelsDownloadPrintsBothPaths(t *testing.T) {
+	modelPath := filepath.Join("/opt/alcatraz/models", "KnightsAnalytics_distilbert-NER")
+	stubEnsure(t, modelPath, nil)
+
+	var out bytes.Buffer
+	if _, err := download(context.Background(), &out, models.DefaultModel, "/opt/alcatraz/models"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	got := out.String()
+
+	// ModelsDir is the parent, ModelPath the model's own directory. Printing
+	// only one of them is the misconfiguration this output exists to prevent.
+	for _, want := range []string{
+		"ModelsDir: " + filepath.Dir(modelPath),
+		"ModelPath: " + modelPath,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	// The manifest is printed before the fetch, the digests after it.
+	for _, f := range models.PinnedFiles(models.DefaultModel) {
+		if !strings.Contains(got, f.Name) {
+			t.Errorf("output does not list %s:\n%s", f.Name, got)
+		}
+		if !strings.Contains(got, f.SHA256) {
+			t.Errorf("output does not report the verified digest of %s", f.Name)
+		}
+	}
+	if i, j := strings.Index(got, "fetching"), strings.Index(got, "verified:"); i < 0 || j < i {
+		t.Errorf("manifest should precede the digests:\n%s", got)
+	}
+}
+
+func TestModelsDownloadUnpinnedModel(t *testing.T) {
+	// No stub: an unpinned id has to be rejected before anything is fetched.
+	code, err := runModels([]string{"download", "-model", "some-org/unpinned-model"})
+	if err == nil {
+		t.Fatal("runModels succeeded for an unpinned model, want an error")
+	}
+	if code != 0 {
+		t.Errorf("code = %d, want 0 so main exits 2 on the error", code)
+	}
+	// Actionable: which id was refused, and what can be used instead.
+	for _, want := range []string{"some-org/unpinned-model", models.DefaultModel} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestModelsDownloadFailureIsActionable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"checksum", errors.New("models: downloading model.onnx: sha256 mismatch for x: got a, want b"), "re-run"},
+		{"size", errors.New("models: downloading model.onnx: size mismatch for x: got 1, want 2"), "re-run"},
+		{"transport", errors.New("models: downloading model.onnx: dial tcp: i/o timeout"), "HTTPS_PROXY"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			stubEnsure(t, "", c.err)
+			_, err := runModels([]string{"download"})
+			if err == nil {
+				t.Fatal("runModels succeeded, want the download error")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error = %v, want a hint mentioning %q", err, c.want)
+			}
+		})
+	}
+}
+
+func TestModelsUsage(t *testing.T) {
+	for _, args := range [][]string{{}, {"downlaod"}} {
+		_, err := runModels(args)
+		if err == nil {
+			t.Fatalf("runModels(%v) succeeded, want a usage error", args)
+		}
+	}
+
+	var out bytes.Buffer
+	modelsUsage(&out)
+	got := out.String()
+	if !strings.Contains(got, "alcatraz models download") {
+		t.Errorf("usage does not show the command:\n%s", got)
+	}
+	// The list of verifiable ids is the point of the usage text.
+	for _, id := range models.PinnedModels() {
+		if !strings.Contains(got, id) {
+			t.Errorf("usage does not list the pinned model %q:\n%s", id, got)
+		}
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{925, "925 B"},
+		{213450, "208.4 KiB"},
+		{260926482, "248.8 MiB"},
+	}
+	for _, c := range cases {
+		if got := humanSize(c.n); got != c.want {
+			t.Errorf("humanSize(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestRunDispatchesModels(t *testing.T) {
+	stubEnsure(t, t.TempDir(), nil)
+	if _, err := run([]string{"models", "download"}); err != nil {
+		t.Errorf("run: %v", err)
+	}
+}

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,15 +13,21 @@ import (
 	"github.com/hoophq/alcatraz/models"
 )
 
+// ensureCall records what the swapped-in downloader was handed.
+type ensureCall struct {
+	ctx         context.Context
+	model, dest string
+}
+
 // stubEnsure swaps the downloader for the duration of a test, so the command
 // is exercised without touching the network. It records the arguments it was
 // called with, since flag handling is most of what these tests check.
-func stubEnsure(t *testing.T, ret string, err error) *struct{ model, dest string } {
+func stubEnsure(t *testing.T, ret string, err error) *ensureCall {
 	t.Helper()
-	got := &struct{ model, dest string }{}
+	got := &ensureCall{}
 	prev := ensureModelIn
-	ensureModelIn = func(_ context.Context, model, dest string) (string, error) {
-		got.model, got.dest = model, dest
+	ensureModelIn = func(ctx context.Context, model, dest string) (string, error) {
+		got.ctx, got.model, got.dest = ctx, model, dest
 		return ret, err
 	}
 	t.Cleanup(func() { ensureModelIn = prev })
@@ -111,11 +119,26 @@ func TestModelsDownloadFailureIsActionable(t *testing.T) {
 	cases := []struct {
 		name string
 		err  error
+		// want is a substring the hint must add. Empty means the failure
+		// speaks for itself and must not be dressed up as a network problem.
 		want string
 	}{
 		{"checksum", errors.New("models: downloading model.onnx: sha256 mismatch for x: got a, want b"), "re-run"},
 		{"size", errors.New("models: downloading model.onnx: size mismatch for x: got 1, want 2"), "re-run"},
-		{"transport", errors.New("models: downloading model.onnx: dial tcp: i/o timeout"), "HTTPS_PROXY"},
+		{
+			"transport",
+			fmt.Errorf("models: downloading model.onnx: %w", &url.Error{
+				Op: "Get", URL: "https://huggingface.co/x", Err: errors.New("dial tcp: i/o timeout"),
+			}),
+			"HTTPS_PROXY",
+		},
+		{"status", errors.New("models: downloading model.onnx: GET https://x: unexpected status 404 Not Found"), "withdrawn"},
+		{"interrupted", fmt.Errorf("models: downloading model.onnx: %w", context.Canceled), "interrupted"},
+		// The deployment this command targets is a non-root container writing
+		// a mounted volume, which makes this the likeliest failure of all.
+		// Answering it with HTTPS_PROXY sends the operator to debug egress
+		// that was never involved.
+		{"local", errors.New("models: creating model directory: mkdir /x: permission denied"), ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -124,10 +147,29 @@ func TestModelsDownloadFailureIsActionable(t *testing.T) {
 			if err == nil {
 				t.Fatal("runModels succeeded, want the download error")
 			}
+			if c.want == "" {
+				if strings.Contains(err.Error(), "HTTPS_PROXY") {
+					t.Errorf("error = %v, want no proxy hint for a local failure", err)
+				}
+				return
+			}
 			if !strings.Contains(err.Error(), c.want) {
 				t.Errorf("error = %v, want a hint mentioning %q", err, c.want)
 			}
 		})
+	}
+}
+
+func TestModelsDownloadContextIsCancellable(t *testing.T) {
+	got := stubEnsure(t, t.TempDir(), nil)
+	if _, err := runModels([]string{"download"}); err != nil {
+		t.Fatalf("runModels: %v", err)
+	}
+	// context.Background().Done() is nil. A non-nil channel is what proves a
+	// signal can unwind the fetch, which is what lets download remove its
+	// temp file instead of stranding up to 250MB of it on a shared volume.
+	if got.ctx == nil || got.ctx.Done() == nil {
+		t.Error("runModels passed a context that cannot be cancelled; a signal would strand the partial download")
 	}
 }
 

--- a/models/download.go
+++ b/models/download.go
@@ -1,0 +1,90 @@
+package models
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// hubBaseURL is the Hugging Face origin the pinned artifacts are fetched
+// from. It is a var so tests can point it at a local server.
+var hubBaseURL = "https://huggingface.co"
+
+// cachedFileValid reports whether path exists and still matches the pinned
+// sha256.
+//
+// A mismatched file is left where it is rather than unlinked: download
+// replaces it by renaming over it, which is atomic, and unlinking here is
+// not. Two callers that find the same corrupt file both hold handles to it,
+// and the slower one would unlink the pathname after the faster one had
+// already installed a verified replacement under it — deleting a good file
+// that its caller had been told was ready.
+func cachedFileValid(path, wantSHA256 string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return false
+	}
+	return hex.EncodeToString(hasher.Sum(nil)) == wantSHA256
+}
+
+// download fetches url into dest atomically: it streams to a temp file in
+// the destination directory, verifies the byte length and the sha256, sets
+// mode, and renames. A failed, corrupt, truncated or oversized download never
+// leaves a file at dest.
+func download(ctx context.Context, url, dest, wantSHA256 string, wantSize int64, mode os.FileMode) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: unexpected status %s", url, resp.Status)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".partial-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	hasher := sha256.New()
+	// Bounded one byte past the pin, so an endpoint that never stops
+	// sending is cut off rather than filling the disk before the digest
+	// gets a chance to reject anything. The bound is on bytes actually
+	// read, not on Content-Length, which the endpoint also controls.
+	n, err := io.Copy(io.MultiWriter(tmp, hasher), io.LimitReader(resp.Body, wantSize+1))
+	if err != nil {
+		return err
+	}
+	if n != wantSize {
+		return fmt.Errorf("size mismatch for %s: got %d bytes, want %d", url, n, wantSize)
+	}
+	if got := hex.EncodeToString(hasher.Sum(nil)); got != wantSHA256 {
+		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", url, got, wantSHA256)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), dest)
+}

--- a/models/models.go
+++ b/models/models.go
@@ -1,12 +1,20 @@
-package ner
+// Package models materialises the model files alcatraz's optional NER
+// backends need, pinned to an immutable revision and verified against
+// recorded sha256 digests and byte lengths.
+//
+// It lives in the root module rather than in ner on purpose. The alcatraz
+// CLI ships "alcatraz models download" so a model can be fetched as a build
+// or deploy step, and that command must not drag the ONNX model runtime —
+// nor its newer Go requirement — into a module that is otherwise standard
+// library only. Nothing here imports anything outside the standard library.
+//
+// The ner package re-exports EnsureModel, EnsureModelIn and PinnedModels, so
+// NER users still have a single import.
+package models
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -14,9 +22,10 @@ import (
 	"strings"
 )
 
-// hubBaseURL is the Hugging Face origin the pinned artifacts are fetched
-// from. It is a var so tests can point it at a local server.
-var hubBaseURL = "https://huggingface.co"
+// DefaultModel is the model ner uses unless told otherwise, and the default
+// for "alcatraz models download". It is the single place the id is written
+// down: ner.DefaultConfig and the pin table below both refer to this.
+const DefaultModel = "KnightsAnalytics/distilbert-NER"
 
 // modelFile is one file of a model repository, pinned by content hash.
 type modelFile struct {
@@ -56,7 +65,7 @@ type modelArtifact struct {
 //	curl -sSLo /tmp/f https://huggingface.co/$REPO/resolve/$rev/$FILE
 //	shasum -a 256 /tmp/f && wc -c < /tmp/f
 var modelArtifacts = map[string]modelArtifact{
-	"KnightsAnalytics/distilbert-NER": {
+	DefaultModel: {
 		revision: "13a742d5ea02349d17e18f3755301282c9ee33f7",
 		files: []modelFile{
 			{path: "config.json", sha256: "8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5", size: 925},
@@ -70,7 +79,7 @@ var modelArtifacts = map[string]modelArtifact{
 }
 
 // PinnedModels returns, sorted, the model ids EnsureModel can fetch and
-// verify. Other model ids still work through Config.Model, but nothing
+// verify. Other model ids still work through ner.Config.Model, but nothing
 // checks what the hub serves for them.
 func PinnedModels() []string {
 	ids := make([]string, 0, len(modelArtifacts))
@@ -81,17 +90,60 @@ func PinnedModels() []string {
 	return ids
 }
 
-// EnsureModel downloads model into the models directory New reads from and
-// returns the local directory holding it, so a warm cache makes New
+// IsPinned reports whether EnsureModel can verify model.
+func IsPinned(model string) bool {
+	_, ok := modelArtifacts[model]
+	return ok
+}
+
+// PinnedFile describes one verified file of a pinned model, as it lands on
+// disk.
+type PinnedFile struct {
+	// Name is the file's name inside the model directory. Repository paths
+	// are flattened to their base name on download, so this is what a
+	// caller finds on disk, not the path within the repository.
+	Name string
+	// SHA256 is the hex digest EnsureModel verifies the file against.
+	SHA256 string
+	// Size is the exact byte length.
+	Size int64
+}
+
+// PinnedFiles returns the files EnsureModel verifies for model, in the order
+// it fetches them, or nil if the model is not pinned. It lets a caller show
+// what a download will cost, and what it verified, without EnsureModel
+// having to report progress itself.
+func PinnedFiles(model string) []PinnedFile {
+	art, ok := modelArtifacts[model]
+	if !ok {
+		return nil
+	}
+	out := make([]PinnedFile, 0, len(art.files))
+	for _, f := range art.files {
+		// path.Base, not filepath.Base: repository paths are always
+		// slash-separated, whatever the host OS uses.
+		out = append(out, PinnedFile{Name: path.Base(f.path), SHA256: f.sha256, Size: f.size})
+	}
+	return out
+}
+
+// Revision returns the commit sha model is pinned to, or "" if it is not
+// pinned.
+func Revision(model string) string {
+	return modelArtifacts[model].revision
+}
+
+// EnsureModel downloads model into the models directory ner.New reads from
+// and returns the local directory holding it, so a warm cache makes ner.New
 // network-free and the returned path can be handed straight to
-// Config.ModelPath.
+// ner.Config.ModelPath.
 //
 // Every file is pinned to a sha256 and a byte length, re-verified on each
 // call, cache hits included: a file that exists is not evidence that it is
 // the file we asked for. A mismatched file is fetched again. Re-hashing the
 // whole model costs roughly half a second for the 260MB default against a
-// warm page cache — small enough beside session setup that New verifies too,
-// rather than trusting the cache once it is populated.
+// warm page cache — small enough beside session setup that ner.New verifies
+// too, rather than trusting the cache once it is populated.
 //
 // It is idempotent, and safe to call concurrently and from several
 // processes: each file is written to a temp file and renamed into place, so
@@ -110,16 +162,16 @@ func EnsureModel(ctx context.Context, model string) (string, error) {
 func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 	art, ok := modelArtifacts[model]
 	if !ok {
-		return "", fmt.Errorf("ner: model %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
+		return "", fmt.Errorf("models: model %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
 			model, strings.Join(PinnedModels(), ", "))
 	}
-	dir, err := resolveModelsDir(dir)
+	dir, err := ResolveDir(dir)
 	if err != nil {
 		return "", err
 	}
-	modelPath := modelDir(dir, model)
+	modelPath := Dir(dir, model)
 	if err := os.MkdirAll(modelPath, 0o755); err != nil {
-		return "", fmt.Errorf("ner: creating model directory: %w", err)
+		return "", fmt.Errorf("models: creating model directory: %w", err)
 	}
 	for _, f := range art.files {
 		// path.Base, not filepath.Base: repository paths are always
@@ -130,109 +182,37 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 		}
 		url := fmt.Sprintf("%s/%s/resolve/%s/%s", hubBaseURL, model, art.revision, f.path)
 		if err := download(ctx, url, dest, f.sha256, f.size, 0o644); err != nil {
-			return "", fmt.Errorf("ner: downloading %s for model %s: %w", f.path, model, err)
+			return "", fmt.Errorf("models: downloading %s for model %s: %w", f.path, model, err)
 		}
 	}
 	return modelPath, nil
 }
 
-// resolveModelsDir returns dir, or (creating it) the default models
-// directory when dir is empty: "alcatraz/models" under the user cache dir.
-func resolveModelsDir(dir string) (string, error) {
+// ResolveDir returns dir, or (creating it) the default models directory when
+// dir is empty: "alcatraz/models" under the user cache dir. This is the
+// directory ner.Config.ModelsDir names — the parent of what EnsureModelIn
+// returns, not the model directory itself.
+func ResolveDir(dir string) (string, error) {
 	if dir != "" {
 		return dir, nil
 	}
 	cache, err := os.UserCacheDir()
 	if err != nil {
-		return "", fmt.Errorf("ner: locating the user cache directory: %w", err)
+		return "", fmt.Errorf("models: locating the user cache directory: %w", err)
 	}
 	dir = filepath.Join(cache, "alcatraz", "models")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("ner: creating the models directory: %w", err)
+		return "", fmt.Errorf("models: creating the models directory: %w", err)
 	}
 	return dir, nil
 }
 
-// modelDir returns the directory a model occupies inside a models
-// directory. It reproduces hugot's naming so both downloaders agree on
-// where a model lives: the id with "/" replaced by "_", minus any ":suffix".
-func modelDir(modelsDir, model string) string {
+// Dir returns the directory a model occupies inside a models directory. It
+// reproduces hugot's naming so both downloaders agree on where a model
+// lives: the id with "/" replaced by "_", minus any ":suffix".
+func Dir(modelsDir, model string) string {
 	if i := strings.Index(model, ":"); i >= 0 {
 		model = model[:i]
 	}
 	return filepath.Join(modelsDir, strings.ReplaceAll(model, "/", "_"))
-}
-
-// cachedFileValid reports whether path exists and still matches the pinned
-// sha256.
-//
-// A mismatched file is left where it is rather than unlinked: download
-// replaces it by renaming over it, which is atomic, and unlinking here is
-// not. Two callers that find the same corrupt file both hold handles to it,
-// and the slower one would unlink the pathname after the faster one had
-// already installed a verified replacement under it — deleting a good file
-// that its caller had been told was ready.
-func cachedFileValid(path, wantSHA256 string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, f); err != nil {
-		return false
-	}
-	return hex.EncodeToString(hasher.Sum(nil)) == wantSHA256
-}
-
-// download fetches url into dest atomically: it streams to a temp file in
-// the destination directory, verifies the byte length and the sha256, sets
-// mode, and renames. A failed, corrupt, truncated or oversized download never
-// leaves a file at dest.
-func download(ctx context.Context, url, dest, wantSHA256 string, wantSize int64, mode os.FileMode) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GET %s: unexpected status %s", url, resp.Status)
-	}
-
-	tmp, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".partial-*")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		tmp.Close()
-		os.Remove(tmp.Name())
-	}()
-
-	hasher := sha256.New()
-	// Bounded one byte past the pin, so an endpoint that never stops
-	// sending is cut off rather than filling the disk before the digest
-	// gets a chance to reject anything. The bound is on bytes actually
-	// read, not on Content-Length, which the endpoint also controls.
-	n, err := io.Copy(io.MultiWriter(tmp, hasher), io.LimitReader(resp.Body, wantSize+1))
-	if err != nil {
-		return err
-	}
-	if n != wantSize {
-		return fmt.Errorf("size mismatch for %s: got %d bytes, want %d", url, n, wantSize)
-	}
-	if got := hex.EncodeToString(hasher.Sum(nil)); got != wantSHA256 {
-		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", url, got, wantSHA256)
-	}
-	if err := tmp.Chmod(mode); err != nil {
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmp.Name(), dest)
 }

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -1,4 +1,4 @@
-package ner
+package models
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -233,7 +234,7 @@ func TestEnsureModelInRejectsChecksumMismatch(t *testing.T) {
 	if !strings.Contains(err.Error(), "sha256 mismatch") {
 		t.Errorf("error = %v, want it to name the sha256 mismatch", err)
 	}
-	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+	assertNoLeftovers(t, Dir(dir, id), "model.onnx")
 }
 
 // TestEnsureModelInRejectsOversizedResponse covers the case the digest alone
@@ -255,7 +256,7 @@ func TestEnsureModelInRejectsOversizedResponse(t *testing.T) {
 	if !strings.Contains(err.Error(), "size mismatch") {
 		t.Errorf("error = %v, want it to name the size mismatch", err)
 	}
-	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+	assertNoLeftovers(t, Dir(dir, id), "model.onnx")
 }
 
 // TestEnsureModelInRejectsTruncatedResponse checks that a short read fails as
@@ -275,7 +276,7 @@ func TestEnsureModelInRejectsTruncatedResponse(t *testing.T) {
 	if !strings.Contains(err.Error(), "size mismatch") {
 		t.Errorf("error = %v, want it to name the size mismatch", err)
 	}
-	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+	assertNoLeftovers(t, Dir(dir, id), "model.onnx")
 }
 
 func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
@@ -292,7 +293,7 @@ func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
 	if !strings.Contains(err.Error(), "model.onnx") {
 		t.Errorf("error = %v, want it to name the file that failed", err)
 	}
-	assertNoLeftovers(t, modelDir(dir, id), "model.onnx")
+	assertNoLeftovers(t, Dir(dir, id), "model.onnx")
 }
 
 func TestEnsureModelUnpinnedModel(t *testing.T) {
@@ -344,7 +345,7 @@ func TestEnsureModelInConcurrent(t *testing.T) {
 	}
 	// Whoever won each rename, the result must be the pinned bytes and
 	// nothing else — no torn file, no surviving temp file.
-	entries, err := os.ReadDir(modelDir(dir, id))
+	entries, err := os.ReadDir(Dir(dir, id))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +353,7 @@ func TestEnsureModelInConcurrent(t *testing.T) {
 		t.Errorf("model dir holds %d entries, want %d", len(entries), len(files))
 	}
 	for name, body := range files {
-		got, err := os.ReadFile(filepath.Join(modelDir(dir, id), name))
+		got, err := os.ReadFile(filepath.Join(Dir(dir, id), name))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -398,7 +399,7 @@ func TestEnsureModelInConcurrentRepair(t *testing.T) {
 	if _, err := EnsureModelIn(context.Background(), id, dir); err != nil {
 		t.Fatalf("seeding the cache: %v", err)
 	}
-	tampered := filepath.Join(modelDir(dir, id), "model.onnx")
+	tampered := filepath.Join(Dir(dir, id), "model.onnx")
 	if err := os.WriteFile(tampered, []byte("malicious"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -438,8 +439,8 @@ func TestModelDir(t *testing.T) {
 		{"org/model:quantized", "org_model"},
 	}
 	for _, c := range cases {
-		if got := modelDir("/models", c.model); got != filepath.Join("/models", c.want) {
-			t.Errorf("modelDir(%q) = %q, want .../%s", c.model, got, c.want)
+		if got := Dir("/models", c.model); got != filepath.Join("/models", c.want) {
+			t.Errorf("Dir(%q) = %q, want .../%s", c.model, got, c.want)
 		}
 	}
 }
@@ -480,9 +481,33 @@ func TestPinnedArtifactsWellFormed(t *testing.T) {
 }
 
 func TestDefaultModelIsPinned(t *testing.T) {
-	if _, ok := modelArtifacts[DefaultConfig().Model]; !ok {
-		t.Errorf("default model %q is not pinned, so New downloads it unverified",
-			DefaultConfig().Model)
+	if !IsPinned(DefaultModel) {
+		t.Errorf("default model %q is not pinned, so it would be fetched unverified", DefaultModel)
+	}
+}
+
+// TestPinnedFiles checks the view the CLI builds its manifest from: the same
+// files as the pin table, in the same order, named as they land on disk
+// rather than as they sit in the repository.
+func TestPinnedFiles(t *testing.T) {
+	if got := PinnedFiles("some-org/unpinned-model"); got != nil {
+		t.Errorf("PinnedFiles(unpinned) = %v, want nil", got)
+	}
+
+	id, files, art := testModel(t)
+	art.files = append(art.files, modelFile{path: "nested/config.json", sha256: sum(files["tokenizer.json"]), size: 1})
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	got := PinnedFiles(id)
+	if len(got) != len(art.files) {
+		t.Fatalf("PinnedFiles returned %d files, want %d", len(got), len(art.files))
+	}
+	for i, f := range art.files {
+		want := PinnedFile{Name: path.Base(f.path), SHA256: f.sha256, Size: f.size}
+		if got[i] != want {
+			t.Errorf("file %d = %+v, want %+v", i, got[i], want)
+		}
 	}
 }
 
@@ -495,7 +520,7 @@ func TestLiveEnsureModel(t *testing.T) {
 	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
 		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live download test")
 	}
-	model := DefaultConfig().Model
+	model := DefaultModel
 	dir := os.Getenv("ALCATRAZ_NER_MODELS_DIR")
 	if dir == "" {
 		dir = t.TempDir()

--- a/ner/config.go
+++ b/ner/config.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/hoophq/alcatraz/entities"
+	"github.com/hoophq/alcatraz/models"
 	"github.com/knights-analytics/hugot/options"
 )
 
@@ -133,7 +134,7 @@ type Config struct {
 // under a canonical name).
 func DefaultConfig() Config {
 	return Config{
-		Model: "KnightsAnalytics/distilbert-NER",
+		Model: models.DefaultModel,
 		LabelMapping: map[string]string{
 			// CoNLL-style labels.
 			"PER": entities.Person,

--- a/ner/models.go
+++ b/ner/models.go
@@ -1,0 +1,40 @@
+package ner
+
+import (
+	"context"
+
+	"github.com/hoophq/alcatraz/models"
+)
+
+// The pin table and the verified downloader live in the root module's
+// [models] package, not here, so the alcatraz CLI can ship
+// "alcatraz models download" without pulling in the model runtime or this
+// module's newer Go requirement. These forwarders keep ner the single import
+// for NER users.
+
+// EnsureModel downloads model into the models directory New reads from and
+// returns the local directory holding it, so a warm cache makes New
+// network-free and the returned path can be handed straight to
+// Config.ModelPath. It is [models.EnsureModel].
+func EnsureModel(ctx context.Context, model string) (string, error) {
+	return models.EnsureModel(ctx, model)
+}
+
+// EnsureModelIn is EnsureModel writing into an explicit models directory,
+// for callers materialising a model outside the user cache — a Docker image
+// layer or a shared volume. An empty dir means the default. It is
+// [models.EnsureModelIn].
+//
+// dir is the models directory, not the model directory: the model lands in a
+// subdirectory named after it, so dir is what Config.ModelsDir wants and the
+// returned path is what Config.ModelPath wants.
+func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
+	return models.EnsureModelIn(ctx, model, dir)
+}
+
+// PinnedModels returns, sorted, the model ids EnsureModel can fetch and
+// verify. Other model ids still work through Config.Model, but nothing
+// checks what the hub serves for them. It is [models.PinnedModels].
+func PinnedModels() []string {
+	return models.PinnedModels()
+}

--- a/ner/models_test.go
+++ b/ner/models_test.go
@@ -1,0 +1,16 @@
+package ner
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz/models"
+)
+
+// TestDefaultModelIsPinned guards the ner default specifically: the pin table
+// lives in another package now, so nothing but this stops DefaultConfig from
+// drifting onto a model New would download unverified.
+func TestDefaultModelIsPinned(t *testing.T) {
+	if model := DefaultConfig().Model; !models.IsPinned(model) {
+		t.Errorf("default model %q is not pinned, so New downloads it unverified", model)
+	}
+}

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -61,6 +61,14 @@
 // file we pinned. Models outside that list still work, but nothing verifies
 // what the hub serves for them.
 //
+// The same fetch is available without writing Go, for a Dockerfile or an
+// init container:
+//
+//	alcatraz models download --dest /opt/alcatraz/models
+//
+// It prints both directories the config wants: ModelsDir, and the ModelPath
+// beneath it. See the alcatraz/models package for the pin table itself.
+//
 // The Engine implements analyzer.NlpEngine, so an analyzer.Engine configured
 // with SetNlpEngine runs the model once per Analyze call and shares the
 // artifacts with every artifact-aware recognizer:
@@ -86,6 +94,7 @@ import (
 
 	"github.com/gomlx/go-huggingface/tokenizers/api"
 	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/models"
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/pipelines"
 )
@@ -219,20 +228,20 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 // ensureModel returns the local path of cfg.Model, downloading it from
 // Hugging Face into the models directory on first use.
 func ensureModel(ctx context.Context, cfg Config) (string, error) {
-	dir, err := resolveModelsDir(cfg.ModelsDir)
+	dir, err := models.ResolveDir(cfg.ModelsDir)
 	if err != nil {
 		return "", err
 	}
 	// Pinned models take the verified path: every file is checked against
 	// its sha256, so a cache hit is a hit only if the bytes still match
 	// and what New loads is what we pinned, not merely what the hub last
-	// served (see download.go).
-	if _, pinned := modelArtifacts[cfg.Model]; pinned {
-		return EnsureModelIn(ctx, cfg.Model, dir)
+	// served (see the models package).
+	if models.IsPinned(cfg.Model) {
+		return models.EnsureModelIn(ctx, cfg.Model, dir)
 	}
 	// Any other model id keeps working, unverified: hugot's cache check is
 	// presence-only, and so is ours.
-	modelPath := modelDir(dir, cfg.Model)
+	modelPath := models.Dir(dir, cfg.Model)
 	if _, err := os.Stat(filepath.Join(modelPath, "tokenizer.json")); err == nil {
 		return modelPath, nil
 	}


### PR DESCRIPTION
Refs ATR-191. Closes #17. Follows #19 (ATR-190), which added the verified downloader this exposes.

## What this fixes

ATR-190 shipped `ner.EnsureModel`: pinned-revision, sha256- and size-verified model downloads. But it was reachable only from Go code, and the CLI exposed just `scan`, `diff`, `hook` and `version`. So every offline strategy — bake the model into an image, prime a shared volume, point at a local path — still meant hand-rolling a `huggingface-cli` call outside alcatraz, with no checksum verification at all.

The docs half is the same blocker: an operator evaluating alcatraz for a restricted network had to find the answer in a call transcript rather than the README.

## What's added

```
alcatraz models download [-dest dir] [-model id]
```

A bare invocation warms the same cache `ner.New` reads from. `-dest` writes a self-contained directory to copy into an image or mount as a volume.

```
KnightsAnalytics/distilbert-NER @ 13a742d5
fetching 6 files, 249.7 MiB total (cached files are verified, not re-fetched):
  config.json                   925 B
  model.onnx                248.8 MiB
  ...
verified:
  config.json              8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5
  model.onnx               4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160
  ...

ModelsDir: /opt/alcatraz/models
ModelPath: /opt/alcatraz/models/KnightsAnalytics_distilbert-NER
```

The manifest goes out before the first byte is fetched — 250 MiB over a slow link is a long silence — and the verified digests after, so a warm cache reads as a receipt. Unpinned model ids are refused rather than downloaded unverified. Failures exit non-zero with a hint keyed to the cause: a checksum mismatch says nothing was installed, a transport error mentions `HTTPS_PROXY`.

Printing **both** paths is the point, not decoration. `EnsureModelIn` returns the model's own directory while `Config.ModelsDir` wants its parent — that off-by-one directory is the likeliest way to misconfigure this.

## The module problem, and the move

`cmd/alcatraz` is in the **root** module: `go.mod` is three lines, zero requires, `go 1.24`, and the README headlines "the standard library is the only dependency." `ner` is `go 1.26` with ~95 modules behind the ONNX runtime. Importing `ner` from the CLI would have taken the root from 0 → 95 dependencies, forced `go 1.24` → `1.26` on every consumer, created a cyclic module requirement, and put the ONNX runtime in the Homebrew binary.

What made it tractable: `ner/download.go` was already **stdlib-only**. So it moves to a new root-module package, `models`, unchanged in substance, and the CLI reaches it with no new dependencies and no Go bump.

| | |
|---|---|
| `models` (new, root module) | the pin table + verified downloader, stdlib only |
| `ner.EnsureModel` / `EnsureModelIn` / `PinnedModels` | unchanged — now thin forwarders |
| `models.IsPinned` / `PinnedFiles` / `Revision` / `ResolveDir` / `Dir` | newly exported, needed by `ner.ensureModel` and the CLI |

`git diff main -- go.mod` is empty. The v0.8.0 `ner` API is untouched, so libhoop needs no change.

## Docs

New README section **Running NER without internet access**: the CLI invocation, a Dockerfile snippet, a k8s init-container + shared-volume example, and a table mapping the two printed paths onto the config — including the part worth knowing:

| Printed path | Config field | Downloads on load | Verifies on load |
|---|---|---|---|
| `ModelsDir:` | `ner.Config.ModelsDir` | only files missing or failing verification | yes, every pinned file |
| `ModelPath:` | `ner.Config.ModelPath` | never | no — trusted as-is |

`ModelsDir` is the better default for a mounted volume: no network when the files are intact, and it still catches a truncated or tampered-with model instead of loading it.

Also corrected two claims this makes false as written: the CLI package doc's blanket "no network calls" (now scoped to scanning, which is still entirely in-process) and a usage string that omitted `hook`.

## CI

`ml-live.yml` runs `TestLiveNER|TestLiveEnsureModel` in one step with `working-directory: ner`. `TestLiveEnsureModel` is in the root module now, so the step is split — folded in, it would simply stop running, silently, and it is the only job that checks the pinned digests against what the hub actually serves. `models/**` also joins the path filter so a revision or digest bump is proved before it lands.

## Verification

- `git diff main -- go.mod` empty; `go vet ./...` and `go test -race ./...` green in both modules; `gofmt -l .` clean.
- Real cold download into a scratch dest: 6 files, 249.7 MiB, every digest matching the pin table; `config.json` independently confirmed with `shasum -a 256`.
- Warm re-run: **0.13s** vs 19.4s cold — verified, not re-fetched.
- Both README wirings loaded end to end from the produced directory and detected `PERSON="John Smith"` / `LOCATION="Berlin"`.
- Offline CLI paths: bare `models` prints usage and exits 2; an unpinned `-model` is refused before anything is fetched.

**Not covered:** no Windows job exists in any alcatraz workflow, so `ResolveDir`/`Dir` path handling on Windows still rests on reading Go's source rather than a green run.
