### PR TITLE
feat(ner): add Config.Offline for a hard no-network guarantee (ATR-192)

### DIFF
--- a/.github/workflows/ml-live.yml
+++ b/.github/workflows/ml-live.yml
@@ -71,13 +71,18 @@ jobs:
           ALCATRAZ_NER_LIVE: "1"
         run: go test -v -run TestLiveEnsureModel -timeout 25m ./models/
 
-      # TestLiveNER runs against the cache restored above, so it exercises
-      # loading but never downloading.
+      # Both run against the cache restored above, so they exercise loading
+      # but never downloading. TestLiveOfflineNER additionally mounts that
+      # cache read-only and fails on any outbound request, which is the only
+      # place the Config.Offline guarantee is checked against a real model
+      # and a real hugot session rather than a fixture. It is named
+      # separately here because -run is a substring match and
+      # "TestLiveOfflineNER" does not contain "TestLiveNER".
       - name: Live model test
         working-directory: ner
         env:
           ALCATRAZ_NER_LIVE: "1"
-        run: go test -v -run TestLiveNER -timeout 25m ./...
+        run: go test -v -run 'TestLiveNER|TestLiveOfflineNER' -timeout 25m ./...
 
   # pfilter: needs libpf (built from the pinned privacy-filter.cpp revision
   # via the pfilter/dist CMake wrapper, cached) and a GGUF (cached).

--- a/README.md
+++ b/README.md
@@ -376,6 +376,45 @@ cfg.ModelsDir = "/opt/alcatraz/models" // the ModelsDir: line, not ModelPath:
 nlp, err := ner.New(ctx, cfg)
 ```
 
+**Make it a guarantee, not an expectation.** Everything above arranges for the
+cache to be warm; `ner.Config.Offline` makes `ner.New` fail rather than fall
+back if it isn't:
+
+```go
+cfg := ner.DefaultConfig()
+cfg.ModelsDir = "/opt/alcatraz/models"
+cfg.Offline = true // New opens no socket; a bad model directory is an error
+```
+
+Falling back to a download is not a graceful degradation in a locked-down
+deployment. The attempt trips egress monitoring even when it fails, and what
+comes back is a DNS or TLS timeout that says nothing about the model. With
+`Offline` set you get the actual problem instead:
+
+```
+ner: obtaining model KnightsAnalytics/distilbert-NER: offline: models: model.onnx
+in /opt/alcatraz/models/KnightsAnalytics_distilbert-NER does not match its pinned
+sha256; pre-download it with "alcatraz models download --dest /opt/alcatraz/models"
+```
+
+Missing and mismatched are reported as different failures on purpose: absent
+means the volume was never seeded, mismatched means it was seeded with the
+wrong bytes — a stale image layer, a truncated copy — and the fixes have
+nothing in common.
+
+Because an offline caller has no fallback, `Offline` also tightens what counts
+as loadable, and it is the one thing that makes `ModelPath` checked at all:
+
+| | `Offline` unset | `Offline` set |
+|---|---|---|
+| `ModelsDir`, pinned model | downloads what is missing or fails verification | verifies every pinned sha256, never downloads |
+| `ModelsDir`, unpinned model | downloads through hugot | requires `config.json`, `tokenizer.json` and an `.onnx` file |
+| `ModelPath` | trusted as-is | same three-file check before hugot sees it |
+
+Nothing on the offline path writes — not the directory lookup, not the
+verification — so a model mounted read-only (`readOnly: true` on the volume
+mount above, or a `COPY`'d image layer) loads unchanged.
+
 From Go, the same fetch is [`ner.EnsureModelIn`](https://pkg.go.dev/github.com/hoophq/alcatraz/ner#EnsureModelIn)
 (or `ner.EnsureModel` for the default cache), which returns the `ModelPath`
 form. Neither `ner` nor `models` reads environment variables — the path is

--- a/README.md
+++ b/README.md
@@ -394,13 +394,14 @@ comes back is a DNS or TLS timeout that says nothing about the model. With
 ```
 ner: obtaining model KnightsAnalytics/distilbert-NER: offline: models: model.onnx
 in /opt/alcatraz/models/KnightsAnalytics_distilbert-NER does not match its pinned
-sha256; pre-download it with "alcatraz models download --dest /opt/alcatraz/models"
+sha256; pre-download it with: alcatraz models download --dest "/opt/alcatraz/models"
 ```
 
-Missing and mismatched are reported as different failures on purpose: absent
-means the volume was never seeded, mismatched means it was seeded with the
-wrong bytes — a stale image layer, a truncated copy — and the fixes have
-nothing in common.
+Missing, mismatched and unreadable are reported as three different failures on
+purpose: absent means the volume was never seeded, mismatched means it was
+seeded with the wrong bytes — a stale image layer, a truncated copy —
+unreadable means the bytes may be fine and the container's user cannot open
+them, and the fixes have nothing in common.
 
 Because an offline caller has no fallback, `Offline` also tightens what counts
 as loadable, and it is the one thing that makes `ModelPath` checked at all:

--- a/models/download.go
+++ b/models/download.go
@@ -15,8 +15,29 @@ import (
 // from. It is a var so tests can point it at a local server.
 var hubBaseURL = "https://huggingface.co"
 
+// fileMatches reports whether path's contents hash to wantSHA256, keeping an
+// I/O failure separate from a false result. A file that cannot be read is not
+// a file with the wrong bytes, and in the deployments VerifyModelIn serves —
+// non-root containers, volumes mounted from elsewhere — the difference
+// between the two is the difference between fixing a mode and re-provisioning
+// the model.
+func fileMatches(path, wantSHA256 string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)) == wantSHA256, nil
+}
+
 // cachedFileValid reports whether path exists and still matches the pinned
-// sha256.
+// sha256. It folds every failure into false because the download path answers
+// all of them the same way: fetch the file again.
 //
 // A mismatched file is left where it is rather than unlinked: download
 // replaces it by renaming over it, which is atomic, and unlinking here is
@@ -25,17 +46,8 @@ var hubBaseURL = "https://huggingface.co"
 // already installed a verified replacement under it — deleting a good file
 // that its caller had been told was ready.
 func cachedFileValid(path, wantSHA256 string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, f); err != nil {
-		return false
-	}
-	return hex.EncodeToString(hasher.Sum(nil)) == wantSHA256
+	ok, err := fileMatches(path, wantSHA256)
+	return err == nil && ok
 }
 
 // download fetches url into dest atomically: it streams to a temp file in

--- a/models/models.go
+++ b/models/models.go
@@ -8,13 +8,15 @@
 // nor its newer Go requirement — into a module that is otherwise standard
 // library only. Nothing here imports anything outside the standard library.
 //
-// The ner package re-exports EnsureModel, EnsureModelIn and PinnedModels, so
-// NER users still have a single import.
+// The ner package re-exports EnsureModel, EnsureModelIn, VerifyModelIn,
+// DefaultDir and PinnedModels, so NER users still have a single import.
 package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -195,13 +197,13 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 // not to touch the network (ner.Config.Offline) or that mounts its models
 // read-only.
 //
-// Where EnsureModelIn answers a missing or mismatched file by fetching it,
-// this reports it, and says which file and which of the two it was. That
-// distinction is the whole diagnostic: absent means the directory was never
-// seeded, mismatched means it was seeded with the wrong bytes — a stale image
-// layer, a truncated copy, a tampered volume — and the two have nothing to do
-// with each other. Both otherwise surface much later as an opaque failure
-// inside the model runtime.
+// Where EnsureModelIn answers a bad file by fetching it, this reports it, and
+// says which file and which kind of bad. That distinction is the whole
+// diagnostic: absent means the directory was never seeded, mismatched means it
+// was seeded with the wrong bytes — a stale image layer, a truncated copy, a
+// tampered volume — unreadable means the bytes may be fine and the process
+// cannot see them, and the three have nothing to do with each other. All
+// otherwise surface much later as an opaque failure inside the model runtime.
 //
 // dir is the models directory, not the model directory, exactly as in
 // EnsureModelIn. An empty dir means the default, which unlike EnsureModelIn
@@ -221,7 +223,10 @@ func VerifyModelIn(model, dir string) (string, error) {
 	modelPath := Dir(dir, model)
 	fi, err := os.Stat(modelPath)
 	if err != nil {
-		return "", fmt.Errorf("models: no model directory at %s", modelPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("models: no model directory at %s", modelPath)
+		}
+		return "", fmt.Errorf("models: cannot read %s: %w", modelPath, err)
 	}
 	if !fi.IsDir() {
 		return "", fmt.Errorf("models: %s is not a directory", modelPath)
@@ -231,10 +236,17 @@ func VerifyModelIn(model, dir string) (string, error) {
 		// slash-separated, whatever the host OS uses.
 		name := path.Base(f.path)
 		dest := filepath.Join(modelPath, name)
-		if _, err := os.Stat(dest); err != nil {
+		// Three outcomes, not two. A file the process cannot open is a
+		// third one: reporting it as a digest mismatch would send an
+		// operator to re-provision a model whose only problem is its mode,
+		// and that is a likely mistake precisely here, where the model
+		// arrives from a build stage or a volume that owns it.
+		switch ok, err := fileMatches(dest, f.sha256); {
+		case errors.Is(err, fs.ErrNotExist):
 			return "", fmt.Errorf("models: %s is missing from %s", name, modelPath)
-		}
-		if !cachedFileValid(dest, f.sha256) {
+		case err != nil:
+			return "", fmt.Errorf("models: cannot read %s in %s: %w", name, modelPath, err)
+		case !ok:
 			return "", fmt.Errorf("models: %s in %s does not match its pinned sha256", name, modelPath)
 		}
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -188,6 +188,59 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 	return modelPath, nil
 }
 
+// VerifyModelIn is EnsureModelIn's verification half without its downloading
+// half: it reports that model is already present in dir and that every pinned
+// file still matches, and returns the model directory. It opens no socket and
+// writes nothing, so it is the resolution step for a caller that has promised
+// not to touch the network (ner.Config.Offline) or that mounts its models
+// read-only.
+//
+// Where EnsureModelIn answers a missing or mismatched file by fetching it,
+// this reports it, and says which file and which of the two it was. That
+// distinction is the whole diagnostic: absent means the directory was never
+// seeded, mismatched means it was seeded with the wrong bytes — a stale image
+// layer, a truncated copy, a tampered volume — and the two have nothing to do
+// with each other. Both otherwise surface much later as an opaque failure
+// inside the model runtime.
+//
+// dir is the models directory, not the model directory, exactly as in
+// EnsureModelIn. An empty dir means the default, which unlike EnsureModelIn
+// is not created: looking is not a reason to write.
+func VerifyModelIn(model, dir string) (string, error) {
+	art, ok := modelArtifacts[model]
+	if !ok {
+		return "", fmt.Errorf("models: model %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
+			model, strings.Join(PinnedModels(), ", "))
+	}
+	if dir == "" {
+		var err error
+		if dir, err = DefaultDir(); err != nil {
+			return "", err
+		}
+	}
+	modelPath := Dir(dir, model)
+	fi, err := os.Stat(modelPath)
+	if err != nil {
+		return "", fmt.Errorf("models: no model directory at %s", modelPath)
+	}
+	if !fi.IsDir() {
+		return "", fmt.Errorf("models: %s is not a directory", modelPath)
+	}
+	for _, f := range art.files {
+		// path.Base, not filepath.Base: repository paths are always
+		// slash-separated, whatever the host OS uses.
+		name := path.Base(f.path)
+		dest := filepath.Join(modelPath, name)
+		if _, err := os.Stat(dest); err != nil {
+			return "", fmt.Errorf("models: %s is missing from %s", name, modelPath)
+		}
+		if !cachedFileValid(dest, f.sha256) {
+			return "", fmt.Errorf("models: %s in %s does not match its pinned sha256", name, modelPath)
+		}
+	}
+	return modelPath, nil
+}
+
 // ResolveDir returns dir, or (creating it) the default models directory when
 // dir is empty: "alcatraz/models" under the user cache dir. This is the
 // directory ner.Config.ModelsDir names — the parent of what EnsureModelIn
@@ -196,15 +249,26 @@ func ResolveDir(dir string) (string, error) {
 	if dir != "" {
 		return dir, nil
 	}
-	cache, err := os.UserCacheDir()
+	dir, err := DefaultDir()
 	if err != nil {
-		return "", fmt.Errorf("models: locating the user cache directory: %w", err)
+		return "", err
 	}
-	dir = filepath.Join(cache, "alcatraz", "models")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("models: creating the models directory: %w", err)
 	}
 	return dir, nil
+}
+
+// DefaultDir returns the default models directory — "alcatraz/models" under
+// the user cache dir — without creating it. ResolveDir is the same lookup for
+// a caller that is about to write there; this one is for a caller that only
+// wants to look, or to name the directory in a message.
+func DefaultDir() (string, error) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("models: locating the user cache directory: %w", err)
+	}
+	return filepath.Join(cache, "alcatraz", "models"), nil
 }
 
 // Dir returns the directory a model occupies inside a models directory. It

--- a/models/verify_test.go
+++ b/models/verify_test.go
@@ -1,0 +1,233 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// seedModel lays a pinned model out in dir exactly as EnsureModelIn would,
+// without going near the hub. Every test here asserts the hub was never
+// touched, so seeding by download would defeat the point.
+func seedModel(t *testing.T, dir, id string, files map[string][]byte) string {
+	t.Helper()
+	modelPath := Dir(dir, id)
+	if err := os.MkdirAll(modelPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(modelPath, name), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return modelPath
+}
+
+func TestVerifyModelInAcceptsSeededDir(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	want := seedModel(t, dir, id, files)
+
+	got, err := VerifyModelIn(id, dir)
+	if err != nil {
+		t.Fatalf("VerifyModelIn: %v", err)
+	}
+	if got != want {
+		t.Errorf("model path = %q, want %q", got, want)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0: VerifyModelIn must not download", n)
+	}
+}
+
+func TestVerifyModelInReportsMissingFile(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath := seedModel(t, dir, id, files)
+	if err := os.Remove(filepath.Join(modelPath, "tokenizer.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := VerifyModelIn(id, dir)
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded on a model directory missing a file")
+	}
+	if !strings.Contains(err.Error(), "tokenizer.json") || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("err = %v, want it to name tokenizer.json as missing", err)
+	}
+	if !strings.Contains(err.Error(), modelPath) {
+		t.Errorf("err = %v, want it to name the directory %s", err, modelPath)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0", n)
+	}
+}
+
+// A file that is present but wrong is a different failure from an absent one
+// — seeded with the wrong bytes, not never seeded — and the message has to
+// say which, because the two have different fixes.
+func TestVerifyModelInReportsMismatchNotMissing(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath := seedModel(t, dir, id, files)
+	tampered := filepath.Join(modelPath, "model.onnx")
+	if err := os.WriteFile(tampered, []byte("wrong bytes entirely"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := VerifyModelIn(id, dir)
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded on a tampered model directory")
+	}
+	if !strings.Contains(err.Error(), "model.onnx") || !strings.Contains(err.Error(), "sha256") {
+		t.Errorf("err = %v, want it to name model.onnx as a sha256 mismatch", err)
+	}
+	if strings.Contains(err.Error(), "missing") {
+		t.Errorf("err = %v, reports a present-but-wrong file as missing", err)
+	}
+
+	// And the tampered file stays put: this is a read-only check, and
+	// deleting the evidence would strand a concurrent reader mid-load.
+	if _, statErr := os.Stat(tampered); statErr != nil {
+		t.Errorf("tampered file was removed: %v", statErr)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0: a mismatch must not trigger a re-fetch", n)
+	}
+}
+
+func TestVerifyModelInColdDir(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	_, err := VerifyModelIn(id, dir)
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded against an empty models directory")
+	}
+	if !strings.Contains(err.Error(), "no model directory at") {
+		t.Errorf("err = %v, want it to report the absent model directory", err)
+	}
+
+	// Looking is not a reason to write: a failed verification leaves the
+	// models directory exactly as it found it.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("VerifyModelIn created %d entries in the models directory", len(entries))
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0", n)
+	}
+}
+
+func TestVerifyModelInModelPathIsAFile(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(Dir(dir, id), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := VerifyModelIn(id, dir)
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Errorf("err = %v, want a not-a-directory error", err)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0", n)
+	}
+}
+
+func TestVerifyModelInUnpinnedModel(t *testing.T) {
+	_, err := VerifyModelIn("nobody/not-pinned", t.TempDir())
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded on an unpinned model")
+	}
+	if !strings.Contains(err.Error(), "nobody/not-pinned") {
+		t.Errorf("err = %v, want it to name the rejected model", err)
+	}
+	for _, id := range PinnedModels() {
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("err = %v, want it to list the pinned model %q", err, id)
+		}
+	}
+}
+
+// A baked image or a shared volume mounts the model read-only, so any
+// incidental write on the verification path is a real bug — and one that
+// only shows up here, since a writable temp dir hides it completely.
+func TestVerifyModelInReadOnlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the permission bits under test")
+	}
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath := seedModel(t, dir, id, files)
+	// Both levels: the model directory and its parent. Restore before the
+	// test ends so t.TempDir's own cleanup can remove the tree.
+	for _, p := range []string{modelPath, dir} {
+		if err := os.Chmod(p, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(p, 0o755) })
+	}
+
+	got, err := VerifyModelIn(id, dir)
+	if err != nil {
+		t.Fatalf("VerifyModelIn on a read-only models directory: %v", err)
+	}
+	if got != modelPath {
+		t.Errorf("model path = %q, want %q", got, modelPath)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0", n)
+	}
+}
+
+// DefaultDir names the directory; ResolveDir is the one that creates it. The
+// distinction is what lets an offline caller report a missing model instead
+// of a permission error from a mkdir it never needed.
+func TestDefaultDirDoesNotCreate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.UserCacheDir reads %LocalAppData% here, which these env vars do not set")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)           // darwin: $HOME/Library/Caches
+	t.Setenv("XDG_CACHE_HOME", home) // linux: $XDG_CACHE_HOME
+
+	dir, err := DefaultDir()
+	if err != nil {
+		t.Fatalf("DefaultDir: %v", err)
+	}
+	if !strings.HasPrefix(dir, home) {
+		t.Fatalf("DefaultDir = %q, want it under the fake cache root %q", dir, home)
+	}
+	if !strings.HasSuffix(dir, filepath.Join("alcatraz", "models")) {
+		t.Errorf("DefaultDir = %q, want it to end in alcatraz/models", dir)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("DefaultDir created %s (stat err = %v); only ResolveDir may create", dir, err)
+	}
+}

--- a/models/verify_test.go
+++ b/models/verify_test.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,6 +106,54 @@ func TestVerifyModelInReportsMismatchNotMissing(t *testing.T) {
 	}
 	if n := hub.totalHits(); n != 0 {
 		t.Errorf("hub hits = %d, want 0: a mismatch must not trigger a re-fetch", n)
+	}
+}
+
+// The third outcome. A file the process cannot open is not a file with the
+// wrong bytes: one is fixed with a chmod, the other by re-provisioning the
+// model, and the deployments this function exists for — non-root containers,
+// volumes owned by whatever wrote them — are where the mode is the likelier
+// of the two. Reporting a permission error as a checksum mismatch sends the
+// operator to redo the expensive thing.
+func TestVerifyModelInReportsUnreadableNotMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the permission bits under test")
+	}
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath := seedModel(t, dir, id, files)
+	locked := filepath.Join(modelPath, "model.onnx")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o644) })
+
+	_, err := VerifyModelIn(id, dir)
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded on an unreadable file")
+	}
+	if !strings.Contains(err.Error(), "model.onnx") || !strings.Contains(err.Error(), "cannot read") {
+		t.Errorf("err = %v, want it to report model.onnx as unreadable", err)
+	}
+	// Matched on the message forms, not the bare words: the temp directory in
+	// the path carries the test's own name.
+	for _, wrong := range []string{"is missing from", "does not match its pinned sha256"} {
+		if strings.Contains(err.Error(), wrong) {
+			t.Errorf("err = %v, misreports a permission problem as %q", err, wrong)
+		}
+	}
+	// Wrapped, not flattened into a string, so a caller can branch on it.
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("err = %v, want it to wrap fs.ErrPermission", err)
+	}
+	if n := hub.totalHits(); n != 0 {
+		t.Errorf("hub hits = %d, want 0: an unreadable file must not trigger a fetch", n)
 	}
 }
 

--- a/ner/config.go
+++ b/ner/config.go
@@ -50,6 +50,23 @@ type Config struct {
 	// OnnxFilename selects the .onnx file when the model repository holds
 	// more than one. Empty means the single .onnx file in the repository.
 	OnnxFilename string
+	// Offline forbids New from performing any network I/O. The model must
+	// already be on disk; a missing or mismatched one is an error naming the
+	// file and the fix, not a download.
+	//
+	// Falling back to a download is not a graceful degradation in a
+	// locked-down deployment. The attempt trips egress monitoring even when
+	// it fails, and what the caller gets back is a DNS or TLS error that says
+	// nothing about the model. This turns "should be cached by now" into a
+	// guarantee that holds whatever the cache turns out to contain.
+	//
+	// It also tightens what counts as loadable, since a caller that cannot
+	// fall back deserves to hear about a bad directory before the runtime
+	// does: pinned models are re-checked against their sha256s, and any model
+	// directory — including one named by ModelPath, which is otherwise passed
+	// through untouched — must hold config.json, tokenizer.json and an .onnx
+	// file. Seed one with EnsureModelIn or "alcatraz models download".
+	Offline bool
 
 	// Backend selects the hugot inference backend (see the package
 	// documentation for the build matrix):

--- a/ner/models.go
+++ b/ner/models.go
@@ -32,6 +32,24 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 	return models.EnsureModelIn(ctx, model, dir)
 }
 
+// VerifyModelIn checks an already-seeded model directory against the pinned
+// digests without fetching anything, and returns it. It is what Config.Offline
+// runs, exported here for a caller that wants to fail at startup — or in a
+// container health check — rather than at first load. It is
+// [models.VerifyModelIn].
+//
+// dir is the models directory, as in EnsureModelIn. An empty dir means the
+// default, which unlike EnsureModelIn is not created.
+func VerifyModelIn(model, dir string) (string, error) {
+	return models.VerifyModelIn(model, dir)
+}
+
+// DefaultDir returns the models directory New reads from when Config.ModelsDir
+// is empty, without creating it. It is [models.DefaultDir].
+func DefaultDir() (string, error) {
+	return models.DefaultDir()
+}
+
 // PinnedModels returns, sorted, the model ids EnsureModel can fetch and
 // verify. Other model ids still work through Config.Model, but nothing
 // checks what the hub serves for them. It is [models.PinnedModels].

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -69,6 +69,20 @@
 // It prints both directories the config wants: ModelsDir, and the ModelPath
 // beneath it. See the alcatraz/models package for the pin table itself.
 //
+// Config.Offline turns "should be cached by now" into a guarantee. New then
+// opens no socket at all: a missing or mismatched model is an error naming
+// the file and the fix, rather than a download that trips egress monitoring
+// on its way to a DNS error that says nothing about the model.
+//
+//	cfg := ner.DefaultConfig()
+//	cfg.ModelsDir = "/opt/alcatraz/models"
+//	cfg.Offline = true
+//
+// Because an offline caller has no fallback, it also gets the directory
+// checked before hugot sees it — pinned models against their sha256s, any
+// model directory for config.json, tokenizer.json and an .onnx file. Nothing
+// on that path writes, so a model mounted read-only loads unchanged.
+//
 // The Engine implements analyzer.NlpEngine, so an analyzer.Engine configured
 // with SetNlpEngine runs the model once per Analyze call and shares the
 // artifacts with every artifact-aware recognizer:
@@ -173,6 +187,14 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 		if err != nil {
 			return nil, fmt.Errorf("ner: obtaining model %s: %w", cfg.Model, err)
 		}
+	} else if cfg.Offline {
+		// An explicit ModelPath already downloads nothing, so Offline adds
+		// only the check — which is the half that matters here, because this
+		// is the baked-image and mounted-volume case and a directory seeded
+		// wrong should say so before hugot does.
+		if err := checkModelDir(modelPath, cfg.OnnxFilename); err != nil {
+			return nil, fmt.Errorf("ner: offline: %w", err)
+		}
 	}
 
 	// hugot's session keeps the ctx it was created with and uses it for
@@ -226,8 +248,12 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 }
 
 // ensureModel returns the local path of cfg.Model, downloading it from
-// Hugging Face into the models directory on first use.
+// Hugging Face into the models directory on first use — unless cfg.Offline
+// forbids that, in which case it only reports what is already there.
 func ensureModel(ctx context.Context, cfg Config) (string, error) {
+	if cfg.Offline {
+		return offlineModel(cfg)
+	}
 	dir, err := models.ResolveDir(cfg.ModelsDir)
 	if err != nil {
 		return "", err

--- a/ner/offline.go
+++ b/ner/offline.go
@@ -1,6 +1,7 @@
 package ner
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -33,7 +34,7 @@ func offlineModel(cfg Config) (string, error) {
 	if models.IsPinned(cfg.Model) {
 		modelPath, err := models.VerifyModelIn(cfg.Model, dir)
 		if err != nil {
-			return "", fmt.Errorf("offline: %w; pre-download it with %q", err, downloadCmd(cfg))
+			return "", fmt.Errorf("offline: %w; pre-download it with: %s", err, downloadCmd(cfg))
 		}
 		return modelPath, nil
 	}
@@ -52,13 +53,18 @@ func offlineModel(cfg Config) (string, error) {
 // downloadCmd is the CLI invocation that seeds the directory this Config
 // reads from. An empty ModelsDir is the default cache, which is exactly what
 // a bare invocation warms, so the advice is copy-pasteable either way.
+//
+// The values are quoted because they are the caller's, not ours. A models
+// directory under "Application Support" or "Program Files" would otherwise
+// produce a command that still runs and writes somewhere else entirely, which
+// is a worse failure than one that does not run at all.
 func downloadCmd(cfg Config) string {
 	cmd := "alcatraz models download"
 	if cfg.ModelsDir != "" {
-		cmd += " --dest " + cfg.ModelsDir
+		cmd += fmt.Sprintf(" --dest %q", cfg.ModelsDir)
 	}
 	if cfg.Model != models.DefaultModel {
-		cmd += " --model " + cfg.Model
+		cmd += fmt.Sprintf(" --model %q", cfg.Model)
 	}
 	return cmd
 }
@@ -68,52 +74,85 @@ func downloadCmd(cfg Config) string {
 // are all required, and the runtime's own complaint about a missing one names
 // neither the file nor the directory.
 //
-// It only rejects what certainly cannot load. A pre-flight check that guessed
-// too much would refuse a directory that works, which is worse than the
-// opaque error it set out to replace.
+// It rejects only what hugot would also reject, with one deliberate
+// exception: a Config.OnnxFilename naming a file that is not there. hugot
+// ignores OnnxFilename entirely when the directory holds exactly one .onnx
+// file, so a stale name there loads whatever is present — a full-precision
+// export where a quantized one was asked for — and says nothing. Offline is
+// the mode for being sure which model is loading, so that is an error here.
 func checkModelDir(modelPath, onnxFilename string) error {
 	fi, err := os.Stat(modelPath)
 	if err != nil {
-		return fmt.Errorf("no model directory at %s", modelPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("no model directory at %s", modelPath)
+		}
+		return fmt.Errorf("cannot read %s: %w", modelPath, err)
 	}
 	if !fi.IsDir() {
 		return fmt.Errorf("%s is not a directory", modelPath)
 	}
 	for _, name := range []string{"config.json", "tokenizer.json"} {
-		if _, err := os.Stat(filepath.Join(modelPath, name)); err != nil {
+		switch err := readable(filepath.Join(modelPath, name)); {
+		case errors.Is(err, fs.ErrNotExist):
 			return fmt.Errorf("%s is missing from %s", name, modelPath)
+		case err != nil:
+			return fmt.Errorf("cannot read %s in %s: %w", name, modelPath, err)
 		}
 	}
-	if onnxFilename != "" {
-		if _, err := os.Stat(filepath.Join(modelPath, onnxFilename)); err != nil {
+	onnx := findONNX(modelPath, onnxFilename)
+	if onnx == "" {
+		if onnxFilename != "" {
 			return fmt.Errorf("%s is missing from %s", onnxFilename, modelPath)
 		}
-		return nil
-	}
-	if !hasONNX(modelPath) {
 		return fmt.Errorf("no .onnx file in %s", modelPath)
+	}
+	if err := readable(onnx); err != nil {
+		return fmt.Errorf("cannot read %s: %w", onnx, err)
 	}
 	return nil
 }
 
-// hasONNX reports whether dir holds an .onnx file anywhere beneath it. It
-// walks rather than testing for "model.onnx" because an empty
-// Config.OnnxFilename means "the single .onnx file in the repository",
-// whatever it is called and wherever the export put it.
-func hasONNX(dir string) bool {
-	found := false
+// readable reports whether the process can actually open path. os.Stat cannot
+// answer that — a file with mode 0 stats perfectly and opens never — and a
+// model directory that arrives from a build stage or a mounted volume is
+// exactly where the two come apart. hugot's complaint about an unreadable
+// file is as opaque as its complaint about an absent one, so the pre-flight
+// has to tell them apart itself.
+func readable(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// findONNX returns the path of the .onnx file dir holds anywhere beneath it,
+// named want when want is not empty, or "" if there is none.
+//
+// Both halves mirror hugot's own resolution (backends.getOnnxFiles): it walks
+// the model directory recursively, tests the ".onnx" suffix case-sensitively,
+// and compares Config.OnnxFilename against the base name wherever the file
+// sits. So weights under onnx/ count, a named file under onnx/ counts, and
+// MODEL.ONNX does not. Matching more loosely than hugot would wave through a
+// directory that then fails inside the runtime with the opaque error this
+// check exists to replace.
+func findONNX(dir, want string) string {
+	found := ""
 	// The error from WalkDir itself is discarded: this answers one question,
-	// and an unreadable subtree is not evidence either way. The callers above
-	// have already established that dir exists and is a directory.
-	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+	// and an unreadable subtree is not evidence either way. The caller above
+	// has already established that dir exists and is a directory.
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if !d.IsDir() && strings.EqualFold(filepath.Ext(d.Name()), ".onnx") {
-			found = true
-			return fs.SkipAll
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".onnx") {
+			return nil
 		}
-		return nil
+		if want != "" && d.Name() != want {
+			return nil
+		}
+		found = p
+		return fs.SkipAll
 	})
 	return found
 }

--- a/ner/offline.go
+++ b/ner/offline.go
@@ -1,0 +1,119 @@
+package ner
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoophq/alcatraz/models"
+)
+
+// The Config.Offline load path. Nothing in this file opens a socket, and
+// nothing writes: not the directory lookup ([models.DefaultDir], unlike
+// ResolveDir, does not create), not the verification, not the file checks.
+// A model directory mounted read-only loads through here unchanged.
+
+// offlineModel resolves cfg.Model against the local models directory, and
+// reports what is wrong with it rather than fetching anything.
+func offlineModel(cfg Config) (string, error) {
+	dir := cfg.ModelsDir
+	if dir == "" {
+		var err error
+		if dir, err = models.DefaultDir(); err != nil {
+			return "", err
+		}
+	}
+
+	// Pinned models get the checksums as well as the presence check. Offline
+	// is the mode where that matters most: a mismatch here cannot be repaired
+	// by re-fetching the file, so it has to be reported, and the operator who
+	// seeded the volume is the only one who can act on it.
+	if models.IsPinned(cfg.Model) {
+		modelPath, err := models.VerifyModelIn(cfg.Model, dir)
+		if err != nil {
+			return "", fmt.Errorf("offline: %w; pre-download it with %q", err, downloadCmd(cfg))
+		}
+		return modelPath, nil
+	}
+
+	// Unpinned: nothing to verify against, and no alcatraz command that
+	// fetches it, so the check is presence and the advice is to seed the
+	// directory by hand.
+	modelPath := models.Dir(dir, cfg.Model)
+	if err := checkModelDir(modelPath, cfg.OnnxFilename); err != nil {
+		return "", fmt.Errorf("offline: %w; %q is not a pinned model, so seed that directory yourself (pinned: %s)",
+			err, cfg.Model, strings.Join(models.PinnedModels(), ", "))
+	}
+	return modelPath, nil
+}
+
+// downloadCmd is the CLI invocation that seeds the directory this Config
+// reads from. An empty ModelsDir is the default cache, which is exactly what
+// a bare invocation warms, so the advice is copy-pasteable either way.
+func downloadCmd(cfg Config) string {
+	cmd := "alcatraz models download"
+	if cfg.ModelsDir != "" {
+		cmd += " --dest " + cfg.ModelsDir
+	}
+	if cfg.Model != models.DefaultModel {
+		cmd += " --model " + cfg.Model
+	}
+	return cmd
+}
+
+// checkModelDir reports the first reason hugot could not open modelPath as a
+// token-classification model: the label map, the tokenizer and the weights
+// are all required, and the runtime's own complaint about a missing one names
+// neither the file nor the directory.
+//
+// It only rejects what certainly cannot load. A pre-flight check that guessed
+// too much would refuse a directory that works, which is worse than the
+// opaque error it set out to replace.
+func checkModelDir(modelPath, onnxFilename string) error {
+	fi, err := os.Stat(modelPath)
+	if err != nil {
+		return fmt.Errorf("no model directory at %s", modelPath)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("%s is not a directory", modelPath)
+	}
+	for _, name := range []string{"config.json", "tokenizer.json"} {
+		if _, err := os.Stat(filepath.Join(modelPath, name)); err != nil {
+			return fmt.Errorf("%s is missing from %s", name, modelPath)
+		}
+	}
+	if onnxFilename != "" {
+		if _, err := os.Stat(filepath.Join(modelPath, onnxFilename)); err != nil {
+			return fmt.Errorf("%s is missing from %s", onnxFilename, modelPath)
+		}
+		return nil
+	}
+	if !hasONNX(modelPath) {
+		return fmt.Errorf("no .onnx file in %s", modelPath)
+	}
+	return nil
+}
+
+// hasONNX reports whether dir holds an .onnx file anywhere beneath it. It
+// walks rather than testing for "model.onnx" because an empty
+// Config.OnnxFilename means "the single .onnx file in the repository",
+// whatever it is called and wherever the export put it.
+func hasONNX(dir string) bool {
+	found := false
+	// The error from WalkDir itself is discarded: this answers one question,
+	// and an unreadable subtree is not evidence either way. The callers above
+	// have already established that dir exists and is a directory.
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.EqualFold(filepath.Ext(d.Name()), ".onnx") {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}

--- a/ner/offline_test.go
+++ b/ner/offline_test.go
@@ -1,0 +1,427 @@
+package ner
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/alcatraz/entities"
+	"github.com/hoophq/alcatraz/models"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// noNetwork fails the test if anything reaches for the network while it runs.
+// Offline is a promise about what does not happen, and the only way to test a
+// negative is to make the forbidden thing loud: asserting on an error message
+// would pass just as well for code that tried the hub first and gave up.
+//
+// It replaces the process-wide http.DefaultTransport, which is what
+// http.DefaultClient resolves lazily at call time, so it covers models.download
+// and anything else on the load path that uses the default client. A test
+// calling this cannot be parallel.
+func noNetwork(t *testing.T) {
+	t.Helper()
+	prev := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("offline mode attempted a request to %s", r.URL)
+		return nil, http.ErrUseLastResponse
+	})
+	t.Cleanup(func() { http.DefaultTransport = prev })
+}
+
+// seedFiles writes name -> content into dir, creating it.
+func seedFiles(t *testing.T, dir string, files map[string]string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// unpinnedModel is a model id nothing has checksums for, which is the other
+// half of the offline path: presence checks only, and different advice.
+const unpinnedModel = "alcatraz-test/unpinned-NER"
+
+func TestOfflineColdCacheDoesNotDownload(t *testing.T) {
+	noNetwork(t)
+	dir := t.TempDir()
+
+	_, err := New(context.Background(), Config{Model: models.DefaultModel, ModelsDir: dir, Offline: true})
+	if err == nil {
+		t.Fatal("New succeeded with Offline set and an empty models directory")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"offline:",
+		"no model directory at",
+		models.Dir(dir, models.DefaultModel),
+		"alcatraz models download --dest " + dir,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("err = %v\nwant it to contain %q", err, want)
+		}
+	}
+}
+
+// The pinned check reports the first file the pin table lists as missing, so
+// an operator fixes one named file rather than guessing at "the model".
+func TestOfflinePinnedIncompleteDirNamesTheFile(t *testing.T) {
+	noNetwork(t)
+	dir := t.TempDir()
+	pinned := models.PinnedFiles(models.DefaultModel)
+	if len(pinned) < 2 {
+		t.Fatalf("expected the default model to pin several files, got %d", len(pinned))
+	}
+	// Everything but the first file, so the report cannot be a lucky guess
+	// at an empty directory.
+	files := map[string]string{}
+	for _, f := range pinned[1:] {
+		files[f.Name] = "placeholder"
+	}
+	seedFiles(t, models.Dir(dir, models.DefaultModel), files)
+
+	_, err := ensureModel(context.Background(), Config{Model: models.DefaultModel, ModelsDir: dir, Offline: true})
+	if err == nil {
+		t.Fatal("ensureModel succeeded on an incomplete pinned model directory")
+	}
+	if !strings.Contains(err.Error(), pinned[0].Name) || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("err = %v, want it to name %s as missing", err, pinned[0].Name)
+	}
+}
+
+// Present but wrong is the case Offline exists for: a stale image layer or a
+// truncated copy cannot be repaired by a re-fetch here, so it has to be said
+// out loud instead of surfacing as an opaque runtime failure much later.
+func TestOfflinePinnedTamperedDirReportsMismatch(t *testing.T) {
+	noNetwork(t)
+	dir := t.TempDir()
+	files := map[string]string{}
+	for _, f := range models.PinnedFiles(models.DefaultModel) {
+		files[f.Name] = "not the pinned bytes"
+	}
+	seedFiles(t, models.Dir(dir, models.DefaultModel), files)
+
+	_, err := ensureModel(context.Background(), Config{Model: models.DefaultModel, ModelsDir: dir, Offline: true})
+	if err == nil {
+		t.Fatal("ensureModel succeeded on a tampered pinned model directory")
+	}
+	if !strings.Contains(err.Error(), "does not match its pinned sha256") {
+		t.Errorf("err = %v, want a sha256 mismatch", err)
+	}
+	if strings.Contains(err.Error(), "missing") {
+		t.Errorf("err = %v, reports a present-but-wrong file as missing", err)
+	}
+}
+
+func TestOfflineUnpinnedModel(t *testing.T) {
+	noNetwork(t)
+
+	complete := map[string]string{
+		"config.json":    `{"id2label":{}}`,
+		"tokenizer.json": `{}`,
+		"model.onnx":     "weights",
+	}
+
+	t.Run("complete directory resolves", func(t *testing.T) {
+		dir := t.TempDir()
+		want := seedFiles(t, models.Dir(dir, unpinnedModel), complete)
+
+		got, err := ensureModel(context.Background(), Config{Model: unpinnedModel, ModelsDir: dir, Offline: true})
+		if err != nil {
+			t.Fatalf("ensureModel: %v", err)
+		}
+		if got != want {
+			t.Errorf("model path = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing file is named, with advice that fits an unpinned model", func(t *testing.T) {
+		dir := t.TempDir()
+		seedFiles(t, models.Dir(dir, unpinnedModel), map[string]string{"config.json": "{}"})
+
+		_, err := ensureModel(context.Background(), Config{Model: unpinnedModel, ModelsDir: dir, Offline: true})
+		if err == nil {
+			t.Fatal("ensureModel succeeded without a tokenizer")
+		}
+		if !strings.Contains(err.Error(), "tokenizer.json") {
+			t.Errorf("err = %v, want it to name tokenizer.json", err)
+		}
+		// "alcatraz models download" refuses unpinned ids, so suggesting it
+		// here would send the operator down a dead end.
+		if strings.Contains(err.Error(), "alcatraz models download") {
+			t.Errorf("err = %v, must not suggest a command that rejects unpinned ids", err)
+		}
+		if !strings.Contains(err.Error(), "not a pinned model") {
+			t.Errorf("err = %v, want it to explain why there is nothing to verify against", err)
+		}
+	})
+
+	t.Run("no onnx file at all", func(t *testing.T) {
+		dir := t.TempDir()
+		seedFiles(t, models.Dir(dir, unpinnedModel), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+		})
+
+		_, err := ensureModel(context.Background(), Config{Model: unpinnedModel, ModelsDir: dir, Offline: true})
+		if err == nil || !strings.Contains(err.Error(), "no .onnx file in") {
+			t.Errorf("err = %v, want it to report the absent weights", err)
+		}
+	})
+
+	// An empty OnnxFilename means "the single .onnx file in the repository",
+	// whatever the export called it, so the check must not assume model.onnx.
+	t.Run("differently named onnx is accepted", func(t *testing.T) {
+		dir := t.TempDir()
+		want := seedFiles(t, models.Dir(dir, unpinnedModel), map[string]string{
+			"config.json":          "{}",
+			"tokenizer.json":       "{}",
+			"model_quantized.onnx": "weights",
+		})
+
+		got, err := ensureModel(context.Background(), Config{Model: unpinnedModel, ModelsDir: dir, Offline: true})
+		if err != nil {
+			t.Fatalf("ensureModel: %v", err)
+		}
+		if got != want {
+			t.Errorf("model path = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("OnnxFilename must exist when set", func(t *testing.T) {
+		dir := t.TempDir()
+		seedFiles(t, models.Dir(dir, unpinnedModel), complete)
+
+		_, err := ensureModel(context.Background(), Config{
+			Model:        unpinnedModel,
+			ModelsDir:    dir,
+			OnnxFilename: "model_quantized.onnx",
+			Offline:      true,
+		})
+		if err == nil || !strings.Contains(err.Error(), "model_quantized.onnx") {
+			t.Errorf("err = %v, want it to name the requested onnx file", err)
+		}
+	})
+}
+
+// ModelPath already downloads nothing, so Offline adds only the pre-flight
+// check — and adds it strictly opt-in, since existing callers pass directories
+// this package has never inspected.
+func TestOfflineModelPathIsChecked(t *testing.T) {
+	noNetwork(t)
+	empty := t.TempDir()
+
+	_, err := New(context.Background(), Config{ModelPath: empty, Offline: true})
+	if err == nil {
+		t.Fatal("New succeeded with Offline set and an empty ModelPath")
+	}
+	if !strings.Contains(err.Error(), "ner: offline:") {
+		t.Errorf("err = %v, want the offline pre-flight error", err)
+	}
+	if !strings.Contains(err.Error(), "config.json is missing from "+empty) {
+		t.Errorf("err = %v, want it to name the missing file and the directory", err)
+	}
+}
+
+func TestCheckModelDir(t *testing.T) {
+	t.Run("path is a file", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "model")
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := checkModelDir(f, ""); err == nil || !strings.Contains(err.Error(), "is not a directory") {
+			t.Errorf("err = %v, want a not-a-directory error", err)
+		}
+	})
+
+	t.Run("path does not exist", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope")
+		if err := checkModelDir(missing, ""); err == nil || !strings.Contains(err.Error(), "no model directory at") {
+			t.Errorf("err = %v, want an absent-directory error", err)
+		}
+	})
+
+	// hugot's own layouts put the weights in an onnx/ subdirectory often
+	// enough that a top-level-only check would reject a directory that loads.
+	t.Run("onnx in a subdirectory counts", func(t *testing.T) {
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+		})
+		seedFiles(t, filepath.Join(dir, "onnx"), map[string]string{"model.onnx": "weights"})
+
+		if err := checkModelDir(dir, ""); err != nil {
+			t.Errorf("checkModelDir: %v", err)
+		}
+	})
+
+	t.Run("extension match is case-insensitive", func(t *testing.T) {
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+			"MODEL.ONNX":     "weights",
+		})
+		if err := checkModelDir(dir, ""); err != nil {
+			t.Errorf("checkModelDir: %v", err)
+		}
+	})
+}
+
+func TestDownloadCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"defaults", Config{Model: models.DefaultModel}, "alcatraz models download"},
+		{"explicit dir", Config{Model: models.DefaultModel, ModelsDir: "/opt/m"}, "alcatraz models download --dest /opt/m"},
+		{"other model", Config{Model: "org/other"}, "alcatraz models download --model org/other"},
+		{"both", Config{Model: "org/other", ModelsDir: "/opt/m"}, "alcatraz models download --dest /opt/m --model org/other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := downloadCmd(tt.cfg); got != tt.want {
+				t.Errorf("downloadCmd = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The offline path never writes, so a model directory mounted read-only —
+// the baked-image and shared-volume case — resolves unchanged.
+func TestOfflineReadOnlyModelsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the permission bits under test")
+	}
+	noNetwork(t)
+
+	dir := t.TempDir()
+	want := seedFiles(t, models.Dir(dir, unpinnedModel), map[string]string{
+		"config.json":    "{}",
+		"tokenizer.json": "{}",
+		"model.onnx":     "weights",
+	})
+	for _, p := range []string{want, dir} {
+		if err := os.Chmod(p, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(p, 0o755) })
+	}
+
+	got, err := ensureModel(context.Background(), Config{Model: unpinnedModel, ModelsDir: dir, Offline: true})
+	if err != nil {
+		t.Fatalf("ensureModel on a read-only models directory: %v", err)
+	}
+	if got != want {
+		t.Errorf("model path = %q, want %q", got, want)
+	}
+}
+
+// TestLiveOfflineNER is the whole feature against a real model: warm the
+// cache, mount a copy of it read-only, forbid the network, and load. Gated
+// behind ALCATRAZ_NER_LIVE=1.
+//
+// The unit tests above stop at path resolution, because the fixtures they use
+// are not loadable models. This is the only place that proves hugot itself
+// gets through a read-only directory without writing — no lockfile, no temp
+// extraction, no metadata rewrite — which is exactly how a baked image or a
+// shared volume presents the model in the deployments Offline exists for.
+func TestLiveOfflineNER(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
+	}
+
+	// Warm the shared cache first — the one step here allowed to use the
+	// network, and on CI a no-op against the restored cache.
+	src, err := models.EnsureModelIn(context.Background(), models.DefaultModel, os.Getenv("ALCATRAZ_NER_MODELS_DIR"))
+	if err != nil {
+		t.Fatalf("EnsureModelIn: %v", err)
+	}
+
+	// Copy rather than chmod the cache in place: a test has no business
+	// leaving the user's model cache read-only if it dies partway through.
+	dir := t.TempDir()
+	dest := models.Dir(dir, models.DefaultModel)
+	copyModelDir(t, src, dest)
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
+		for _, p := range []string{dest, dir} {
+			if err := os.Chmod(p, 0o555); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { os.Chmod(p, 0o755) })
+		}
+	}
+
+	noNetwork(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	nlp, err := New(ctx, Config{Model: models.DefaultModel, ModelsDir: dir, Offline: true})
+	cancel()
+	if err != nil {
+		t.Fatalf("New with Offline against a read-only model directory: %v", err)
+	}
+	defer nlp.Close()
+
+	arts, err := nlp.ProcessText("My name is John Smith and I live in Berlin", "en")
+	if err != nil {
+		t.Fatalf("ProcessText: %v", err)
+	}
+	found := map[string]bool{}
+	for _, span := range arts.Ents {
+		found[span.EntityType] = true
+	}
+	if !found[entities.Person] {
+		t.Errorf("no PERSON in %v", arts.Ents)
+	}
+}
+
+// copyModelDir copies the flat model directory src to dest, read-only.
+func copyModelDir(t *testing.T, src, dest string) {
+	t.Helper()
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			copyModelDir(t, filepath.Join(src, e.Name()), filepath.Join(dest, e.Name()))
+			continue
+		}
+		in, err := os.Open(filepath.Join(src, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := os.OpenFile(filepath.Join(dest, e.Name()), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o444)
+		if err != nil {
+			in.Close()
+			t.Fatal(err)
+		}
+		_, err = io.Copy(out, in)
+		in.Close()
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/ner/offline_test.go
+++ b/ner/offline_test.go
@@ -51,6 +51,18 @@ func seedFiles(t *testing.T, dir string, files map[string]string) string {
 	return dir
 }
 
+// requireUnprivilegedUnix skips a test that means nothing without enforced
+// unix permission bits: Windows does not have them, and root ignores them.
+func requireUnprivilegedUnix(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the permission bits under test")
+	}
+}
+
 // unpinnedModel is a model id nothing has checksums for, which is the other
 // half of the offline path: presence checks only, and different advice.
 const unpinnedModel = "alcatraz-test/unpinned-NER"
@@ -68,7 +80,7 @@ func TestOfflineColdCacheDoesNotDownload(t *testing.T) {
 		"offline:",
 		"no model directory at",
 		models.Dir(dir, models.DefaultModel),
-		"alcatraz models download --dest " + dir,
+		`alcatraz models download --dest "` + dir + `"`,
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("err = %v\nwant it to contain %q", err, want)
@@ -254,6 +266,74 @@ func TestCheckModelDir(t *testing.T) {
 		}
 	})
 
+	// "not there" and "there, and you may not look at it" have different
+	// fixes, and stat reports the second as the first for a file while
+	// reporting it honestly for a directory. Both are checked because both
+	// happen when the model is mounted in rather than downloaded.
+	t.Run("unreadable directory is not reported as absent", func(t *testing.T) {
+		requireUnprivilegedUnix(t)
+		parent := t.TempDir()
+		modelPath := filepath.Join(parent, "model")
+		if err := os.Mkdir(modelPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(parent, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+		err := checkModelDir(modelPath, "")
+		if err == nil || !strings.Contains(err.Error(), "cannot read") {
+			t.Errorf("err = %v, want it to report the directory as unreadable", err)
+		}
+		if err != nil && strings.Contains(err.Error(), "no model directory at") {
+			t.Errorf("err = %v, reports an unreadable directory as absent", err)
+		}
+	})
+
+	t.Run("unreadable file is not reported as missing", func(t *testing.T) {
+		requireUnprivilegedUnix(t)
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+			"model.onnx":     "weights",
+		})
+		locked := filepath.Join(dir, "tokenizer.json")
+		if err := os.Chmod(locked, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(locked, 0o644) })
+
+		err := checkModelDir(dir, "")
+		if err == nil || !strings.Contains(err.Error(), "cannot read tokenizer.json") {
+			t.Errorf("err = %v, want it to report tokenizer.json as unreadable", err)
+		}
+		if err != nil && strings.Contains(err.Error(), "is missing from") {
+			t.Errorf("err = %v, reports a permission problem as an absent file", err)
+		}
+	})
+
+	// The weights are found by walking, which needs only the directory bit,
+	// so an unreadable .onnx passes a name-only check and fails inside hugot.
+	t.Run("unreadable onnx is caught", func(t *testing.T) {
+		requireUnprivilegedUnix(t)
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+		})
+		seedFiles(t, filepath.Join(dir, "onnx"), map[string]string{"model.onnx": "weights"})
+		locked := filepath.Join(dir, "onnx", "model.onnx")
+		if err := os.Chmod(locked, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(locked, 0o644) })
+
+		err := checkModelDir(dir, "")
+		if err == nil || !strings.Contains(err.Error(), "cannot read "+locked) {
+			t.Errorf("err = %v, want it to report the weights as unreadable", err)
+		}
+	})
+
 	// hugot's own layouts put the weights in an onnx/ subdirectory often
 	// enough that a top-level-only check would reject a directory that loads.
 	t.Run("onnx in a subdirectory counts", func(t *testing.T) {
@@ -268,14 +348,45 @@ func TestCheckModelDir(t *testing.T) {
 		}
 	})
 
-	t.Run("extension match is case-insensitive", func(t *testing.T) {
+	// A named file is matched by base name wherever it sits, because that is
+	// how hugot matches it. Requiring it at the top level would reject the
+	// onnx/ layout above the moment OnnxFilename was set.
+	t.Run("named onnx in a subdirectory counts", func(t *testing.T) {
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+		})
+		seedFiles(t, filepath.Join(dir, "onnx"), map[string]string{"model_quantized.onnx": "weights"})
+
+		if err := checkModelDir(dir, "model_quantized.onnx"); err != nil {
+			t.Errorf("checkModelDir: %v", err)
+		}
+	})
+
+	t.Run("a different onnx does not satisfy OnnxFilename", func(t *testing.T) {
+		dir := seedFiles(t, t.TempDir(), map[string]string{
+			"config.json":    "{}",
+			"tokenizer.json": "{}",
+			"model.onnx":     "weights",
+		})
+		err := checkModelDir(dir, "model_quantized.onnx")
+		if err == nil || !strings.Contains(err.Error(), "model_quantized.onnx") {
+			t.Errorf("err = %v, want it to name the requested onnx file", err)
+		}
+	})
+
+	// hugot's suffix test is case-sensitive, so MODEL.ONNX is not weights as
+	// far as the runtime is concerned. Accepting it here would pass the
+	// pre-flight and then fail inside hugot, which is the whole failure mode
+	// checkModelDir exists to prevent.
+	t.Run("extension match is case-sensitive, as hugot's is", func(t *testing.T) {
 		dir := seedFiles(t, t.TempDir(), map[string]string{
 			"config.json":    "{}",
 			"tokenizer.json": "{}",
 			"MODEL.ONNX":     "weights",
 		})
-		if err := checkModelDir(dir, ""); err != nil {
-			t.Errorf("checkModelDir: %v", err)
+		if err := checkModelDir(dir, ""); err == nil || !strings.Contains(err.Error(), "no .onnx file in") {
+			t.Errorf("err = %v, want MODEL.ONNX rejected the way hugot rejects it", err)
 		}
 	})
 }
@@ -287,9 +398,12 @@ func TestDownloadCmd(t *testing.T) {
 		want string
 	}{
 		{"defaults", Config{Model: models.DefaultModel}, "alcatraz models download"},
-		{"explicit dir", Config{Model: models.DefaultModel, ModelsDir: "/opt/m"}, "alcatraz models download --dest /opt/m"},
-		{"other model", Config{Model: "org/other"}, "alcatraz models download --model org/other"},
-		{"both", Config{Model: "org/other", ModelsDir: "/opt/m"}, "alcatraz models download --dest /opt/m --model org/other"},
+		{"explicit dir", Config{Model: models.DefaultModel, ModelsDir: "/opt/m"}, `alcatraz models download --dest "/opt/m"`},
+		{"other model", Config{Model: "org/other"}, `alcatraz models download --model "org/other"`},
+		{"both", Config{Model: "org/other", ModelsDir: "/opt/m"}, `alcatraz models download --dest "/opt/m" --model "org/other"`},
+		// The reason the values are quoted at all: unquoted, this is a
+		// command that runs and seeds "/opt/my".
+		{"dir with a space", Config{Model: models.DefaultModel, ModelsDir: "/opt/my models"}, `alcatraz models download --dest "/opt/my models"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -303,12 +417,7 @@ func TestDownloadCmd(t *testing.T) {
 // The offline path never writes, so a model directory mounted read-only —
 // the baked-image and shared-volume case — resolves unchanged.
 func TestOfflineReadOnlyModelsDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix permission bits")
-	}
-	if os.Geteuid() == 0 {
-		t.Skip("running as root, which ignores the permission bits under test")
-	}
+	requireUnprivilegedUnix(t)
 	noNetwork(t)
 
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #18 (ATR-192).

`EnsureModel` (ATR-190) and `alcatraz models download` (ATR-191) make a warm
cache *likely*. Nothing made it *required* — `ner.New` still fell back to
downloading, and in a locked-down deployment that is not a graceful
degradation: the attempt trips egress monitoring even when it fails, and what
the caller gets back is a DNS or TLS error that says nothing about the model.

`ner.Config.Offline` turns "should be cached by now" into a guarantee.

```go
cfg := ner.DefaultConfig()
cfg.ModelsDir = "/opt/alcatraz/models"
cfg.Offline = true // New opens no socket; a bad model directory is an error
```

```
ner: obtaining model KnightsAnalytics/distilbert-NER: offline: models: model.onnx
in /opt/alcatraz/models/KnightsAnalytics_distilbert-NER does not match its pinned
sha256; pre-download it with "alcatraz models download --dest /opt/alcatraz/models"
```

## What it changes

Because an offline caller has no fallback, `Offline` also tightens what counts
as loadable — and it is the one thing that makes `ModelPath` checked at all:

| | `Offline` unset | `Offline` set |
|---|---|---|
| `ModelsDir`, pinned model | downloads what is missing or fails verification | verifies every pinned sha256, never downloads |
| `ModelsDir`, unpinned model | downloads through hugot | requires `config.json`, `tokenizer.json` and an `.onnx` file |
| `ModelPath` | trusted as-is | same three-file check before hugot sees it |

Existing callers are unaffected: `Offline` is opt-in and its zero value is
today's behaviour.

## Notes on the design

- **`models.VerifyModelIn`** is `EnsureModelIn`'s verification half without its
  downloading half. It reports *missing* and *mismatched* as distinct failures
  on purpose — absent means the volume was never seeded, mismatched means it
  was seeded with the wrong bytes (a stale image layer, a truncated copy), and
  the fixes have nothing in common. A mismatched file is left in place rather
  than deleted, matching `cachedFileValid`.
- **`models.DefaultDir`** is split out of `ResolveDir` so the lookup can happen
  without the `os.MkdirAll`. In a read-only container that mkdir would surface
  as `creating the models directory: permission denied`, which is precisely the
  opaque failure this PR exists to remove.
- **Unpinned models get different advice.** `alcatraz models download` refuses
  unpinned ids, so suggesting it there would send an operator down a dead end;
  the error says to seed the directory by hand and lists what *is* pinned.
- **The `.onnx` check walks** rather than looking for `model.onnx`. An empty
  `OnnxFilename` means "the single `.onnx` file in the repository", whatever
  the export called it and wherever it put it — a wrong guess would reject a
  directory that works, which is worse than the opaque error being replaced.

## Tests

Per the issue:

- cold cache + `Offline: true` → the specific error, and **no outbound request
  is attempted**. Asserted with a `http.DefaultTransport` that fails the test
  if it is invoked, rather than by matching an error string, which would pass
  just as well for code that tried the hub first and gave up.
- warm cache + `Offline: true` → loads.
- **read-only model directory** → loads. Covered at both levels: `models` and
  `ner` unit tests chmod their fixture to `0555`, and `TestLiveOfflineNER`
  copies a real model, mounts the copy read-only, forbids the network, and
  loads it through hugot — the only place that proves the runtime itself
  writes no lockfile, temp extraction or metadata on the load path.

`TestLiveOfflineNER` is named explicitly in `ml-live.yml`: `-run` is a
substring match, so `-run TestLiveNER` would have skipped it silently.

Also covered: mismatch reported as a mismatch and not as "missing"; the first
pinned file named when a directory is incomplete; `OnnxFilename` honoured when
set and a differently-named `.onnx` accepted when it is not; `DefaultDir`
creating nothing; the `downloadCmd` hint for each combination of `Model` and
`ModelsDir`.

## Not in scope

Docs beyond the README section (ATR-193). Root module `go.mod` is untouched —
`git diff main -- go.mod` is empty, the standard library is still the only
dependency.
