### PR TITLE
fix(recognizers): never bridge a tab or newline in a separator class (ATR-207)

### DIFF
--- a/recognizers/au.go
+++ b/recognizers/au.go
@@ -10,7 +10,7 @@ import (
 func AUTFN() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"AuTfnRecognizer", entities.AUTFN, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("AU TFN", `\b\d{3}\s?\d{3}\s?\d{3}\b`, 0.3)},
+		[]*analyzer.Pattern{analyzer.MustPattern("AU TFN", `\b\d{3}`+hsp+`?\d{3}`+hsp+`?\d{3}\b`, 0.3)},
 	).WithContext("tfn", "tax file").WithValidator(validateTFN)
 }
 
@@ -32,7 +32,7 @@ func validateTFN(s string) bool {
 func AUABN() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"AuAbnRecognizer", entities.AUABN, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("AU ABN", `\b\d{2}\s?\d{3}\s?\d{3}\s?\d{3}\b`, 0.3)},
+		[]*analyzer.Pattern{analyzer.MustPattern("AU ABN", `\b\d{2}`+hsp+`?\d{3}`+hsp+`?\d{3}`+hsp+`?\d{3}\b`, 0.3)},
 	).WithContext("abn", "business number").WithValidator(validateABN)
 }
 
@@ -56,7 +56,7 @@ func validateABN(s string) bool {
 func AUACN() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"AuAcnRecognizer", entities.AUACN, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("AU ACN", `\b\d{3}\s?\d{3}\s?\d{3}\b`, 0.3)},
+		[]*analyzer.Pattern{analyzer.MustPattern("AU ACN", `\b\d{3}`+hsp+`?\d{3}`+hsp+`?\d{3}\b`, 0.3)},
 	).WithContext("acn", "company number").WithValidator(validateACN)
 }
 
@@ -78,7 +78,7 @@ func validateACN(s string) bool {
 func AUMedicare() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"AuMedicareRecognizer", entities.AUMedicare, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("AU Medicare", `\b\d{4}\s?\d{5}\s?\d{1}\b`, 0.6)},
+		[]*analyzer.Pattern{analyzer.MustPattern("AU Medicare", `\b\d{4}`+hsp+`?\d{5}`+hsp+`?\d{1}\b`, 0.6)},
 	).WithContext("medicare", "health").WithValidator(validateMedicare)
 }
 

--- a/recognizers/generic.go
+++ b/recognizers/generic.go
@@ -33,7 +33,7 @@ func Phone() analyzer.Recognizer {
 		"PhoneRecognizer", entities.PhoneNumber, "en",
 		[]*analyzer.Pattern{
 			analyzer.MustPattern("Phone (US)",
-				`(?:^|\W)((?:\+?1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4})\b`, 0.5).WithGroup(1),
+				`(?:^|\W)((?:\+?1[-.`+hsp+`]?)?(?:\(\d{3}\)|\d{3})[-.`+hsp+`]?\d{3}[-.`+hsp+`]?\d{4})\b`, 0.5).WithGroup(1),
 			// A '+' country prefix followed by 8-15 digits (the E.164 range)
 			// with at most two separator characters between consecutive
 			// digits. The digit count is enforced by the repetition bounds,
@@ -41,13 +41,13 @@ func Phone() analyzer.Recognizer {
 			// prefix. \B rejects a '+' preceded by a word character, keeping
 			// arithmetic like 2+34567890 out.
 			analyzer.MustPattern("Phone (intl)",
-				`\B\+(?:[\s.()-]{0,2}\d){8,15}\b`, 0.5),
+				`\B\+(?:[`+hsp+`.()-]{0,2}\d){8,15}\b`, 0.5),
 			// Brazilian domestic format: optional 55 country code, 2-digit
 			// area code (DDD), optional mobile '9', then 4+4 digits. Scored
 			// like the US pattern: with balanced parens its shape is no
 			// weaker, and 0.5 clears the `alcatraz hook` default threshold.
 			analyzer.MustPattern("Phone (BR)",
-				`(?:^|\W)((?:\+?55[\s.-]?)?(?:\(\d{2}\)|\d{2})[\s.-]?9?\d{4}[\s.-]?\d{4})\b`, 0.5).WithGroup(1),
+				`(?:^|\W)((?:\+?55[`+hsp+`.-]?)?(?:\(\d{2}\)|\d{2})[`+hsp+`.-]?9?\d{4}[`+hsp+`.-]?\d{4})\b`, 0.5).WithGroup(1),
 		},
 	).WithContext("phone", "number", "telephone", "cell", "mobile")
 }
@@ -90,8 +90,11 @@ func IP() analyzer.Recognizer {
 func URL() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"UrlRecognizer", entities.URL, "en",
+		// The character after the host's first byte is `[^\s]`, not `.`: an
+		// unqualified dot also matches a tab, which lets a URL in one column
+		// swallow the start of the next one.
 		[]*analyzer.Pattern{analyzer.MustPattern("URL",
-			`\b(?:https?://|ftp://|www\.)[^\s/$.?#].[^\s]*\b`, 0.5)},
+			`\b(?:https?://|ftp://|www\.)[^\s/$.?#][^\s][^\s]*\b`, 0.5)},
 	).WithContext("url", "link", "website")
 }
 
@@ -104,10 +107,14 @@ func DateTime() analyzer.Recognizer {
 				`\b(0?[1-9]|1[0-2])[/-](0?[1-9]|[12]\d|3[01])[/-](\d{4})\b`, 0.6),
 			analyzer.MustPattern("Date (ISO)",
 				`\b(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\b`, 0.7),
+			// hsp rather than \s: a date wrapped across a line is rare, while
+			// three adjacent table cells that happen to read as one is not,
+			// and DATE_TIME scores high enough (0.7-0.8) to clear most
+			// caller thresholds and mask them.
 			analyzer.MustPattern("Date (Month DD, YYYY)",
-				`\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b`, 0.8),
+				`\b(January|February|March|April|May|June|July|August|September|October|November|December)`+hsp+`+(\d{1,2}),?`+hsp+`+(\d{4})\b`, 0.8),
 			analyzer.MustPattern("Date (Mon DD, YYYY)",
-				`\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\.?\s+(\d{1,2}),?\s+(\d{4})\b`, 0.7),
+				`\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\.?`+hsp+`+(\d{1,2}),?`+hsp+`+(\d{4})\b`, 0.7),
 		},
 	).WithContext("date", "born", "birthday", "dob")
 }
@@ -119,7 +126,7 @@ func IBAN() analyzer.Recognizer {
 		"IbanRecognizer", entities.IBANCode, "en",
 		[]*analyzer.Pattern{
 			analyzer.MustPattern("IBAN", `\b[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}\b`, 0.3),
-			analyzer.MustPattern("IBAN (spaces)", `\b([A-Z]{2}[0-9]{2}\s?([A-Z0-9]{4}\s?){1,7}[A-Z0-9]{1,4})\b`, 0.4),
+			analyzer.MustPattern("IBAN (spaces)", `\b([A-Z]{2}[0-9]{2}`+hsp+`?([A-Z0-9]{4}`+hsp+`?){1,7}[A-Z0-9]{1,4})\b`, 0.4),
 		},
 	).WithContext("iban", "account", "bank").WithValidator(validateIBAN)
 }

--- a/recognizers/india.go
+++ b/recognizers/india.go
@@ -9,7 +9,7 @@ import (
 func INAadhaar() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"InAadhaarRecognizer", entities.INAadhaar, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("Aadhaar", `\b\d{4}\s?\d{4}\s?\d{4}\b`, 0.6)},
+		[]*analyzer.Pattern{analyzer.MustPattern("Aadhaar", `\b\d{4}`+hsp+`?\d{4}`+hsp+`?\d{4}\b`, 0.6)},
 	).WithContext("aadhaar", "aadhar").WithValidator(func(m string) bool {
 		ds := digitValues(m)
 		if len(ds) != 12 {
@@ -40,7 +40,7 @@ func INVehicle() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"InVehicleRecognizer", entities.INVehicleRegistration, "en",
 		[]*analyzer.Pattern{analyzer.MustPattern("IN Vehicle",
-			`\b[A-Z]{2}\s?\d{1,2}\s?[A-Z]{1,2}\s?\d{4}\b`, 0.6)},
+			`\b[A-Z]{2}`+hsp+`?\d{1,2}`+hsp+`?[A-Z]{1,2}`+hsp+`?\d{4}\b`, 0.6)},
 	).WithContext("vehicle", "registration", "car")
 }
 

--- a/recognizers/separators.go
+++ b/recognizers/separators.go
@@ -1,0 +1,33 @@
+package recognizers
+
+// hsp matches a single horizontal space separator: the Unicode Zs category
+// (U+0020 SPACE, U+00A0 NO-BREAK SPACE, U+202F NARROW NO-BREAK SPACE, the
+// U+2000-U+200A range, U+3000 and friends).
+//
+// Use it — never `\s` — for the optional separators inside a grouped
+// identifier, a phone number or a date.
+//
+// Go's RE2 desugars `\s` to `[\t\n\f\r ]`, so a separator class built on `\s`
+// happily bridges a tab or a newline. In the tabular output alcatraz is
+// routinely pointed at (psql results, TSV exports, log tables) a tab is a
+// column boundary and a newline is a row boundary, and no identifier ever
+// spans one. A `\s`-based class stitches two unrelated cells into a single
+// match: `100\t000\t0001` reads as a UK NHS number, `09.93009\t2026` as a
+// phone number.
+//
+// That is worse than an ordinary false positive for checksum-backed entities.
+// digitValues ignores every non-digit byte, so a bridged run still passes its
+// checksum, and analyzer.PatternRecognizer.Analyze then promotes any
+// validator-passing match to analyzer.MaxScore — a 1.000 that clears every
+// caller threshold and masks the wrong bytes unconditionally.
+//
+// Filtering boundary-crossing spans after the fact is not an option: on
+// "count\t1\t415-555-2671" the greedy match is "1\t415-555-2671", so dropping
+// the span would discard a real phone number. The separator class is the only
+// place where the distinction can be drawn without losing the true positive.
+//
+// Zs is preferred over a bare literal space because it keeps the real values
+// that carry a non-breaking or narrow no-break space — common when a number is
+// pasted out of a web page or formatted for a European locale — while still
+// excluding everything vertical.
+const hsp = `\p{Zs}`

--- a/recognizers/separators_test.go
+++ b/recognizers/separators_test.go
@@ -1,0 +1,225 @@
+package recognizers
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/alcatraz/analyzer"
+)
+
+// psqlOutput is a tab-separated database result of the shape alcatraz sees
+// when a caller streams query output through it. Every value in it is
+// synthetic, and none of them is a phone number — but before separator classes
+// were narrowed to hsp, four spans were reported anyway, each stitched out of
+// two adjacent cells (`417768` + `2026`, `09.93009` + `2026`, ...).
+const psqlOutput = "session_id\tyear\tuser_name\tuser_email\tstarted_at\tduration_ms\n" +
+	"417768\t2026\tLuan\tluan@example.com\t13:45:09.93009\t2026\n" +
+	"417769\t2026\tMaria\tmaria@example.com\t09:12:31.44021\t1204\n"
+
+// boundary reports the spans of results that contain a tab, a newline or a
+// carriage return — that is, spans stitched across a column or row boundary.
+func boundary(text string, results []analyzer.Result) []string {
+	var out []string
+	for _, r := range results {
+		if s := text[r.Start:r.End]; strings.ContainsAny(s, "\t\n\r") {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestPsqlFixtureExercisesTheBug keeps the fixture honest. If a future edit
+// makes psqlOutput stop reproducing the original defect, the invariant tests
+// below would still pass while testing nothing, so assert here that the
+// pre-fix pattern really does stitch cells together on it.
+func TestPsqlFixtureExercisesTheBug(t *testing.T) {
+	// The Phone (BR) pattern exactly as it read before the fix: `\s` where
+	// hsp now is.
+	before := regexp.MustCompile(
+		`(?:^|\W)((?:\+?55[\s.-]?)?(?:\(\d{2}\)|\d{2})[\s.-]?9?\d{4}[\s.-]?\d{4})\b`)
+
+	var crossed []string
+	for _, m := range before.FindAllStringSubmatch(psqlOutput, -1) {
+		if strings.ContainsAny(m[1], "\t\n\r") {
+			crossed = append(crossed, m[1])
+		}
+	}
+	if len(crossed) == 0 {
+		t.Fatal("psqlOutput no longer reproduces the cross-column defect; " +
+			"the invariant tests below would pass vacuously")
+	}
+	t.Logf("pre-fix pattern stitched %d cross-cell matches: %q", len(crossed), crossed)
+}
+
+// TestNoDefaultRecognizerCrossesABoundary is the general invariant: no
+// built-in recognizer may ever report a span that contains a tab or a newline.
+// A tab is a column boundary and a newline is a row boundary; a single entity
+// value never spans one.
+func TestNoDefaultRecognizerCrossesABoundary(t *testing.T) {
+	texts := map[string]string{
+		"psql output": psqlOutput,
+		"tsv ids":     "a\tb\tc\td\n100\t000\t0001\t2026\n123\t456\t782\t99\n",
+		"row wrap":    "header\n100000\n0001\nfooter\n",
+		"letters":     "AB\t12\t34\t56\tC\tnext\n",
+		"aadhaar":     "w\tx\ty\tz\n2341\t2341\t2346\tq\n",
+		"iban":        "cc\tacct\nDE89\t3704 0044 0532 0130 00\n",
+		"dates":       "month\tday\tyear\nJanuary\t15,\t2024\nJan\t3\t2025\n",
+		"url":         "site\tnote\nhttps://a\tredacted\nwww.b\tredacted\n",
+		"medicare":    "a\tb\tc\n2123\t45670\t1\n",
+	}
+	for _, r := range All() {
+		for name, text := range texts {
+			if got := boundary(text, r.Analyze(text, nil)); len(got) != 0 {
+				t.Errorf("%s on %s reported boundary-crossing spans %q",
+					r.Name(), name, got)
+			}
+		}
+	}
+}
+
+// TestBridgedIdentifiersAreNotDetected covers each recognizer whose separator
+// class used to be built on `\s`. Every one of these used to be reported, and
+// the checksum-backed ones at score 1.000: digitValues ignores the tab, so the
+// checksum passed, and a passing validator is promoted to analyzer.MaxScore.
+func TestBridgedIdentifiersAreNotDetected(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  analyzer.Recognizer
+		text string
+	}{
+		{"nhs across columns", UKNHS(), "a\tb\tc\n943\t476\t5919\tz"},
+		{"nhs across rows", UKNHS(), "header\n943476\n5919\n"},
+		{"nino across columns", UKNINO(), "AB\t12\t34\t56\tC\tnext"},
+		{"tfn across columns", AUTFN(), "a\tb\tc\n123\t456\t782\tq"},
+		{"abn across columns", AUABN(), "a\tb\tc\td\n51\t824\t753\t556\tq"},
+		{"acn across columns", AUACN(), "a\tb\tc\n004\t085\t616\tq"},
+		{"medicare across columns", AUMedicare(), "a\tb\tc\n2123\t45670\t1\tz"},
+		{"aadhaar across columns", INAadhaar(), "x\ty\tz\n2341\t2341\t2346\tw"},
+		{"vehicle across columns", INVehicle(), "st\tno\n KA\t01\tAB\t1234\t"},
+		{"iban across columns", IBAN(), "cc\tv\nDE89\t3704\t0044\t0532\t0130\t00\t"},
+		{"us phone across columns", Phone(), "a\tb\tc\n415\t555\t2671\tz"},
+		{"br phone across columns", Phone(), "id\tyear\n417768\t2026\tz"},
+		{"intl phone across columns", Phone(), "cc\tnum\n+55\t11912345678\t"},
+		{"month date across columns", DateTime(), "m\td\ty\nJanuary\t15,\t2024\t"},
+		{"abbrev date across columns", DateTime(), "m\td\ty\nJan\t15,\t2024\t"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boundary(tt.text, tt.rec.Analyze(tt.text, nil)); len(got) != 0 {
+				t.Fatalf("%s.Analyze(%q) reported %q, want no boundary-crossing span",
+					tt.rec.Name(), tt.text, got)
+			}
+		})
+	}
+}
+
+// TestSpaceSeparatedIdentifiersStillDetected is the other half: narrowing the
+// class must not cost a single real value. These are the space-separated forms
+// of the same identifiers, and every checksum-backed one must still reach
+// MaxScore.
+func TestSpaceSeparatedIdentifiersStillDetected(t *testing.T) {
+	tests := []struct {
+		name  string
+		rec   analyzer.Recognizer
+		text  string
+		want  string
+		score float64
+	}{
+		{"nhs", UKNHS(), "nhs 943 476 5919 on file", "943 476 5919", analyzer.MaxScore},
+		{"nino", UKNINO(), "nino AB 12 34 56 C here", "AB 12 34 56 C", analyzer.MaxScore},
+		{"tfn", AUTFN(), "tfn 123 456 782 ok", "123 456 782", analyzer.MaxScore},
+		{"abn", AUABN(), "abn 51 824 753 556 ok", "51 824 753 556", analyzer.MaxScore},
+		{"acn", AUACN(), "acn 004 085 616 ok", "004 085 616", analyzer.MaxScore},
+		{"medicare", AUMedicare(), "medicare 2123 45670 1 ok", "2123 45670 1", analyzer.MaxScore},
+		{"aadhaar", INAadhaar(), "aadhaar 2341 2341 2346 ok", "2341 2341 2346", analyzer.MaxScore},
+		{"iban", IBAN(), "iban DE89 3704 0044 0532 0130 00 ok",
+			"DE89 3704 0044 0532 0130 00", analyzer.MaxScore},
+		{"month date", DateTime(), "born January 15, 2024 in Lisbon", "January 15, 2024", 0.8},
+		{"abbrev date", DateTime(), "born Jan 15, 2024 in Lisbon", "Jan 15, 2024", 0.7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			var score float64
+			for _, r := range tt.rec.Analyze(tt.text, nil) {
+				if s := tt.text[r.Start:r.End]; s == tt.want {
+					got, score = append(got, s), r.Score
+				}
+			}
+			if len(got) == 0 {
+				t.Fatalf("%s.Analyze(%q) did not report %q",
+					tt.rec.Name(), tt.text, tt.want)
+			}
+			if score != tt.score {
+				t.Fatalf("%s.Analyze(%q) scored %q at %.2f, want %.2f",
+					tt.rec.Name(), tt.text, tt.want, score, tt.score)
+			}
+		})
+	}
+}
+
+// TestNoBreakSpaceSeparatorsAreDetected is what hsp buys over a bare literal
+// space: values pasted out of a web page or formatted for a European locale
+// carry U+00A0 or U+202F between the groups, and they are still real values.
+func TestNoBreakSpaceSeparatorsAreDetected(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  analyzer.Recognizer
+		text string
+		want string
+	}{
+		{"nhs nbsp", UKNHS(), "nhs 943\u00a0476\u00a05919 ok", "943\u00a0476\u00a05919"},
+		{"tfn narrow nbsp", AUTFN(), "tfn 123\u202f456\u202f782 ok", "123\u202f456\u202f782"},
+		{"us phone nbsp", Phone(), "call 415\u00a0555\u00a02671 now", "415\u00a0555\u00a02671"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			for _, r := range tt.rec.Analyze(tt.text, nil) {
+				got = append(got, tt.text[r.Start:r.End])
+			}
+			for _, g := range got {
+				if g == tt.want {
+					return
+				}
+			}
+			t.Fatalf("%s.Analyze(%q) = %q, want it to contain %q",
+				tt.rec.Name(), tt.text, got, tt.want)
+		})
+	}
+}
+
+// TestPhoneAfterAColumnBoundaryKeepsTheRealNumber is why the fix belongs in
+// the separator class and not in a post-filter that drops boundary-crossing
+// spans. The greedy pre-fix match here was "1\t415-555-2671": discarding it
+// would have thrown away a real phone number along with the false positive.
+func TestPhoneAfterAColumnBoundaryKeepsTheRealNumber(t *testing.T) {
+	const text = "count\t1\t415-555-2671"
+	var got []string
+	for _, r := range Phone().Analyze(text, nil) {
+		got = append(got, text[r.Start:r.End])
+	}
+	if len(got) != 1 || got[0] != "415-555-2671" {
+		t.Fatalf("Phone().Analyze(%q) = %q, want [\"415-555-2671\"]", text, got)
+	}
+}
+
+// TestPsqlOutputKeepsItsRealEntities guards the recall side of the fixture:
+// narrowing the separator classes must not have cost the values that really
+// are there.
+func TestPsqlOutputKeepsItsRealEntities(t *testing.T) {
+	reg := analyzer.NewRegistry()
+	LoadDefaults(reg, "en")
+	eng := analyzer.NewEngine(reg, []string{"en"})
+
+	found := map[string]bool{}
+	for _, r := range eng.Analyze(psqlOutput, analyzer.Options{Language: "en"}) {
+		found[psqlOutput[r.Start:r.End]] = true
+	}
+	for _, want := range []string{"luan@example.com", "maria@example.com"} {
+		if !found[want] {
+			t.Errorf("engine no longer detects %q in the psql fixture", want)
+		}
+	}
+}

--- a/recognizers/uk.go
+++ b/recognizers/uk.go
@@ -11,7 +11,7 @@ import (
 func UKNHS() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"UkNhsRecognizer", entities.UKNHS, "en",
-		[]*analyzer.Pattern{analyzer.MustPattern("NHS Number", `\b\d{3}\s?\d{3}\s?\d{4}\b`, 0.6)},
+		[]*analyzer.Pattern{analyzer.MustPattern("NHS Number", `\b\d{3}`+hsp+`?\d{3}`+hsp+`?\d{4}\b`, 0.6)},
 	).WithContext("nhs", "health").WithValidator(validateNHS)
 }
 
@@ -37,7 +37,7 @@ func UKNINO() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"UkNinoRecognizer", entities.UKNINO, "en",
 		[]*analyzer.Pattern{analyzer.MustPattern("NINO",
-			`\b[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z]\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D]\b`, 0.7)},
+			`\b[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z]`+hsp+`?\d{2}`+hsp+`?\d{2}`+hsp+`?\d{2}`+hsp+`?[A-D]\b`, 0.7)},
 	).WithContext("nino", "national insurance").WithValidator(validateNINO)
 }
 


### PR DESCRIPTION
Closes ATR-207.

## The defect

Go's RE2 desugars `\s` to `[\t\n\f\r ]`. Every recognizer that wrote its
intra-identifier separator as `[\s.-]?` or `\s?` therefore matches straight
across a tab or a newline — a column boundary and a row boundary in the
tabular output alcatraz is routinely pointed at (psql results, TSV exports,
log tables). No identifier ever spans one.

Fifteen patterns across four files did this, and all fifteen are registered
in the default English engine (`LoadDefaults` registers `All()` under
whichever language is requested), so every caller was exposed. On a
1505-byte psql sample the analyzer reported two phone numbers that appear
nowhere in the data:

```
PHONE_NUMBER 0.500 "417768\t2026"      <- session_id + year
PHONE_NUMBER 0.500 "09.93009\t2026"    <- started_at + duration_ms
```

## Why the checksum-backed entities are worse

The phones surfaced first only because they are the ones without a
validator. `digitValues` in `recognizers/checksum.go` "returns the decimal
digits of s as integers, ignoring any other characters" — so a bridged run
launders its tab and passes the checksum, and
`analyzer.PatternRecognizer.Analyze` then promotes any validator-passing
match to `analyzer.MaxScore`. Measured on synthetic tabular text before this
change:

| entity | span | score |
| --- | --- | --- |
| `UK_NHS` | `100\t000\t0001` | 1.000 |
| `UK_NHS` | `100000\n0001` | 1.000 |
| `AU_TFN` | `100\t000\t001` | 1.000 |
| `AU_MEDICARE` | `2123\t45670\t1` | 1.000 |
| `UK_NINO` | `AB\t12\t34\t56\tC` | 1.000 |
| `IN_AADHAAR` | `1000\t0000\t0004` | 1.000 |

1.000 clears every threshold a caller can set, so those spans were masked
unconditionally — the analyzer redacting bytes that are not the entity it
named.

## The fix

`recognizers/separators.go` introduces one constant:

```go
const hsp = `\p{Zs}`
```

and every intra-identifier separator now uses it. Keeping the policy in a
single named place is the point: the next recognizer to be added reaches for
`hsp`, not for `\s`.

`Zs` rather than a bare literal space is deliberate — it keeps the real
values that carry U+00A0 or U+202F between groups, which is what you get
when a number is pasted out of a web page or formatted for a European
locale, while excluding everything vertical.

The `URL` pattern had the same problem via an unqualified `.` (which matches
a tab); it is narrowed to `[^\s]`.

`validateIBAN` already returned `false` on a tab through its `default`
branch, so IBAN was never promoted; its regex is narrowed for consistency,
not as a false-positive fix.

## Why not a post-filter

Dropping any span that contains a tab or a newline after the fact is
provably wrong. On `"count\t1\t415-555-2671"` the greedy pre-fix match is
`"1\t415-555-2671"` — discarding it turns a false positive into a
PII-leaking false negative. The separator class is the only place the
distinction can be drawn without losing the true positive. There is a test
for exactly this.

## Tests

`recognizers/separators_test.go`:

- **`TestNoDefaultRecognizerCrossesABoundary`** — the general invariant, over
  every recognizer in `All()` × nine tabular texts. This is what stops the
  bug from coming back in a recognizer that does not exist yet.
- **`TestBridgedIdentifiersAreNotDetected`** — 15 targeted cases, one per
  pattern that used to bridge, including NHS across a *row* boundary.
- **`TestSpaceSeparatedIdentifiersStillDetected`** — the recall half: the
  space-separated forms still match, and the checksum-backed ones still
  reach `MaxScore`. Fixtures reused from `validators_test.go`.
- **`TestNoBreakSpaceSeparatorsAreDetected`** — what `Zs` buys over a literal
  space.
- **`TestPhoneAfterAColumnBoundaryKeepsTheRealNumber`** — the post-filter
  counterexample above.
- **`TestPsqlFixtureExercisesTheBug`** — an anti-vacuity guard. It compiles
  the pre-fix `Phone (BR)` pattern inline and fails if the fixture ever stops
  reproducing the defect, so the invariant tests can never quietly pass by
  testing nothing. It logs:
  `pre-fix pattern stitched 3 cross-cell matches: ["417768\t2026" "09.93009\t2026" "417769\t2026"]`
- **`TestPsqlOutputKeepsItsRealEntities`** — runs the real default engine and
  asserts both emails survive.

End-to-end on the original 1505-byte sample: 13 results → 11. The two false
positives are gone; every real entity (5 dates, 6 emails) is kept.

`gofmt -l` clean, `go vet ./recognizers/` clean, `go test ./...` green.
