### PR TITLE
fix(ner): report entity spans on word boundaries (ATR-206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ Design notes:
 - **Byte offsets, guaranteed.** Model spans are mapped back to byte offsets
   in the original text, so `text[r.Start:r.End] == r.Text` holds for NER
   results too, including multi-byte input.
+- **Whole words, guaranteed.** The model classifies subword tokens and can
+  tag only part of one — `Luan` comes back as `Lu` + `an`, each with its own
+  score, so a threshold can accept one half and leak the other. Spans are
+  grown to the word they sit inside and same-type spans that then touch are
+  unioned, so a caller never has to mask half a name.
 
 ### Running NER without internet access
 

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,19 @@ lives in a **separate module** so importers of the core never pull the dep.
       per **byte**, shifting all subsequent token spans on multi-byte input.
       File an issue/PR; once fixed upstream the ASCII-fold workaround can be
       retired.
+- [x] Word-boundary guarantee: spans are grown to the word they sit inside and
+      same-type spans that then touch are unioned, so a subword split never
+      reaches a caller as half a name (`ner/words.go`).
+- [ ] Upstream: hugot `getGoTokens` (`backends/tokenizer_go.go`) decodes each
+      token id on its own, and the WordPiece decoder is configured with
+      `cleanup: true`, so the `##` marker is stripped before
+      `gatherPreEntities` compares token length to the source slice. `isSubword`
+      is therefore always false on `BackendGo` and every word-aggregating
+      strategy (FIRST/MAX/AVERAGE) is inert there — the Rust tokenizer path
+      keeps the marker and works. File an issue/PR (decode the batch in one
+      call, or keep the raw tokens alongside the ids). Independently, SIMPLE
+      aggregation never consults `isSubword` at all and splits on every `B-`
+      tag, so `ner/words.go` stays either way.
 - [x] `pfilter` module (separate module): privacy-filter.cpp backend over
       purego FFI (no cgo — cross-compiles everywhere; the dlopen path builds
       on 64-bit darwin/linux, everything else gets a clean "unsupported" stub).

--- a/TODO.md
+++ b/TODO.md
@@ -42,15 +42,17 @@ lives in a **separate module** so importers of the core never pull the dep.
       same-type spans that then touch are unioned, so a subword split never
       reaches a caller as half a name (`ner/words.go`).
 - [ ] Upstream: hugot `getGoTokens` (`backends/tokenizer_go.go`) decodes each
-      token id on its own, and the WordPiece decoder is configured with
-      `cleanup: true`, so the `##` marker is stripped before
-      `gatherPreEntities` compares token length to the source slice. `isSubword`
-      is therefore always false on `BackendGo` and every word-aggregating
-      strategy (FIRST/MAX/AVERAGE) is inert there — the Rust tokenizer path
-      keeps the marker and works. File an issue/PR (decode the batch in one
-      call, or keep the raw tokens alongside the ids). Independently, SIMPLE
-      aggregation never consults `isSubword` at all and splits on every `B-`
-      tag, so `ner/words.go` stays either way.
+      token id on its own, so the WordPiece decoder strips the `##` marker
+      before `gatherPreEntities` compares token length to the source slice.
+      `isSubword` is therefore always false on `BackendGo` and every
+      word-aggregating strategy (FIRST/MAX/AVERAGE) is inert there — all four
+      strategies return byte-identical output, silently. The Rust tokenizer
+      path does not go through `getGoTokens` and keeps the marker. Reported as
+      [knights-analytics/hugot#136](https://github.com/knights-analytics/hugot/issues/136)
+      (fix: decode the batch in one call, or keep the raw tokens alongside the
+      ids); nothing here waits on it. Independently, SIMPLE aggregation never
+      consults `isSubword` at all and splits on every `B-` tag, so
+      `ner/words.go` stays either way.
 - [x] `pfilter` module (separate module): privacy-filter.cpp backend over
       purego FFI (no cgo — cross-compiles everywhere; the dlopen path builds
       on 64-bit darwin/linux, everything else gets a clean "unsupported" stub).

--- a/ner/bench_test.go
+++ b/ner/bench_test.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/entities"
 )
 
 // BenchmarkLiveProcessTexts measures end-to-end batched inference throughput
@@ -64,5 +67,25 @@ func BenchmarkLiveProcessTexts(b *testing.B) {
 		if _, err := nlp.ProcessTexts(texts, "en"); err != nil {
 			b.Fatalf("ProcessTexts: %v", err)
 		}
+	}
+}
+
+// BenchmarkSnapToWordsOpaqueBlob pins the cost of snapping a span stranded
+// inside a long run of word runes — a base64 payload or an opaque identifier,
+// where there is no word boundary to find. wordBounds gives up after
+// maxWordChars runes, so the time is a function of the cap and not of the
+// blob: walking to the ends of a 4 MiB run first cost 17ms per span, against
+// under a microsecond now. Needs no model, so it runs unconditionally.
+func BenchmarkSnapToWordsOpaqueBlob(b *testing.B) {
+	text := strings.Repeat("a", 4<<20)
+	span := analyzer.NerSpan{EntityType: entities.Person, Start: 1000, End: 1010, Score: 0.9}
+	// snapToWords writes through its input slice, so each iteration needs a
+	// fresh copy or it would measure the second pass over a snapped span.
+	spans := make([]analyzer.NerSpan, 1)
+	b.ReportAllocs()
+	for b.Loop() {
+		spans = spans[:1]
+		spans[0] = span
+		snapToWords(text, spans)
 	}
 }

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -37,9 +37,17 @@
 // library at runtime (on macOS, "brew install onnxruntime" is found
 // automatically; elsewhere set Config.ORTLibraryPath). Selecting a backend
 // that is not compiled in makes New fail with an error saying which build
-// tag is missing, so a pure-Go binary degrades loudly, not silently. The
-// whole pipeline — windowing, batching, span merging — behaves identically
-// on every backend.
+// tag is missing, so a pure-Go binary degrades loudly, not silently.
+//
+// Everything this package does around the model — windowing, batching,
+// fold-offset remapping, span merging and word snapping — is backend
+// independent, and the spans it returns satisfy the same guarantees on every
+// backend. The model's own tokenization does not: hugot's pure-Go tokenizer
+// decodes each token id in isolation, which erases the WordPiece "##" marker
+// and leaves its subword detection permanently false, so the upstream
+// word-aggregating strategies are inert under BackendGo. That is why
+// snapToWords (words.go) is applied unconditionally rather than delegated to
+// the pipeline; see its doc comment.
 //
 // # Getting the model
 //
@@ -308,6 +316,10 @@ func (e *Engine) ProcessText(text, language string) (*analyzer.NlpArtifacts, err
 // Texts longer than the model's token limit are split into overlapping
 // windows (see windows.go) and their spans merged, so entities anywhere in a
 // text of any length are detected — they are never truncated away.
+//
+// Spans are reported on word boundaries: the model tags subword tokens and
+// can hand back half of one, so every span is grown to the word it sits
+// inside and same-type spans that then touch are unioned (see words.go).
 func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpArtifacts, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -371,11 +383,13 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 	}
 
 	// Overlapping windows can report the same entity twice; single-window
-	// texts need no merge.
+	// texts need no merge. Word snapping applies to every text: the model
+	// splits words into subword tokens and can tag only part of one.
 	for i, a := range artifacts {
 		if windowed[i] {
 			a.Ents = mergeSpans(a.Ents)
 		}
+		a.Ents = snapToWords(texts[i], a.Ents)
 	}
 	return artifacts, nil
 }

--- a/ner/words.go
+++ b/ner/words.go
@@ -1,0 +1,141 @@
+package ner
+
+import (
+	"sort"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hoophq/alcatraz/analyzer"
+)
+
+// maxWordChars bounds how far snapToWords will grow a span at one edge.
+//
+// It is WordPiece's max_input_chars_per_word, 100 in the pinned model's
+// tokenizer.json and the default in every BERT tokenizer config. A word longer
+// than that is never split into subwords — the tokenizer emits a single [UNK]
+// covering the whole word — so a span edge stranded inside a word can only
+// ever be inside a run of at most 100 characters. Refusing to extend across a
+// longer run therefore costs nothing real, and it stops a stray span inside a
+// base64 blob or a long opaque identifier from growing into a mask over
+// thousands of bytes.
+const maxWordChars = 100
+
+// wordRune reports whether r can appear inside a tokenizer word.
+//
+// Letters and digits only. '_' and '-' are deliberately excluded: BERT's
+// pre-tokenizer splits on punctuation, so `user_name` and `Jean-Pierre` are
+// several words to the model, and treating them as one would let a span over
+// `name` swallow `user_`, or a span over one half of a hyphenated name swallow
+// the other half the model deliberately left untagged.
+func wordRune(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }
+
+// wordStart returns the first byte of the maximal run of word runes ending at
+// byte offset i, which is i itself when the preceding rune is not a word rune.
+func wordStart(s string, i int) int {
+	for i > 0 {
+		r, n := utf8.DecodeLastRuneInString(s[:i])
+		if !wordRune(r) {
+			break
+		}
+		i -= n
+	}
+	return i
+}
+
+// wordEnd returns the byte just past the maximal run of word runes starting at
+// byte offset i, which is i itself when the rune at i is not a word rune.
+func wordEnd(s string, i int) int {
+	for i < len(s) {
+		r, n := utf8.DecodeRuneInString(s[i:])
+		if !wordRune(r) {
+			break
+		}
+		i += n
+	}
+	return i
+}
+
+// snapToWords grows every span out to the word boundaries it sits inside and
+// unions same-type spans that then touch or overlap. Scores are combined by
+// taking the maximum.
+//
+// A span that begins or ends in the middle of a word is never a usable answer
+// from a redactor. The rest of the word stays in the clear — on
+// "Bandar Seri Begawan" the model reports "andar Seri Begawa", so masking
+// leaves "B<PERSON>n" and the reader recovers the name. The span cannot be
+// allow-listed or pseudonymized either, because it is not the value anyone
+// would write down. And each fragment carries its own score, so a caller
+// threshold can accept one half of a name and reject the other: "Luan" in
+// tabular context scores 0.81 on "Lu" and 0.58 on "an", and at a threshold of
+// 0.6 exactly half the name is masked.
+//
+// Mid-word spans arise because the model tags WordPiece tokens, not words, and
+// hugot's SIMPLE aggregation starts a new group at every B- tag — so a name
+// split into "Lu" + "##an" and tagged B-PER twice comes back as two entities.
+// The word-aggregating strategies (FIRST/MAX/AVERAGE) exist upstream to solve
+// exactly this, but they are inert on the pure-Go backend: see the note on
+// Config.Backend. Snapping here is not a substitute for that. It is a property
+// of what this package promises its callers — byte spans over their text, on
+// value boundaries — and it holds on every backend, including the ones where
+// the upstream aggregation works.
+//
+// Growth is bounded at maxWordChars per edge and never crosses a non-word
+// rune, so a span can only ever expand within the single word it was already
+// inside. text must be the exact string the spans index into.
+func snapToWords(text string, spans []analyzer.NerSpan) []analyzer.NerSpan {
+	if len(spans) == 0 {
+		return spans
+	}
+
+	for i := range spans {
+		s := &spans[i]
+		if s.Start < 0 || s.End > len(text) || s.Start >= s.End {
+			continue // malformed; leave it exactly as it is
+		}
+		// Only grow an edge that is genuinely mid-word: the rune inside the
+		// span and the rune outside it must both be word runes.
+		if first, _ := utf8.DecodeRuneInString(text[s.Start:]); wordRune(first) {
+			if start := wordStart(text, s.Start); start != s.Start {
+				if run := text[start:wordEnd(text, s.Start)]; utf8.RuneCountInString(run) <= maxWordChars {
+					s.Start = start
+				}
+			}
+		}
+		if last, _ := utf8.DecodeLastRuneInString(text[:s.End]); wordRune(last) {
+			if end := wordEnd(text, s.End); end != s.End {
+				if run := text[wordStart(text, s.End):end]; utf8.RuneCountInString(run) <= maxWordChars {
+					s.End = end
+				}
+			}
+		}
+	}
+
+	// Stable: two spans of different types can snap to the exact same word,
+	// and callers should not see them swap order run to run.
+	sort.SliceStable(spans, func(i, j int) bool {
+		if spans[i].Start != spans[j].Start {
+			return spans[i].Start < spans[j].Start
+		}
+		return spans[i].End > spans[j].End
+	})
+
+	// last[type] indexes the running union of that type in out. Spans arrive
+	// in ascending Start order, so any span that touches an earlier one of its
+	// type also touches that union.
+	last := map[string]int{}
+	out := spans[:0]
+	for _, s := range spans {
+		if i, ok := last[s.EntityType]; ok && s.Start <= out[i].End {
+			if s.End > out[i].End {
+				out[i].End = s.End
+			}
+			if s.Score > out[i].Score {
+				out[i].Score = s.Score
+			}
+			continue
+		}
+		out = append(out, s)
+		last[s.EntityType] = len(out) - 1
+	}
+	return out
+}

--- a/ner/words.go
+++ b/ner/words.go
@@ -22,37 +22,57 @@ const maxWordChars = 100
 
 // wordRune reports whether r can appear inside a tokenizer word.
 //
-// Letters and digits only. '_' and '-' are deliberately excluded: BERT's
-// pre-tokenizer splits on punctuation, so `user_name` and `Jean-Pierre` are
-// several words to the model, and treating them as one would let a span over
-// `name` swallow `user_`, or a span over one half of a hyphenated name swallow
-// the other half the model deliberately left untagged.
-func wordRune(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }
-
-// wordStart returns the first byte of the maximal run of word runes ending at
-// byte offset i, which is i itself when the preceding rune is not a word rune.
-func wordStart(s string, i int) int {
-	for i > 0 {
-		r, n := utf8.DecodeLastRuneInString(s[:i])
-		if !wordRune(r) {
-			break
-		}
-		i -= n
-	}
-	return i
+// Letters, digits and combining marks. A mark belongs to the letter it sits
+// on: decomposed text reaches us from macOS exports and database dumps that
+// never normalized, and foldASCII renders one byte per rune, so the model
+// sees "n" and "x" where the text holds "n" + U+0301 and can tag the base
+// letter alone. Counting the mark as a boundary would end the span between a
+// letter and its own accent — masking NFD "Zieliński" then yields
+// "<PERSON>́ski", the leak this file exists to close.
+//
+// '_' and '-' are deliberately excluded: BERT's pre-tokenizer splits on
+// punctuation, so `user_name` and `Jean-Pierre` are several words to the
+// model, and treating them as one would let a span over `name` swallow
+// `user_`, or a span over one half of a hyphenated name swallow the other
+// half the model deliberately left untagged.
+func wordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.Is(unicode.M, r)
 }
 
-// wordEnd returns the byte just past the maximal run of word runes starting at
-// byte offset i, which is i itself when the rune at i is not a word rune.
-func wordEnd(s string, i int) int {
-	for i < len(s) {
-		r, n := utf8.DecodeRuneInString(s[i:])
+// wordBounds returns the maximal run of word runes spanning byte offset i:
+// the word runes immediately before i, and those from i onwards. Either half
+// may be empty, so a run of one word rune, or none at all, is a normal answer.
+//
+// ok is false when the run holds more than maxWordChars runes. That verdict
+// is reached after walking at most maxWordChars+1 of them, so the cost is
+// bounded by the cap rather than by the length of the run — a stray span
+// inside a megabyte-long base64 blob is refused without reading the blob.
+func wordBounds(s string, i int) (start, end int, ok bool) {
+	budget := maxWordChars
+	start, end = i, i
+	for start > 0 {
+		r, n := utf8.DecodeLastRuneInString(s[:start])
 		if !wordRune(r) {
 			break
 		}
-		i += n
+		if budget == 0 {
+			return i, i, false
+		}
+		budget--
+		start -= n
 	}
-	return i
+	for end < len(s) {
+		r, n := utf8.DecodeRuneInString(s[end:])
+		if !wordRune(r) {
+			break
+		}
+		if budget == 0 {
+			return i, i, false
+		}
+		budget--
+		end += n
+	}
+	return start, end, true
 }
 
 // snapToWords grows every span out to the word boundaries it sits inside and
@@ -93,19 +113,17 @@ func snapToWords(text string, spans []analyzer.NerSpan) []analyzer.NerSpan {
 			continue // malformed; leave it exactly as it is
 		}
 		// Only grow an edge that is genuinely mid-word: the rune inside the
-		// span and the rune outside it must both be word runes.
+		// span and the rune outside it must both be word runes. The guards
+		// establish the inside rune — without them a span ending just after a
+		// space would grow forward into the next word.
 		if first, _ := utf8.DecodeRuneInString(text[s.Start:]); wordRune(first) {
-			if start := wordStart(text, s.Start); start != s.Start {
-				if run := text[start:wordEnd(text, s.Start)]; utf8.RuneCountInString(run) <= maxWordChars {
-					s.Start = start
-				}
+			if start, _, ok := wordBounds(text, s.Start); ok {
+				s.Start = start
 			}
 		}
 		if last, _ := utf8.DecodeLastRuneInString(text[:s.End]); wordRune(last) {
-			if end := wordEnd(text, s.End); end != s.End {
-				if run := text[wordStart(text, s.End):end]; utf8.RuneCountInString(run) <= maxWordChars {
-					s.End = end
-				}
+			if _, end, ok := wordBounds(text, s.End); ok {
+				s.End = end
 			}
 		}
 	}

--- a/ner/words_test.go
+++ b/ner/words_test.go
@@ -1,0 +1,420 @@
+package ner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+// render formats spans as "TYPE:text" so a test case can state what it wants
+// to see rather than a table of byte offsets.
+func render(text string, spans []analyzer.NerSpan) []string {
+	out := make([]string, len(spans))
+	for i, s := range spans {
+		out[i] = fmt.Sprintf("%s:%s", s.EntityType, text[s.Start:s.End])
+	}
+	return out
+}
+
+func person(start, end int, score float64) analyzer.NerSpan {
+	return analyzer.NerSpan{EntityType: entities.Person, Start: start, End: end, Score: score}
+}
+
+func TestSnapToWords(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		text  string
+		spans []analyzer.NerSpan
+		want  []string
+	}{{
+		name:  "left edge inside a word",
+		text:  "Bandar",
+		spans: []analyzer.NerSpan{person(1, 6, 0.9)},
+		want:  []string{"PERSON:Bandar"},
+	}, {
+		name:  "right edge inside a word",
+		text:  "Begawan",
+		spans: []analyzer.NerSpan{person(0, 6, 0.9)},
+		want:  []string{"PERSON:Begawan"},
+	}, {
+		name:  "both edges inside a word",
+		text:  "Bandar Seri Begawan",
+		spans: []analyzer.NerSpan{person(1, 18, 0.9)},
+		want:  []string{"PERSON:Bandar Seri Begawan"},
+	}, {
+		name:  "adjacent subwords are unioned",
+		text:  "Luan",
+		spans: []analyzer.NerSpan{person(0, 2, 0.81), person(2, 4, 0.58)},
+		want:  []string{"PERSON:Luan"},
+	}, {
+		name:  "three subwords are unioned",
+		text:  "Nguyen Thi Hoa",
+		spans: []analyzer.NerSpan{person(0, 2, 0.9), person(2, 4, 0.9), person(4, 14, 0.9)},
+		want:  []string{"PERSON:Nguyen Thi Hoa"},
+	}, {
+		name:  "overlapping spans are unioned",
+		text:  "Ouagadougou",
+		spans: []analyzer.NerSpan{person(0, 7, 0.9), person(5, 11, 0.9)},
+		want:  []string{"PERSON:Ouagadougou"},
+	}, {
+		name: "different types are kept apart",
+		text: "Luan",
+		spans: []analyzer.NerSpan{
+			person(0, 2, 0.9),
+			{EntityType: entities.Location, Start: 2, End: 4, Score: 0.7},
+		},
+		want: []string{"PERSON:Luan", "LOCATION:Luan"},
+	}, {
+		name:  "separate words are not unioned",
+		text:  "Alice Bob",
+		spans: []analyzer.NerSpan{person(0, 5, 0.9), person(6, 9, 0.9)},
+		want:  []string{"PERSON:Alice", "PERSON:Bob"},
+	}, {
+		// An underscore is a word boundary to BERT's pre-tokenizer, so it is
+		// one here: a span over the value must not swallow the column name.
+		name:  "underscore is not crossed",
+		text:  "user_name",
+		spans: []analyzer.NerSpan{person(5, 7, 0.9)},
+		want:  []string{"PERSON:name"},
+	}, {
+		name:  "hyphen is not crossed",
+		text:  "Jean-Pierre",
+		spans: []analyzer.NerSpan{person(5, 8, 0.9)},
+		want:  []string{"PERSON:Pierre"},
+	}, {
+		name:  "apostrophe is not crossed",
+		text:  "O'Brien",
+		spans: []analyzer.NerSpan{person(2, 5, 0.9)},
+		want:  []string{"PERSON:Brien"},
+	}, {
+		name:  "email local part is not swallowed",
+		text:  "luan@example.com",
+		spans: []analyzer.NerSpan{person(5, 9, 0.9)},
+		want:  []string{"PERSON:example"},
+	}, {
+		name:  "tab is not crossed",
+		text:  "417768\tLuan",
+		spans: []analyzer.NerSpan{person(7, 9, 0.9)},
+		want:  []string{"PERSON:Luan"},
+	}, {
+		name:  "spans already on boundaries are untouched",
+		text:  "John Smith lives here",
+		spans: []analyzer.NerSpan{person(0, 10, 0.9)},
+		want:  []string{"PERSON:John Smith"},
+	}, {
+		name:  "trailing punctuation is not absorbed",
+		text:  "Hello Smith, goodbye",
+		spans: []analyzer.NerSpan{person(6, 9, 0.9)},
+		want:  []string{"PERSON:Smith"},
+	}, {
+		// "Zieliński": the n-acute is two bytes, so a naive byte walk would
+		// land mid-rune. [0:5] is "Zieli", [5:10] is "ński".
+		name:  "multi-byte rune before the edge",
+		text:  "Zieliński",
+		spans: []analyzer.NerSpan{person(0, 5, 0.9)},
+		want:  []string{"PERSON:Zieliński"},
+	}, {
+		name:  "multi-byte rune after the edge",
+		text:  "Zieliński",
+		spans: []analyzer.NerSpan{person(5, 10, 0.9)},
+		want:  []string{"PERSON:Zieliński"},
+	}, {
+		name:  "digits are word runes",
+		text:  "417768",
+		spans: []analyzer.NerSpan{person(0, 3, 0.9)},
+		want:  []string{"PERSON:417768"},
+	}, {
+		name:  "no spans",
+		text:  "nothing here",
+		spans: nil,
+		want:  nil,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := render(tc.text, snapToWords(tc.text, tc.spans))
+			if !equalStrings(got, tc.want) {
+				t.Errorf("snapToWords = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSnapToWordsUsesTheHighestScore records that a union keeps the score of
+// its most confident part. Taking the minimum would let one weak subword pull
+// a whole confident name below a caller's threshold — the failure this fix
+// exists to prevent, reintroduced from the other side.
+func TestSnapToWordsUsesTheHighestScore(t *testing.T) {
+	text := "Luan"
+	got := snapToWords(text, []analyzer.NerSpan{person(0, 2, 0.8138), person(2, 4, 0.5778)})
+	if len(got) != 1 {
+		t.Fatalf("got %d spans, want 1: %q", len(got), render(text, got))
+	}
+	if got[0].Score != 0.8138 {
+		t.Errorf("score = %v, want 0.8138", got[0].Score)
+	}
+}
+
+// TestSnapToWordsBoundsGrowth pins the maxWordChars cap. WordPiece emits a
+// word longer than max_input_chars_per_word as a single [UNK], so no subword
+// split can exist inside one — extending across it would only ever turn a
+// stray span inside an opaque blob into a mask over the whole blob.
+func TestSnapToWordsBoundsGrowth(t *testing.T) {
+	t.Run("a word at the cap is snapped", func(t *testing.T) {
+		text := strings.Repeat("a", maxWordChars)
+		got := snapToWords(text, []analyzer.NerSpan{person(10, 20, 0.9)})
+		if len(got) != 1 || got[0].Start != 0 || got[0].End != len(text) {
+			t.Errorf("got %v, want one span covering [0:%d]", got, len(text))
+		}
+	})
+
+	t.Run("a longer word is left alone", func(t *testing.T) {
+		text := strings.Repeat("a", maxWordChars+1)
+		got := snapToWords(text, []analyzer.NerSpan{person(10, 20, 0.9)})
+		if len(got) != 1 || got[0].Start != 10 || got[0].End != 20 {
+			t.Errorf("got %v, want the span unchanged at [10:20]", got)
+		}
+	})
+
+	t.Run("the cap counts runes, not bytes", func(t *testing.T) {
+		// 60 two-byte runes: 120 bytes, 60 characters, so under the cap.
+		text := strings.Repeat("é", 60)
+		got := snapToWords(text, []analyzer.NerSpan{person(20, 40, 0.9)})
+		if len(got) != 1 || got[0].Start != 0 || got[0].End != len(text) {
+			t.Errorf("got %v, want one span covering [0:%d]", got, len(text))
+		}
+	})
+}
+
+// TestSnapToWordsLeavesMalformedSpansAlone: an out-of-range span means a bug
+// upstream of here. Snapping would index out of bounds; silently dropping it
+// would hide the bug and unmask whatever it covered.
+func TestSnapToWordsLeavesMalformedSpansAlone(t *testing.T) {
+	text := "Luan"
+	for _, s := range []analyzer.NerSpan{
+		person(-1, 2, 0.9),
+		person(0, 99, 0.9),
+		person(3, 3, 0.9),
+		person(3, 1, 0.9),
+	} {
+		got := snapToWords(text, []analyzer.NerSpan{s})
+		if len(got) != 1 || got[0] != s {
+			t.Errorf("snapToWords(%v) = %v, want it unchanged", s, got)
+		}
+	}
+}
+
+func TestSnapToWordsIsIdempotent(t *testing.T) {
+	text := "Bandar Seri Begawan lives at user_name\tLuan"
+	once := snapToWords(text, []analyzer.NerSpan{
+		person(1, 18, 0.9), person(33, 35, 0.7), person(39, 41, 0.6), person(41, 43, 0.5),
+	})
+	twice := snapToWords(text, append([]analyzer.NerSpan(nil), once...))
+	if !equalStrings(render(text, once), render(text, twice)) {
+		t.Errorf("second pass changed the result: %q then %q",
+			render(text, once), render(text, twice))
+	}
+}
+
+// TestObservedSubwordSplitsBecomeWholeWords replays the exact spans the live
+// model returned during the ATR-206 investigation (distilbert-NER on the
+// pure-Go backend, SIMPLE aggregation). It is the non-vacuous core of this
+// file: the unit cases above prove snapToWords does what it says, and these
+// prove that what it says is what the model's output actually needs.
+//
+// Measured with ALCATRAZ_NER_LIVE against KnightsAnalytics/distilbert-NER.
+func TestObservedSubwordSplitsBecomeWholeWords(t *testing.T) {
+	for _, tc := range []struct {
+		text  string
+		spans []analyzer.NerSpan // as reported by the model
+		want  []string
+	}{{
+		// Two B-PER tags on one word: hugot's SIMPLE aggregation starts a new
+		// group at every B-, so "Lu" + "##an" comes back as two entities.
+		text:  "Luan",
+		spans: []analyzer.NerSpan{person(0, 2, 0.9949), person(2, 4, 0.9912)},
+		want:  []string{"PERSON:Luan"},
+	}, {
+		// The same name in tabular context, where the scores diverge enough
+		// that a 0.6 threshold keeps "Lu" and drops "an" — half a name masked.
+		text:  "user_name\nLuan\n",
+		spans: []analyzer.NerSpan{person(10, 12, 0.8138), person(12, 14, 0.5778)},
+		want:  []string{"PERSON:Luan"},
+	}, {
+		text: "Nguyen Thi Hoa lives in Hanoi.",
+		spans: []analyzer.NerSpan{
+			person(0, 2, 0.99), person(2, 4, 0.99), person(4, 14, 0.99),
+			{EntityType: entities.Location, Start: 24, End: 27, Score: 0.99},
+			{EntityType: entities.Location, Start: 27, End: 29, Score: 0.99},
+		},
+		want: []string{"PERSON:Nguyen Thi Hoa", "LOCATION:Hanoi"},
+	}, {
+		// The case merging alone cannot fix: the model tagged neither the
+		// leading "B" nor the trailing "n", so masking the reported span
+		// leaves "B<PERSON>n" and the reader recovers the name.
+		text:  "Bandar Seri Begawan",
+		spans: []analyzer.NerSpan{person(1, 18, 0.98)},
+		want:  []string{"PERSON:Bandar Seri Begawan"},
+	}} {
+		t.Run(strings.TrimSpace(tc.text), func(t *testing.T) {
+			// Anti-vacuity: the recorded spans must actually be broken, or
+			// this case is asserting nothing.
+			if equalStrings(render(tc.text, tc.spans), tc.want) {
+				t.Fatalf("recorded spans %q already equal the want; the case tests nothing",
+					render(tc.text, tc.spans))
+			}
+			got := render(tc.text, snapToWords(tc.text, tc.spans))
+			if !equalStrings(got, tc.want) {
+				t.Errorf("snapToWords = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// midWordEdges returns a description of every span edge that falls inside a
+// word — the property this fix exists to eliminate.
+func midWordEdges(text string, spans []analyzer.NerSpan) []string {
+	var bad []string
+	for _, s := range spans {
+		if s.Start > 0 {
+			before, _ := utf8.DecodeLastRuneInString(text[:s.Start])
+			first, _ := utf8.DecodeRuneInString(text[s.Start:])
+			if wordRune(before) && wordRune(first) {
+				bad = append(bad, fmt.Sprintf("%s start [%d] in %q", s.EntityType, s.Start, text[s.Start:s.End]))
+			}
+		}
+		if s.End < len(text) {
+			last, _ := utf8.DecodeLastRuneInString(text[:s.End])
+			after, _ := utf8.DecodeRuneInString(text[s.End:])
+			if wordRune(last) && wordRune(after) {
+				bad = append(bad, fmt.Sprintf("%s end [%d] in %q", s.EntityType, s.End, text[s.Start:s.End]))
+			}
+		}
+	}
+	return bad
+}
+
+// liveCorpus is deliberately heavy on names the WordPiece vocabulary does not
+// hold whole, plus the tabular shapes hoop streams through the analyzer.
+func liveCorpus() []string {
+	names := []string{
+		"Luan Lorenzo", "Nguyen Thi Hoa", "Wojciech Szczęsny", "Oluwaseun Adebayo",
+		"Xochitl Guadalupe", "Þórunn Sveinsdóttir", "Aoife Ó Súilleabháin",
+		"Thaddeus Kosciuszko", "Anastasiya Dziamidava", "Chidinma Okonkwo",
+		"Bandar Seri Begawan", "Ouagadougou", "Antananarivo", "Reykjavík",
+		"Thiruvananthapuram", "Ekaterinburg",
+	}
+	var texts []string
+	for _, n := range names {
+		texts = append(texts,
+			n,
+			"My name is "+n+" and I live here.",
+			"user_name\t"+n+"\n",
+			"id\tname\temail\n417768\t"+n+"\ta@b.com\n",
+		)
+	}
+	return texts
+}
+
+// TestLiveNoSpanEndsMidWord is the end-to-end half of ATR-206: over a corpus
+// built to provoke subword splits, no span the engine returns may start or end
+// inside a word. Gated behind ALCATRAZ_NER_LIVE=1 (downloads ~250MB on first
+// run); see TestLiveNER for the backend environment variables.
+func TestLiveNoSpanEndsMidWord(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
+	}
+	cfg := DefaultConfig()
+	cfg.Backend = os.Getenv("ALCATRAZ_NER_BACKEND")
+	cfg.ORTLibraryPath = os.Getenv("ALCATRAZ_NER_ORT_LIB")
+	cfg.Accelerator = os.Getenv("ALCATRAZ_NER_ACCELERATOR")
+
+	nlp, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer nlp.Close()
+
+	texts := liveCorpus()
+	arts, err := nlp.ProcessTexts(texts, "en")
+	if err != nil {
+		t.Fatalf("ProcessTexts: %v", err)
+	}
+
+	var total, rawSplit int
+	for i, text := range texts {
+		if bad := midWordEdges(text, arts[i].Ents); len(bad) > 0 {
+			t.Errorf("%q: span edges inside a word: %v", text, bad)
+		}
+		total += len(arts[i].Ents)
+		if raw := nlp.rawSpans(t, text); len(raw) > len(arts[i].Ents) {
+			rawSplit++
+		}
+	}
+	if total == 0 {
+		t.Fatal("the model found nothing in the whole corpus; the test proves nothing")
+	}
+	if rawSplit == 0 {
+		t.Log("the pipeline no longer splits words on this backend: snapToWords is " +
+			"now a safety net rather than a repair. Revisit the backend note in ner.go " +
+			"and whether the upstream aggregation strategy should be selected instead.")
+	} else {
+		t.Logf("%d/%d texts came back split before snapping", rawSplit, len(texts))
+	}
+
+	// The measured regression, asserted directly: "Luan" under a column
+	// header arrived as PERSON 0.8138 "Lu" and PERSON 0.5778 "an", so a 0.6
+	// threshold masked exactly half the name.
+	const tabular = "user_name\nLuan\n"
+	arts2, err := nlp.ProcessTexts([]string{tabular}, "en")
+	if err != nil {
+		t.Fatalf("ProcessTexts: %v", err)
+	}
+	var got []string
+	for _, s := range arts2[0].Ents {
+		if s.EntityType == entities.Person {
+			got = append(got, tabular[s.Start:s.End])
+		}
+	}
+	if !equalStrings(got, []string{"Luan"}) {
+		t.Errorf("PERSON spans in %q = %q, want [\"Luan\"]", tabular, got)
+	}
+}
+
+// rawSpans runs the pipeline the way ProcessTexts does but without merging or
+// snapping, so a live test can see what the model actually handed back.
+func (e *Engine) rawSpans(t *testing.T, text string) []analyzer.NerSpan {
+	t.Helper()
+	folded, foldOffsets := foldASCII(text)
+	out, err := e.pipeline.RunPipeline(e.runCtx, []string{folded})
+	if err != nil {
+		t.Fatalf("RunPipeline: %v", err)
+	}
+	var spans []analyzer.NerSpan
+	for _, ents := range out.Entities {
+		for _, ent := range ents {
+			if s, ok := e.toNerSpan(text, foldOffsets, ent); ok {
+				spans = append(spans, s)
+			}
+		}
+	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i].Start < spans[j].Start })
+	return spans
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/ner/words_test.go
+++ b/ner/words_test.go
@@ -131,6 +131,25 @@ func TestSnapToWords(t *testing.T) {
 		spans: []analyzer.NerSpan{person(0, 3, 0.9)},
 		want:  []string{"PERSON:417768"},
 	}, {
+		// Decomposed "Zieliński": the "ń" is "n" + U+0301, so [0:6] ends
+		// between the letter and its own accent. A combining mark is part of
+		// its word, so the span grows past it — otherwise masking yields
+		// "<PERSON>\u0301ski", the accent floating outside the mask and "ski"
+		// left in the clear. This is not a hypothetical input: foldASCII
+		// renders one byte per rune, so the model sees "Zielinxski" and can
+		// tag "Zielin" on its own.
+		name:  "combining mark is part of the word",
+		text:  "Zielin\u0301ski",
+		spans: []analyzer.NerSpan{person(0, 6, 0.9)},
+		want:  []string{"PERSON:Zielin\u0301ski"},
+	}, {
+		// The same shape at the other edge: [8:11] is "ski", and growing it
+		// leftwards must cross the mark rather than strand "Zielin".
+		name:  "combining mark is crossed leftwards",
+		text:  "Zielin\u0301ski",
+		spans: []analyzer.NerSpan{person(8, 11, 0.9)},
+		want:  []string{"PERSON:Zielin\u0301ski"},
+	}, {
 		name:  "no spans",
 		text:  "nothing here",
 		spans: nil,


### PR DESCRIPTION
Closes ATR-206.

Stacked conceptually on #23 (ATR-207) but independent — different files, no
conflicts.

## The defect

The model classifies WordPiece subword tokens, not words. hugot's SIMPLE
aggregation groups consecutive tokens by tag but starts a new group at every
`B-` tag, so a word split into `Lu` + `##an` and tagged `B-PER` twice comes
back as **two entities**. Each carries its own score:

```
"user_name\nLuan\n"  ->  PERSON 0.8138 "Lu"
                         PERSON 0.5778 "an"
```

At hoop's 0.6 profile threshold `"an"` is dropped and half the name streams
through in the clear. Even at threshold 0 the result is unusable: `"Lu"` is not
a value anyone can allow-list, pseudonymize, or audit.

## Why merging adjacent spans is not enough

Measured over a 135-text corpus of names the WordPiece vocabulary does not hold
whole (`/tmp/atr206`, real model, pure-Go backend):

```
135 texts | 261 in-word adjacent splits (merge fixes) | 18 partial-tag edges (merge does NOT fix)
```

The 18 are cases where the model tagged neither the first nor the last token of
the word:

| text | span reported | masked output |
| --- | --- | --- |
| `Bandar Seri Begawan` | `andar Seri Begawa` | `B<PERSON>n` |
| `Ouagadougou` | `uagadougo` | `O<LOCATION>u` |

The reader recovers the name from the leftovers. `Reykjavík`,
`Antananarivo`, `Þórunn Sveinsdóttir`, `Thaddeus Kosciuszko`,
`Aoife Ó Súilleabháin`, `Wojciech Szczęsny`, `Xochitl Guadalupe` and
`Oluwaseun Adebayo` all leak the same way. Extension to word boundaries is
required, not just merging.

## The fix

`ner/words.go` adds `snapToWords`, applied to every text in `ProcessTexts`
after the existing windowed `mergeSpans`: grow each span to the word run it
sits inside, then union same-type spans that touch or overlap, keeping the
highest score.

Three decisions worth stating:

- **A word rune is a letter or a digit.** `_`, `-` and `'` are deliberately
  excluded. BERT's pre-tokenizer splits on punctuation, so `user_name` is two
  words to the model — treating it as one would let a span over the value
  swallow the column name. `Jean-Pierre` and `O'Brien` still come back whole
  because the model tags the whole run; snapping just doesn't force it.
- **The highest score wins a union.** Taking the minimum would let one weak
  subword pull a confident name below a caller's threshold — the same failure
  from the other side. There is a test for it.
- **Growth is capped at 100 characters per edge.** That is WordPiece's
  `max_input_chars_per_word`, verified in the pinned model's `tokenizer.json`.
  A longer word is emitted as a single `[UNK]`, so no subword split can exist
  inside one; refusing to cross it costs nothing real and stops a stray span
  inside a base64 blob or a long opaque id from growing into a mask over the
  whole thing.

## This belongs upstream too — and separately

hugot's `getGoTokens` (`backends/tokenizer_go.go:151`) decodes each token id on
its own:

```go
tokens[i] = tokenizer.GoTokenizer.Tokenizer.Decode([]int{id})
```

The pinned model's decoder is `{"type":"WordPiece","prefix":"##","cleanup":true}`,
so the `##` marker is stripped before `gatherPreEntities` computes
`isSubword := len(word) != len(wordRef)`. **`isSubword` is therefore always
false on `BackendGo`**, and every word-aggregating strategy — FIRST, MAX,
AVERAGE — is inert there. The Rust tokenizer path keeps the marker and works.
That is a real upstream defect and it is tracked in `TODO.md` next to the
existing go-huggingface offset-table entry, for an issue/PR (decode the batch
in one call, or keep the raw tokens alongside the ids).

**It is not what this PR works around, though.** Two reasons:

1. SIMPLE aggregation never consults `isSubword` on *any* backend
   (`pipelines/tokenClassification.go:467` short-circuits before
   `aggregateWords`), and it splits on every `B-` tag. The split is not
   BackendGo-specific in origin.
2. Byte spans on value boundaries are what this package promises its callers.
   That guarantee is ours to keep on every backend, including the ones where
   upstream aggregation works.

So `snapToWords` stays after upstream lands. I did **not** switch to
`WithFirstAggregation()`: it is a byte-identical no-op on BackendGo today and
an untestable behavior change on ORT/Rust from this machine (needs `-tags ORT`
plus the native library). Once hugot is fixed, selecting it becomes a real
choice worth making on its own.

## Also

The package doc claimed "the whole pipeline — windowing, batching, span
merging — behaves identically on every backend." The surrounding code does; the
tokenizer does not. Corrected, with the reason.

## Tests

`ner/words_test.go`:

- **`TestSnapToWords`** — 19 table cases pinning the boundary rules: each edge
  in isolation, unions, different types kept apart, separate words *not*
  unioned, `_`/`-`/`'`/`@`/tab not crossed, multi-byte runes on both edges,
  trailing punctuation not absorbed.
- **`TestSnapToWordsBoundsGrowth`** — at the cap, past the cap, and that the
  cap counts runes rather than bytes.
- **`TestSnapToWordsUsesTheHighestScore`**, **`TestSnapToWordsIsIdempotent`**,
  **`TestSnapToWordsLeavesMalformedSpansAlone`** (an out-of-range span means a
  bug upstream of here — snapping would panic and dropping would hide it).
- **`TestObservedSubwordSplitsBecomeWholeWords`** — replays the exact spans
  distilbert-NER returned during the investigation, including the 0.8138/0.5778
  threshold case and `Bandar Seri Begawan`. Each case first asserts the
  recorded spans are *not* already correct, so it can never pass vacuously.
- **`TestLiveNoSpanEndsMidWord`** (`ALCATRAZ_NER_LIVE=1`) — over a 64-text
  corpus of hard names in bare, sentence and tabular forms, no span may start
  or end inside a word. It also runs the raw pipeline alongside and reports how
  many texts arrived split; if that ever reaches zero it logs that upstream
  appears fixed and points at the backend note, rather than failing.

Verification:

```
ALCATRAZ_NER_LIVE=1 go test ./...        # ner module, green
                                         #   46/64 texts came back split before snapping
```

With the `snapToWords` call commented out, the same live test fails on 46 of
the 64 texts. On the 135-text corpus: 261 splits and 18 partial edges → **0 and
0**, with `Alice Johnson` / `Bob Miller` / `Carol Davis` still three separate
spans and `Jean-Pierre Dubois`, `Saint-Denis`, `O'Brien`, `D'Angelo` unchanged.

`gofmt -l` clean, `go vet` clean, all five modules green.
