### PR TITLE
feat(ner): add Config.Segmentation for tabular and log input (ATR-205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,21 @@ id      org_id  connection  ...  user_email       user_name  user_email     ...
 ```
 
 `PERSON "Luan"` is found instantly on its own. As one blob, three rows of it
-yield **nothing**. The fix is not a better model — it is to stop asking the
-model to read the table as a sentence. `ner.Config.Segmentation` chooses what
-counts as one sequence:
+yield **nothing**. Ablating that input shows where the damage comes from:
+
+| Input | Names found |
+|---|---|
+| header + 3 rows | 0/3 |
+| 3 rows, no header | 2/3 |
+| 1 row alone | 1/1 |
+
+A tab-separated header is the worst single thing in there — 28 column names in
+a row is a sequence the model has no reading of, and it drags the rows after it
+down with it. Cross-row context costs the rest.
+
+The fix is not a better model — it is to stop asking the model to read the
+table as a sentence. `ner.Config.Segmentation` chooses what counts as one
+sequence:
 
 | Value | Cuts after | Recall | Cost |
 |---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -280,6 +280,53 @@ Design notes:
   in the original text, so `text[r.Start:r.End] == r.Text` holds for NER
   results too, including multi-byte input.
 
+### Tabular and log output: `Config.Segmentation`
+
+Transformer NER is context-sensitive by construction: a token's label depends
+on every other token in the sequence. That is what makes it good at prose and
+erratic on machine output. Feed it a 28-column `psql` row and the name sits
+among UUIDs, timestamps and JSON that no news-trained model has seen — and the
+whole row can come back empty:
+
+```
+id      org_id  connection  ...  user_email       user_name  user_email     ...
+8aa71f6d-…  8aa73e5c-…  postgres-demo  ...  luan@hoop.dev  Luan  luan@hoop.dev  ...
+```
+
+`PERSON "Luan"` is found instantly on its own. As one blob, three rows of it
+yield **nothing**. The fix is not a better model — it is to stop asking the
+model to read the table as a sentence. `ner.Config.Segmentation` chooses what
+counts as one sequence:
+
+| Value | Cuts after | Recall | Cost |
+|---|---|---|---|
+| `SegmentWhole` (default) | nothing — one sequence per text | 82% | 1.0x |
+| `SegmentLines` | `\n`, so each row or log line stands alone | 88% | 1.8x |
+| `SegmentFields` | `\n` and `\t`, so each cell stands alone | 94% | 4.3x |
+
+```go
+cfg := ner.DefaultConfig()
+cfg.Segmentation = ner.SegmentFields // tab-delimited query output
+```
+
+Measured on a corpus of generated `psql`/log output plus a real 28-column
+capture (286 planted names). Cost is inference calls: finer segmentation means
+more, shorter sequences.
+
+The default stays `SegmentWhole` because prose is the common case and finer
+segmentation cannot help it — a segment boundary is a hard context boundary, so
+an entity is never read across one, and `"Alice Johnson met Bob Miller in
+Paris"` scores identically either way. Callers streaming query results or logs
+should set `SegmentLines`, and `SegmentFields` when the output is
+tab-delimited and recall matters more than throughput. Only tab is treated as
+a field delimiter: comma and pipe occur inside names and prose, so cutting on
+them would fragment the free text this engine is mainly used on.
+
+Segmentation composes with windowing rather than replacing it — a segment
+longer than the token budget is still split into overlapping windows, so no
+input is truncated under any setting, and byte offsets survive the extra
+rebase (window → segment → text).
+
 ### Running NER without internet access
 
 By default `ner.New` downloads the model on first use — ~250 MiB from

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,16 @@ lives in a **separate module** so importers of the core never pull the dep.
       runtime-defined entity types without retraining. Needs custom span
       decoding against the ONNX graph (not a plain token-classification
       pipeline).
+- [ ] `Config.SegmentFields` only recognizes tab as a field delimiter, so
+      aligned psql/`column -t` output and pipe-delimited tables fall back to
+      line segmentation. Splitting those needs layout detection (a run of 2+
+      spaces is a delimiter only if the same columns line up across rows),
+      which is a different kind of guess from "cut on the byte that is already
+      there" — worth it only if callers hit it.
+- [ ] Under `SegmentFields` a wide table produces many short segments of very
+      uneven length, and a batch pads to its longest member. Sorting rows by
+      length before bucketing (and restoring order after) would cut the
+      padding waste that makes fields 4.3x rather than ~3x.
 
 ## Context-aware scoring (precision follow-up)
 

--- a/ner/config.go
+++ b/ner/config.go
@@ -24,6 +24,14 @@ const (
 	AcceleratorDirectML = "directml"
 )
 
+// Input segmentation rules selectable via Config.Segmentation. The zero value
+// means SegmentWhole. See Config.Segmentation for the recall/cost tradeoff.
+const (
+	SegmentWhole  = "whole"
+	SegmentLines  = "lines"
+	SegmentFields = "fields"
+)
+
 // Config configures the NER engine: which model to run and how its labels
 // map onto alcatraz entity types.
 //
@@ -143,6 +151,40 @@ type Config struct {
 	BatchBuckets []int
 	// SequenceBuckets is documented with BatchBuckets.
 	SequenceBuckets []int
+
+	// Segmentation selects what the model sees as one sequence. It exists
+	// because transformer NER is context-sensitive by construction: the same
+	// name scores differently depending on what surrounds it, and machine
+	// output (query results, logs) surrounds it with text no news-trained
+	// model has seen. Feeding a wide table in as one blob can drive recall to
+	// zero on names the model finds easily in isolation.
+	//
+	//   - SegmentWhole (default): one sequence per text, split only when it
+	//     exceeds the token budget (see BatchBuckets). Correct for prose.
+	//   - SegmentLines: cut after every newline, so each record — table row,
+	//     log line — is its own sequence.
+	//   - SegmentFields: cut after every newline and tab, so each cell of
+	//     tab-delimited output is its own sequence.
+	//
+	// Measured on a corpus of generated psql/log output plus a real 28-column
+	// psql capture (286 planted names), against the default model:
+	//
+	//   whole    82% recall   1.0x cost
+	//   lines    88% recall   1.8x cost
+	//   fields   94% recall   4.3x cost
+	//
+	// The cost is inference calls: finer segmentation means more, shorter
+	// sequences. The default stays SegmentWhole because prose is the common
+	// case and finer segmentation cannot help it — a segment boundary is a
+	// hard context boundary, so an entity is never read across one. Callers
+	// streaming tabular or log output should set SegmentLines, and
+	// SegmentFields when the output is tab-delimited and recall matters more
+	// than throughput.
+	//
+	// Segmentation composes with windowing: a segment longer than the token
+	// budget is still split into overlapping windows, so no input is
+	// truncated under any setting.
+	Segmentation string
 }
 
 // DefaultConfig returns a configuration matching Presidio's default NER

--- a/ner/config.go
+++ b/ner/config.go
@@ -174,7 +174,13 @@ type Config struct {
 	//   fields   94% recall   4.3x cost
 	//
 	// The cost is inference calls: finer segmentation means more, shorter
-	// sequences. The default stays SegmentWhole because prose is the common
+	// sequences — roughly one per non-blank line under SegmentLines and one
+	// per non-blank cell under SegmentFields. Those multipliers are corpus
+	// averages, not bounds: cost scales with line and cell count rather than
+	// byte count, so a very wide table costs more than the figure above and
+	// is worth measuring on your own output.
+	//
+	// The default stays SegmentWhole because prose is the common
 	// case and finer segmentation cannot help it — a segment boundary is a
 	// hard context boundary, so an entity is never read across one. Callers
 	// streaming tabular or log output should set SegmentLines, and

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -311,6 +311,47 @@ func (e *Engine) ProcessText(text, language string) (*analyzer.NlpArtifacts, err
 	return all[0], nil
 }
 
+// inferenceRow is one call to the model: one window of one segment of one
+// text, with the offset needed to rebase its spans onto the folded text.
+type inferenceRow struct {
+	textIdx int
+	offset  int // window start, in folded-text bytes
+	body    string
+}
+
+// inferenceRows expands texts into the rows the model will see: each folded
+// text is cut into segments (the caller's Config.Segmentation rule), layout-
+// only segments are dropped, and each surviving segment is windowed to the
+// token budget. A short unsegmented text — the common case — yields exactly
+// one row covering the whole text.
+//
+// The second result records, per text, that some segment needed more than one
+// window. That is the only way one text can report the same entity twice, so
+// it is the only case that needs mergeSpans: segments are disjoint, so their
+// spans never overlap.
+//
+// folded and foldOffsets come from foldASCII over texts, positionally.
+func (e *Engine) inferenceRows(texts, folded []string, foldOffsets [][]int) ([]inferenceRow, []bool) {
+	var rows []inferenceRow
+	windowed := make([]bool, len(texts))
+	for i := range texts {
+		for _, seg := range e.segments(folded[i]) {
+			if !hasWordRune(segmentText(texts[i], foldOffsets[i], seg)) {
+				continue
+			}
+			body := folded[i][seg.start:seg.end]
+			wins := e.windows(body)
+			if len(wins) > 1 {
+				windowed[i] = true
+			}
+			for _, w := range wins {
+				rows = append(rows, inferenceRow{i, seg.start + w.start, body[w.start:w.end]})
+			}
+		}
+	}
+	return rows, windowed
+}
+
 // ProcessTexts implements analyzer.BatchNlpEngine: it runs the model over all
 // texts in batched inference calls and returns one NlpArtifacts per text, in
 // input order. Batching amortizes the per-call tokenization and graph
@@ -336,34 +377,7 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 		folded[i], foldOffsets[i] = foldASCII(text)
 	}
 
-	// One inference row per window. Short unsegmented texts (the common case)
-	// produce exactly one row covering the whole text.
-	type inferenceRow struct {
-		textIdx int
-		offset  int // window start, in folded-text bytes
-		body    string
-	}
-	var rows []inferenceRow
-	// windowed[i] records that some segment of text i was split across
-	// several windows, which is the only way one text can report an entity
-	// twice. Segments cannot: they are disjoint, so their spans never
-	// overlap.
-	windowed := make([]bool, len(texts))
-	for i := range texts {
-		for _, seg := range e.segments(folded[i]) {
-			body := folded[i][seg.start:seg.end]
-			if !hasWordRune(body) {
-				continue
-			}
-			wins := e.windows(body)
-			if len(wins) > 1 {
-				windowed[i] = true
-			}
-			for _, w := range wins {
-				rows = append(rows, inferenceRow{i, seg.start + w.start, body[w.start:w.end]})
-			}
-		}
-	}
+	rows, windowed := e.inferenceRows(texts, folded, foldOffsets)
 
 	artifacts := make([]*analyzer.NlpArtifacts, len(texts))
 	for i := range texts {

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -179,10 +179,14 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	if len(cfg.SequenceBuckets) > 0 && cfg.SequenceBuckets[0] <= 0 {
 		return nil, fmt.Errorf("ner: SequenceBuckets entries must be positive, got %v", cfg.SequenceBuckets)
 	}
+	segmentation, err := normalizeSegmentation(cfg.Segmentation)
+	if err != nil {
+		return nil, fmt.Errorf("ner: %w", err)
+	}
+	cfg.Segmentation = segmentation
 
 	modelPath := cfg.ModelPath
 	if modelPath == "" {
-		var err error
 		modelPath, err = ensureModel(ctx, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("ner: obtaining model %s: %w", cfg.Model, err)
@@ -305,9 +309,11 @@ func (e *Engine) ProcessText(text, language string) (*analyzer.NlpArtifacts, err
 // overhead, so it is substantially faster than calling ProcessText in a loop;
 // the spans of each text carry the same byte-offset guarantee as ProcessText.
 //
-// Texts longer than the model's token limit are split into overlapping
-// windows (see windows.go) and their spans merged, so entities anywhere in a
-// text of any length are detected — they are never truncated away.
+// Each text is first split into segments — one by default, per line or per
+// field when Config.Segmentation asks for it — and each segment that exceeds
+// the model's token limit is split further into overlapping windows (see
+// windows.go), whose spans are merged. Entities anywhere in a text of any
+// length are detected; nothing is truncated away under any setting.
 func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpArtifacts, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -318,17 +324,32 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 		folded[i], foldOffsets[i] = foldASCII(text)
 	}
 
-	// One inference row per window. Short texts (the common case) produce
-	// exactly one row covering the whole text.
+	// One inference row per window. Short unsegmented texts (the common case)
+	// produce exactly one row covering the whole text.
 	type inferenceRow struct {
 		textIdx int
 		offset  int // window start, in folded-text bytes
 		body    string
 	}
 	var rows []inferenceRow
+	// windowed[i] records that some segment of text i was split across
+	// several windows, which is the only way one text can report an entity
+	// twice. Segments cannot: they are disjoint, so their spans never
+	// overlap.
+	windowed := make([]bool, len(texts))
 	for i := range texts {
-		for _, w := range e.windows(folded[i]) {
-			rows = append(rows, inferenceRow{i, w.start, folded[i][w.start:w.end]})
+		for _, seg := range e.segments(folded[i]) {
+			body := folded[i][seg.start:seg.end]
+			if !hasWordRune(body) {
+				continue
+			}
+			wins := e.windows(body)
+			if len(wins) > 1 {
+				windowed[i] = true
+			}
+			for _, w := range wins {
+				rows = append(rows, inferenceRow{i, seg.start + w.start, body[w.start:w.end]})
+			}
 		}
 	}
 
@@ -336,7 +357,6 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 	for i := range texts {
 		artifacts[i] = &analyzer.NlpArtifacts{}
 	}
-	windowed := make([]bool, len(texts))
 
 	for c := 0; c < len(rows); c += e.maxBatch {
 		chunk := rows[c:min(c+e.maxBatch, len(rows))]
@@ -353,11 +373,8 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 				break
 			}
 			row := chunk[j]
-			if row.offset > 0 {
-				windowed[row.textIdx] = true
-			}
 			for _, ent := range ents {
-				// Window-relative offsets → folded-text offsets; toNerSpan
+				// Row-relative offsets → folded-text offsets; toNerSpan
 				// then remaps folded → original text.
 				ent.Start += uint(row.offset)
 				ent.End += uint(row.offset)
@@ -370,8 +387,8 @@ func (e *Engine) ProcessTexts(texts []string, language string) ([]*analyzer.NlpA
 		}
 	}
 
-	// Overlapping windows can report the same entity twice; single-window
-	// texts need no merge.
+	// Overlapping windows can report the same entity twice; texts whose
+	// segments each fit one window need no merge.
 	for i, a := range artifacts {
 		if windowed[i] {
 			a.Ents = mergeSpans(a.Ents)

--- a/ner/ner.go
+++ b/ner/ner.go
@@ -332,7 +332,9 @@ type inferenceRow struct {
 //
 // folded and foldOffsets come from foldASCII over texts, positionally.
 func (e *Engine) inferenceRows(texts, folded []string, foldOffsets [][]int) ([]inferenceRow, []bool) {
-	var rows []inferenceRow
+	// Exactly right for SegmentWhole over texts that fit a window, which is
+	// the common case; a floor for the rest.
+	rows := make([]inferenceRow, 0, len(texts))
 	windowed := make([]bool, len(texts))
 	for i := range texts {
 		for _, seg := range e.segments(folded[i]) {

--- a/ner/segments.go
+++ b/ner/segments.go
@@ -18,6 +18,18 @@ package ner
 // Cutting on the delimiters the output already has removes that noise without
 // inventing any structure the caller has to describe.
 //
+// Ablating the reproduction fixture (three psql rows, one name each) shows
+// how much of that noise is which, under SegmentWhole:
+//
+//	header + 3 rows   0/3
+//	3 rows, no header 2/3
+//	1 row alone       1/1
+//
+// A tab-separated header is the single worst thing in the input — 28 column
+// names in a row is a sequence the model has no reading of, and it drags the
+// rows after it down with it. Cross-row context costs the rest. Segmentation
+// removes both, because both are context that was never really context.
+//
 // Segments partition the folded text: disjoint, in order, covering every
 // byte. That is what lets a window offset inside a segment be rebased onto
 // the text by adding the segment start, and it means concatenating the

--- a/ner/segments.go
+++ b/ner/segments.go
@@ -116,7 +116,24 @@ func isLineSep(b byte) bool { return b == '\n' }
 // into fields either.
 func isFieldSep(b byte) bool { return b == '\n' || b == '\t' }
 
-// hasWordRune reports whether s holds a letter or a digit.
+// segmentText returns a segment's bytes as they appear in the original text.
+// seg indexes the folded text; offsets is the table from foldASCII, nil when
+// the text was already ASCII and folded and original are the same string.
+//
+// The skip decision below has to read the original, because the fold is lossy
+// in exactly the direction that matters: foldRune renders a rune with no ASCII
+// decomposition as the letter 'x', so a box-drawing rule "├────┼────┤" folds
+// to "xxxxxxxxxx" and looks like a word. Under SegmentLines that rule is its
+// own segment, and sending it to inference does not merely waste a call — the
+// model can tag the run, and snapToWords then hands the caller a span over
+// bytes that were never letters.
+func segmentText(text string, offsets []int, seg segment) string {
+	start, end := remapSpan(offsets, len(text), seg.start, seg.end)
+	return text[start:end]
+}
+
+// hasWordRune reports whether s holds a letter or a digit. Callers pass the
+// original text, not the folded rendering — see segmentText.
 //
 // Segments without one are pure layout — a blank line, "|", "+----+----+", a
 // run of dashes — and cannot carry an entity, so they are dropped before

--- a/ner/segments.go
+++ b/ner/segments.go
@@ -48,17 +48,20 @@ type segment struct {
 	start, end int
 }
 
-// normalizeSegmentation lower-cases Config.Segmentation and rejects anything
-// that is not a known rule.
+// normalizeSegmentation lower-cases Config.Segmentation, resolves the zero
+// value to SegmentWhole, and rejects anything that is not a known rule.
 //
 // A misspelling has to be an error rather than a fallback: the quiet result
 // would be analyzing tabular output as one blob, which is the exact failure
 // this option exists to avoid, and it would look like the model simply not
 // finding the names.
 func normalizeSegmentation(mode string) (string, error) {
-	mode = strings.ToLower(mode)
-	switch mode {
-	case "", SegmentWhole, SegmentLines, SegmentFields:
+	switch mode = strings.ToLower(mode); mode {
+	case "":
+		// Resolved rather than passed through, so Engine.Config reports the
+		// rule actually in force instead of the empty string.
+		return SegmentWhole, nil
+	case SegmentWhole, SegmentLines, SegmentFields:
 		return mode, nil
 	default:
 		return "", fmt.Errorf("unknown segmentation %q (want %q, %q or %q)",
@@ -78,6 +81,8 @@ func (e *Engine) segments(folded string) []segment {
 	case SegmentFields:
 		return cutAfter(folded, isFieldSep)
 	default:
+		// SegmentWhole. New resolves the zero value and rejects everything
+		// else, so this arm is the whole-text rule, not a silent fallback.
 		return []segment{{0, len(folded)}}
 	}
 }
@@ -86,7 +91,19 @@ func (e *Engine) segments(folded string) []segment {
 // The separator belongs to the segment it terminates, so the segments
 // concatenate back to the input.
 func cutAfter(folded string, sep func(byte) bool) []segment {
-	segs := make([]segment, 0, 8)
+	// Size the result first. Under SegmentFields a wide table yields one
+	// segment per cell, and growing from a fixed guess copies the whole slice
+	// a dozen times over on exactly the input this option exists to handle.
+	// One separator means at most one more segment — exactly one more unless
+	// the text ends with a separator, in which case this over-counts by one.
+	n := 1
+	for i := 0; i < len(folded); i++ {
+		if sep(folded[i]) {
+			n++
+		}
+	}
+
+	segs := make([]segment, 0, n)
 	start := 0
 	for i := 0; i < len(folded); i++ {
 		if sep(folded[i]) {

--- a/ner/segments.go
+++ b/ner/segments.go
@@ -1,0 +1,123 @@
+package ner
+
+// This file implements input segmentation: the caller-selected rule that
+// decides what the model sees as one sequence (Config.Segmentation).
+//
+// Windowing (windows.go) and segmentation answer different questions.
+// Windowing is a capacity constraint — a text longer than the token budget
+// physically cannot be one sequence, so it is cut into overlapping windows
+// and the spans are merged back. Segmentation is a quality choice — the text
+// would fit, but the model reads it better in pieces.
+//
+// The reason it is a choice at all is that a transformer's prediction for a
+// token depends on every other token in the sequence. That is what makes the
+// model good at prose and what makes it erratic on machine output: a name in
+// a 28-column psql row sits among UUIDs, timestamps and JSON, which no
+// news-trained model has seen, and the whole row can come back with nothing.
+// The same name on its own line, or on its own in a cell, is found reliably.
+// Cutting on the delimiters the output already has removes that noise without
+// inventing any structure the caller has to describe.
+//
+// Segments partition the folded text: disjoint, in order, covering every
+// byte. That is what lets a window offset inside a segment be rebased onto
+// the text by adding the segment start, and it means concatenating the
+// segments reproduces the input exactly — separators stay attached to the
+// segment they terminate rather than being dropped.
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// segment is one inference unit: a byte range [start, end) into the folded
+// text.
+type segment struct {
+	start, end int
+}
+
+// normalizeSegmentation lower-cases Config.Segmentation and rejects anything
+// that is not a known rule.
+//
+// A misspelling has to be an error rather than a fallback: the quiet result
+// would be analyzing tabular output as one blob, which is the exact failure
+// this option exists to avoid, and it would look like the model simply not
+// finding the names.
+func normalizeSegmentation(mode string) (string, error) {
+	mode = strings.ToLower(mode)
+	switch mode {
+	case "", SegmentWhole, SegmentLines, SegmentFields:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unknown segmentation %q (want %q, %q or %q)",
+			mode, SegmentWhole, SegmentLines, SegmentFields)
+	}
+}
+
+// segments splits a folded text according to the configured rule. The result
+// partitions the text; an empty text yields no segments.
+func (e *Engine) segments(folded string) []segment {
+	if folded == "" {
+		return nil
+	}
+	switch e.cfg.Segmentation {
+	case SegmentLines:
+		return cutAfter(folded, isLineSep)
+	case SegmentFields:
+		return cutAfter(folded, isFieldSep)
+	default:
+		return []segment{{0, len(folded)}}
+	}
+}
+
+// cutAfter partitions folded, ending a segment after every separator byte.
+// The separator belongs to the segment it terminates, so the segments
+// concatenate back to the input.
+func cutAfter(folded string, sep func(byte) bool) []segment {
+	segs := make([]segment, 0, 8)
+	start := 0
+	for i := 0; i < len(folded); i++ {
+		if sep(folded[i]) {
+			segs = append(segs, segment{start, i + 1})
+			start = i + 1
+		}
+	}
+	if start < len(folded) {
+		segs = append(segs, segment{start, len(folded)})
+	}
+	return segs
+}
+
+// isLineSep cuts records apart. Only "\n" is a cut point: a bare "\r" as a
+// line ending is extinct, and in CRLF text the "\r" simply trails the segment
+// like any other separator byte.
+func isLineSep(b byte) bool { return b == '\n' }
+
+// isFieldSep cuts values apart, in addition to records.
+//
+// Tab is the only field delimiter recognized, because it is the only one that
+// is unambiguously layout rather than punctuation: it is what psql's
+// unaligned mode, TSV exports, cut and awk emit, and it does not occur inside
+// prose or inside a name. Comma and pipe do occur in both ("Davis, Carol",
+// "a || b"), so cutting on them would fragment the free text this engine is
+// mainly used on. Aligned output padded with spaces is therefore not split
+// into fields either.
+func isFieldSep(b byte) bool { return b == '\n' || b == '\t' }
+
+// hasWordRune reports whether s holds a letter or a digit.
+//
+// Segments without one are pure layout — a blank line, "|", "+----+----+", a
+// run of dashes — and cannot carry an entity, so they are dropped before
+// inference. That is a saving, not a filter: a sweep of 56 separator-only
+// strings through the default model returned zero entities, and the corpus
+// recall figures in Config.Segmentation are identical with and without the
+// skip. Under SegmentFields it removes a large fraction of the segments a
+// wide table produces.
+func hasWordRune(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/ner/segments_test.go
+++ b/ner/segments_test.go
@@ -12,11 +12,26 @@ import (
 	"github.com/hoophq/alcatraz/entities"
 )
 
+// testEngine builds a model-less Engine for the segmentation helpers below.
+//
+// It goes through normalizeSegmentation rather than assigning mode straight
+// into the config, because segments falls back to whole on anything it does
+// not recognize: a test that typo'd "line" for "lines" would otherwise pass
+// while silently asserting the wrong rule.
+func testEngine(t *testing.T, mode string) *Engine {
+	t.Helper()
+	norm, err := normalizeSegmentation(mode)
+	if err != nil {
+		t.Fatalf("normalizeSegmentation(%q): %v", mode, err)
+	}
+	return &Engine{cfg: Config{Segmentation: norm}, tokenBudget: 4096}
+}
+
 // segsOf renders the segments of folded under mode as strings, so tests can
 // state the expected split literally.
 func segsOf(t *testing.T, mode, folded string) []string {
 	t.Helper()
-	e := &Engine{cfg: Config{Segmentation: mode}}
+	e := testEngine(t, mode)
 	var out []string
 	for _, s := range e.segments(folded) {
 		out = append(out, folded[s.start:s.end])
@@ -196,18 +211,25 @@ func TestSegmentTextIsNotFolded(t *testing.T) {
 	}
 }
 
-// rowsOf runs the segment→window expansion the way ProcessTexts does, on an
-// engine with no model: winTok is nil, so windows falls back to byte windows
-// sized off tokenBudget, which is enough to observe which segments survive.
-func rowsOf(t *testing.T, mode string, texts ...string) []string {
+// expandRows runs the segment→window expansion the way ProcessTexts does, on
+// an engine with no model: winTok is nil, so windows falls back to byte
+// windows sized off tokenBudget, which is enough to observe which segments
+// survive and which of them needed more than one window.
+func expandRows(t *testing.T, mode string, texts ...string) ([]inferenceRow, []bool) {
 	t.Helper()
-	e := &Engine{cfg: Config{Segmentation: mode}, tokenBudget: 4096}
+	e := testEngine(t, mode)
 	folded := make([]string, len(texts))
 	foldOffsets := make([][]int, len(texts))
 	for i, text := range texts {
 		folded[i], foldOffsets[i] = foldASCII(text)
 	}
-	rows, _ := e.inferenceRows(texts, folded, foldOffsets)
+	return e.inferenceRows(texts, folded, foldOffsets)
+}
+
+// rowsOf is expandRows reduced to the bodies the model would be sent.
+func rowsOf(t *testing.T, mode string, texts ...string) []string {
+	t.Helper()
+	rows, _ := expandRows(t, mode, texts...)
 	out := make([]string, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, r.body)
@@ -247,9 +269,55 @@ func TestInferenceRowsSkipsUnicodeRules(t *testing.T) {
 	}
 }
 
+// TestInferenceRowsWindowedFlag pins the rule that decides whether a text
+// needs mergeSpans afterwards. Only overlapping windows can report the same
+// entity twice; segments are disjoint, so a text cut into many segments that
+// each fit one window has nothing to merge. Keying the flag off the window
+// count is what keeps those apart — "this row starts past zero" would call
+// every segmented text windowed.
+func TestInferenceRowsWindowedFlag(t *testing.T) {
+	// The byte fallback cuts at tokenBudget-fallbackSpecialsSlack bytes, so
+	// this line is comfortably two overlapping windows and the short row is
+	// comfortably one.
+	long := strings.Repeat("Luan Lorenzo ", 400) + "\n"
+	short := "Luan\tLorenzo\tluan@hoop.dev\n"
+	table := strings.Repeat(short, 200)
+
+	for _, tc := range []struct {
+		name string
+		mode string
+		text string
+		want bool
+	}{
+		{"whole, fits one window", SegmentWhole, short, false},
+		{"whole, over budget", SegmentWhole, long, true},
+		{"lines, one line over budget", SegmentLines, short + long, true},
+		{"lines, every line short", SegmentLines, table, false},
+		{"fields, every cell short", SegmentFields, table, false},
+		// Same bytes as the two cases above: segmenting a long table is what
+		// removes the merge, so this pair is the whole point of the flag.
+		{"whole, same table unsegmented", SegmentWhole, table, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, windowed := expandRows(t, tc.mode, tc.text)
+			if windowed[0] != tc.want {
+				t.Errorf("windowed = %v, want %v (%d rows)", windowed[0], tc.want, len(rows))
+			}
+		})
+	}
+
+	// The flag is per text, not per batch: one long text must not mark a
+	// short one beside it.
+	_, windowed := expandRows(t, SegmentWhole, short, long, short)
+	if want := []bool{false, true, false}; fmt.Sprint(windowed) != fmt.Sprint(want) {
+		t.Errorf("windowed = %v, want %v", windowed, want)
+	}
+}
+
 func TestNormalizeSegmentation(t *testing.T) {
 	for in, want := range map[string]string{
-		"":       "",
+		// The zero value resolves, so Engine.Config reports the real rule.
+		"":       SegmentWhole,
 		"whole":  SegmentWhole,
 		"lines":  SegmentLines,
 		"fields": SegmentFields,

--- a/ner/segments_test.go
+++ b/ner/segments_test.go
@@ -152,6 +152,101 @@ func TestHasWordRune(t *testing.T) {
 	}
 }
 
+// TestSegmentTextIsNotFolded pins the reason the skip decision reads the
+// original text. Every one of these is layout, and every one of them folds to
+// a run of 'x' that hasWordRune would call a word — under SegmentLines a rule
+// line is its own segment, so reading the fold would send it to inference and
+// let a tagged run of placeholders reach the caller as a span over bytes that
+// were never letters.
+func TestSegmentTextIsNotFolded(t *testing.T) {
+	rules := []string{
+		"┌───┬───┐", "├───┼───┤", "└───┴───┘", "│   │   │",
+		"═════", "▀▄▀▄", "•••", "→→→",
+	}
+	for _, rule := range rules {
+		folded, offsets := foldASCII(rule)
+		seg := segment{0, len(folded)}
+		if !hasWordRune(folded) {
+			t.Errorf("fold of %q is %q, which no longer looks like a word — "+
+				"this test is not exercising the hazard any more", rule, folded)
+		}
+		if got := segmentText(rule, offsets, seg); got != rule {
+			t.Errorf("segmentText(%q) = %q, want the original bytes", rule, got)
+		}
+		if hasWordRune(segmentText(rule, offsets, seg)) {
+			t.Errorf("%q counted as a word segment, want it skipped", rule)
+		}
+	}
+
+	// The remap must be exact, not just word-free: a segment that is not the
+	// whole text has to come back as its own bytes. "José" is there so the
+	// fold table is non-nil and the offsets actually shift.
+	const text = "José\t├──┤\tLuan\n"
+	folded, offsets := foldASCII(text)
+	e := &Engine{cfg: Config{Segmentation: SegmentFields}}
+	var kept []string
+	for _, seg := range e.segments(folded) {
+		if s := segmentText(text, offsets, seg); hasWordRune(s) {
+			kept = append(kept, s)
+		}
+	}
+	want := []string{"José\t", "Luan\n"}
+	if fmt.Sprint(kept) != fmt.Sprint(want) {
+		t.Errorf("kept segments = %q, want %q", kept, want)
+	}
+}
+
+// rowsOf runs the segment→window expansion the way ProcessTexts does, on an
+// engine with no model: winTok is nil, so windows falls back to byte windows
+// sized off tokenBudget, which is enough to observe which segments survive.
+func rowsOf(t *testing.T, mode string, texts ...string) []string {
+	t.Helper()
+	e := &Engine{cfg: Config{Segmentation: mode}, tokenBudget: 4096}
+	folded := make([]string, len(texts))
+	foldOffsets := make([][]int, len(texts))
+	for i, text := range texts {
+		folded[i], foldOffsets[i] = foldASCII(text)
+	}
+	rows, _ := e.inferenceRows(texts, folded, foldOffsets)
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.body)
+	}
+	return out
+}
+
+// TestInferenceRowsSkipsUnicodeRules is the call-site half of
+// TestSegmentTextIsNotFolded: a box-drawn table must send only its data rows
+// to the model. Reading the fold instead of the original would keep all five
+// lines, because "├────┼────┤" folds to a run of 'x'.
+func TestInferenceRowsSkipsUnicodeRules(t *testing.T) {
+	const table = "┌──────┬───────────────┐\n" +
+		"│ name │ email         │\n" +
+		"├──────┼───────────────┤\n" +
+		"│ Luan │ luan@hoop.dev │\n" +
+		"└──────┴───────────────┘\n"
+
+	got := rowsOf(t, SegmentLines, table)
+	want := []string{
+		"x name x email         x\n",
+		"x Luan x luan@hoop.dev x\n",
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("rows = %q\nwant   %q", got, want)
+	}
+
+	// The ASCII table the model would have been fed anyway, so the skip is not
+	// quietly encoding-dependent: same shape in, same two rows out.
+	ascii := "+------+---------------+\n" +
+		"| name | email         |\n" +
+		"+------+---------------+\n" +
+		"| Luan | luan@hoop.dev |\n" +
+		"+------+---------------+\n"
+	if got := len(rowsOf(t, SegmentLines, ascii)); got != 2 {
+		t.Errorf("ASCII table produced %d rows, want 2", got)
+	}
+}
+
 func TestNormalizeSegmentation(t *testing.T) {
 	for in, want := range map[string]string{
 		"":       "",

--- a/ner/segments_test.go
+++ b/ner/segments_test.go
@@ -1,0 +1,429 @@
+package ner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+// segsOf renders the segments of folded under mode as strings, so tests can
+// state the expected split literally.
+func segsOf(t *testing.T, mode, folded string) []string {
+	t.Helper()
+	e := &Engine{cfg: Config{Segmentation: mode}}
+	var out []string
+	for _, s := range e.segments(folded) {
+		out = append(out, folded[s.start:s.end])
+	}
+	return out
+}
+
+func TestSegments(t *testing.T) {
+	const row = "id\tuser_name\temail\n1\tLuan\tluan@hoop.dev\n"
+
+	tests := []struct {
+		name string
+		mode string
+		text string
+		want []string
+	}{
+		{"whole keeps one segment", SegmentWhole, row, []string{row}},
+		{"empty mode means whole", "", row, []string{row}},
+		{
+			"lines cut after newline", SegmentLines, row,
+			[]string{"id\tuser_name\temail\n", "1\tLuan\tluan@hoop.dev\n"},
+		},
+		{
+			"fields cut after newline and tab", SegmentFields, row,
+			[]string{"id\t", "user_name\t", "email\n", "1\t", "Luan\t", "luan@hoop.dev\n"},
+		},
+		{
+			"unterminated last line is a segment", SegmentLines, "a\nb",
+			[]string{"a\n", "b"},
+		},
+		{
+			"blank lines survive as their own segments", SegmentLines, "a\n\nb\n",
+			[]string{"a\n", "\n", "b\n"},
+		},
+		{
+			"empty fields survive", SegmentFields, "a\t\tb\n",
+			[]string{"a\t", "\t", "b\n"},
+		},
+		{
+			"CRLF keeps the CR on the segment it ends", SegmentLines, "a\r\nb\r\n",
+			[]string{"a\r\n", "b\r\n"},
+		},
+		{
+			"prose is untouched by lines when it has no newline",
+			SegmentLines, "Alice Johnson met Bob Miller in Paris.",
+			[]string{"Alice Johnson met Bob Miller in Paris."},
+		},
+		{
+			"fields ignores comma and pipe", SegmentFields, "Davis, Carol | Berlin\n",
+			[]string{"Davis, Carol | Berlin\n"},
+		},
+		{"whole of empty text yields nothing", SegmentWhole, "", nil},
+		{"lines of empty text yields nothing", SegmentLines, "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := segsOf(t, tt.mode, tt.text)
+			if len(got) != len(tt.want) {
+				t.Fatalf("segments = %q, want %q", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segments = %q, want %q", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestSegmentsPartition pins the invariant every offset rebase in
+// ProcessTexts depends on: segments are ordered, disjoint, and cover the text
+// exactly, so concatenating them reproduces the input under every mode.
+func TestSegmentsPartition(t *testing.T) {
+	texts := []string{
+		"",
+		"\n",
+		"\t",
+		"a",
+		"a\n",
+		"\na",
+		"\n\n\n",
+		"\t\t\t",
+		"id\tuser_name\n1\tLuan\n(1 row)\n",
+		"no separators at all",
+		"trailing tab\t",
+		"José\tSão Paulo\nNúñez\tBogotá\n",
+		strings.Repeat("col\tvalue\n", 50),
+	}
+	for _, mode := range []string{SegmentWhole, SegmentLines, SegmentFields, ""} {
+		for _, text := range texts {
+			segs := (&Engine{cfg: Config{Segmentation: mode}}).segments(text)
+			prev := 0
+			var b strings.Builder
+			for i, s := range segs {
+				if s.start != prev {
+					t.Fatalf("mode %q text %q: segment %d starts at %d, want %d (gap or overlap)",
+						mode, text, i, s.start, prev)
+				}
+				if s.end <= s.start {
+					t.Fatalf("mode %q text %q: segment %d is empty [%d,%d)",
+						mode, text, i, s.start, s.end)
+				}
+				if s.end > len(text) {
+					t.Fatalf("mode %q text %q: segment %d ends past the text at %d",
+						mode, text, i, s.end)
+				}
+				b.WriteString(text[s.start:s.end])
+				prev = s.end
+			}
+			if prev != len(text) {
+				t.Fatalf("mode %q text %q: segments cover %d of %d bytes", mode, text, prev, len(text))
+			}
+			if b.String() != text {
+				t.Fatalf("mode %q: segments concatenate to %q, want %q", mode, b.String(), text)
+			}
+		}
+	}
+}
+
+func TestHasWordRune(t *testing.T) {
+	with := []string{"a", "Z", "0", "Luan", "id\t", "x\n", "José", "日本", "_a_", "v1.2"}
+	without := []string{"", " ", "\t", "\n", "\t\t", " | ", "+----+----+", "---",
+		"!@#$%^&*()", "  \t \n", "::", "->", "«»", "—"}
+	for _, s := range with {
+		if !hasWordRune(s) {
+			t.Errorf("hasWordRune(%q) = false, want true", s)
+		}
+	}
+	for _, s := range without {
+		if hasWordRune(s) {
+			t.Errorf("hasWordRune(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestNormalizeSegmentation(t *testing.T) {
+	for in, want := range map[string]string{
+		"":       "",
+		"whole":  SegmentWhole,
+		"lines":  SegmentLines,
+		"fields": SegmentFields,
+		"Lines":  SegmentLines,
+		"FIELDS": SegmentFields,
+	} {
+		got, err := normalizeSegmentation(in)
+		if err != nil {
+			t.Errorf("normalizeSegmentation(%q): %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("normalizeSegmentation(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"per-line", "line", "field", "cells", "none", " lines"} {
+		if _, err := normalizeSegmentation(in); err == nil {
+			t.Errorf("normalizeSegmentation(%q) accepted an unknown rule", in)
+		}
+	}
+}
+
+func TestNewRejectsUnknownSegmentation(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Segmentation = "per-line"
+	// Validation runs before any model resolution, so this needs no model on
+	// disk and no network.
+	_, err := New(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("New accepted an unknown segmentation")
+	}
+	for _, want := range []string{"segmentation", `"per-line"`, SegmentLines} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// psqlColumns and psqlRow mirror, column for column, the `SELECT * FROM
+// sessions` capture from hoop that motivated Config.Segmentation: 28 columns
+// of tab-separated psql output in unaligned mode. The value shapes matter as
+// much as the width — the sparse empty cells, the JSON blob, and the name
+// sandwiched between two lowercase addresses derived from it are what the
+// model actually chokes on — so they are reproduced rather than filled with
+// generic placeholder text. The identifiers are synthesized.
+var psqlColumns = []string{
+	"id", "org_id", "connection", "connection_type", "verb", "labels",
+	"user_id", "user_name", "user_email", "status", "blob_input_id",
+	"blob_stream_id", "metadata", "created_at", "ended_at", "metrics",
+	"jira_issue", "integrations_metadata", "exit_code", "connection_subtype",
+	"connection_tags", "session_batch_id", "ai_analysis", "guardrails_info",
+	"correlation_id", "machine_identity_id", "identity_type", "origin",
+}
+
+// psqlRow returns the 28 cell values for row r, with "" marking the cell the
+// caller fills with the planted name.
+func psqlRow(r int, handle string) []string {
+	uuid := func(seed int) string {
+		return fmt.Sprintf("%08x-%04x-4%03x-8%03x-%012x",
+			0x8aa7007e+seed*7919, (0x18e9+seed*31)&0xffff, (0x4f9+seed*13)&0xfff,
+			(0xa84+seed*17)&0xfff, 0x8c237351fd68+seed*104729)
+	}
+	mail := handle + "@example.com"
+	return []string{
+		uuid(r*10 + 1), uuid(r*10 + 2), "postgres-demo", "database", "exec", "",
+		mail, "", mail, "done", uuid(r*10 + 3), uuid(r*10 + 4), "{}",
+		fmt.Sprintf("2026-07-29 15:%02d:09.93009", 19+r),
+		fmt.Sprintf("2026-07-29 15:%02d:12.072462", 19+r),
+		`{"truncated": false, "event_size": 342871, "data_masking": {"err_count": 0, ` +
+			`"info_types": {}, "transformed_bytes": 0, "total_redact_count": 0}}`,
+		"", "", "0", "postgres", "{}", "", "", "", "", "", "user", "webapp",
+	}
+}
+
+// psqlFixture renders nCols columns of that capture with one name per row in
+// the user_name cell. handles supplies the local part of the surrounding email
+// addresses, so the name keeps its real neighbours.
+//
+// It returns the text, the byte range of each planted name, and the byte
+// ranges of the email cells. Those hold the name's own handle, so the model
+// tags parts of them too — "ose" inside "jose.nunez@example.com" — and an
+// offset assertion has to allow for that without allowing a span that landed
+// on a UUID or a timestamp.
+func psqlFixture(nCols int, names, handles []string) (text string, planted, mails [][2]int) {
+	head := append([]string(nil), psqlColumns[:min(nCols, len(psqlColumns))]...)
+	nameCol := 7 // user_name
+	if nameCol >= len(head) {
+		nameCol = len(head) / 2
+		head[nameCol] = "user_name"
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.Join(head, "\t") + "\n")
+	for r, name := range names {
+		mail := handles[r%len(handles)] + "@example.com"
+		cells := psqlRow(r, handles[r%len(handles)])
+		for c := range head {
+			if c > 0 {
+				b.WriteString("\t")
+			}
+			if c == nameCol {
+				planted = append(planted, [2]int{b.Len(), b.Len() + len(name)})
+				b.WriteString(name)
+				continue
+			}
+			if cells[c] == mail {
+				mails = append(mails, [2]int{b.Len(), b.Len() + len(mail)})
+			}
+			b.WriteString(cells[c])
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(fmt.Sprintf("(%d rows)\n", len(names)))
+	return b.String(), planted, mails
+}
+
+// analyzeWith runs one text through an engine configured with the given
+// segmentation and returns its spans.
+func analyzeWith(t *testing.T, mode, text string) []analyzer.NerSpan {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Backend = os.Getenv("ALCATRAZ_NER_BACKEND")
+	cfg.ORTLibraryPath = os.Getenv("ALCATRAZ_NER_ORT_LIB")
+	cfg.Accelerator = os.Getenv("ALCATRAZ_NER_ACCELERATOR")
+	cfg.Segmentation = mode
+
+	nlp, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New(%q): %v", mode, err)
+	}
+	defer nlp.Close()
+
+	arts, err := nlp.ProcessTexts([]string{text}, "en")
+	if err != nil {
+		t.Fatalf("ProcessTexts(%q): %v", mode, err)
+	}
+	return arts[0].Ents
+}
+
+// found counts how many planted ranges a PERSON span overlaps.
+func found(spans []analyzer.NerSpan, planted [][2]int) int {
+	n := 0
+	for _, p := range planted {
+		for _, s := range spans {
+			if s.EntityType == entities.Person && s.Start < p[1] && p[0] < s.End {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+// TestLiveSegmentationTabular is the ATR-205 regression: names that the model
+// finds easily on their own disappear when a wide tab-separated row is fed in
+// as one sequence, and segmentation recovers them.
+func TestLiveSegmentationTabular(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
+	}
+	names := []string{"Luan", "Luan", "Luan"}
+	text, planted, _ := psqlFixture(28, names, []string{"luan"})
+
+	whole := found(analyzeWith(t, SegmentWhole, text), planted)
+	lines := found(analyzeWith(t, SegmentLines, text), planted)
+	fields := found(analyzeWith(t, SegmentFields, text), planted)
+	t.Logf("%d bytes, %d planted names: whole=%d lines=%d fields=%d",
+		len(text), len(planted), whole, lines, fields)
+
+	if lines != len(planted) {
+		t.Errorf("SegmentLines found %d/%d planted names", lines, len(planted))
+	}
+	if fields != len(planted) {
+		t.Errorf("SegmentFields found %d/%d planted names", fields, len(planted))
+	}
+	// The defect itself. If the model ever stops losing these names as one
+	// blob this fails, which is the right prompt to re-measure the tradeoff
+	// documented on Config.Segmentation rather than a silent pass.
+	if whole >= lines {
+		t.Errorf("SegmentWhole found %d/%d, no worse than SegmentLines' %d — "+
+			"the recall gap this option exists to close is gone; re-measure",
+			whole, len(planted), lines)
+	}
+}
+
+// TestLiveSegmentationOffsets pins the byte-offset guarantee under every
+// segmentation: spans are rebased window → segment → folded → original, and
+// multi-byte input exercises the fold remap on top of the segment offset.
+func TestLiveSegmentationOffsets(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
+	}
+	text, planted, mails := psqlFixture(28,
+		[]string{"José Núñez", "Wojciech Nowak", "Hiroshi Tanaka"},
+		[]string{"jose.nunez", "wojciech.nowak", "hiroshi.tanaka"})
+	// The only cells holding anything person-shaped. Everything else in the
+	// row is a UUID, a timestamp, a JSON blob or a keyword.
+	personCells := append(append([][2]int(nil), planted...), mails...)
+
+	for _, mode := range []string{SegmentWhole, SegmentLines, SegmentFields} {
+		t.Run(mode, func(t *testing.T) {
+			spans := analyzeWith(t, mode, text)
+			for _, s := range spans {
+				if s.Start < 0 || s.End > len(text) || s.Start >= s.End {
+					t.Fatalf("span [%d:%d) out of range for %d bytes", s.Start, s.End, len(text))
+				}
+				if !utf8.ValidString(text[s.Start:s.End]) {
+					t.Errorf("span [%d:%d) = %q cuts a rune", s.Start, s.End, text[s.Start:s.End])
+				}
+			}
+			// Every PERSON span must land inside a name cell or one of the
+			// email cells built from that name. A rebase off by a segment
+			// start would still produce in-range, rune-aligned offsets while
+			// pointing at a UUID, so this — not the range check — is what
+			// catches a bad segment offset.
+			for _, s := range spans {
+				if s.EntityType != entities.Person {
+					continue
+				}
+				hit := false
+				for _, p := range personCells {
+					if s.Start >= p[0] && s.End <= p[1] {
+						hit = true
+						break
+					}
+				}
+				if !hit {
+					t.Errorf("PERSON %q at [%d:%d) is outside every name and email cell",
+						text[s.Start:s.End], s.Start, s.End)
+				}
+			}
+			if n := found(spans, planted); n == 0 {
+				t.Errorf("no planted name found at all under %q", mode)
+			}
+			t.Logf("%d spans, %d/%d planted names, offsets hold",
+				len(spans), found(spans, planted), len(planted))
+		})
+	}
+}
+
+// TestLiveSegmentationProse guards the reason SegmentWhole stays the default:
+// segmentation must not be a free win that everyone should take. On prose,
+// cutting at newlines changes nothing, and cutting further can only remove
+// context the model needs.
+func TestLiveSegmentationProse(t *testing.T) {
+	if os.Getenv("ALCATRAZ_NER_LIVE") != "1" {
+		t.Skip("set ALCATRAZ_NER_LIVE=1 to run the live model test")
+	}
+	const prose = "Alice Johnson met Bob Miller in Paris last spring.\n" +
+		"They were joined by Carol Davis, who had flown in from Berlin.\n"
+
+	render := func(spans []analyzer.NerSpan) []string {
+		var out []string
+		for _, s := range spans {
+			out = append(out, fmt.Sprintf("%s:%q", s.EntityType, prose[s.Start:s.End]))
+		}
+		return out
+	}
+	whole := render(analyzeWith(t, SegmentWhole, prose))
+	lines := render(analyzeWith(t, SegmentLines, prose))
+	t.Logf("whole=%v", whole)
+	t.Logf("lines=%v", lines)
+
+	if strings.Join(whole, " ") != strings.Join(lines, " ") {
+		t.Errorf("prose spans differ between whole and lines:\n whole = %v\n lines = %v", whole, lines)
+	}
+	for _, want := range []string{`PERSON:"Alice Johnson"`, `PERSON:"Bob Miller"`, `LOCATION:"Paris"`} {
+		if !strings.Contains(strings.Join(whole, " "), want) {
+			t.Errorf("prose is missing %s (got %v)", want, whole)
+		}
+	}
+}


### PR DESCRIPTION
## What happens

Streaming psql output through the analyzer, a name that is found instantly on its own is lost entirely once it sits in a row:

```
id      org_id  connection  ...  user_email     user_name  user_email     ...
8aa71f6d-…  8aa73e5c-…  postgres-demo  ...  luan@hoop.dev  Luan  luan@hoop.dev  ...
```

`PERSON "Luan"` is found instantly on its own. Three rows of that as one blob: **0/3**. Ablating the input shows where the damage comes from:

| Input | Names found |
| --- | --- |
| header + 3 rows | **0/3** |
| 3 rows, no header | 2/3 |
| 1 row alone | 1/1 |

So the reported hypothesis holds: a tab-separated header is the worst single thing in there — 28 column names in a row is a sequence the model has no reading of, and it drags the rows after it down with it. Cross-row context costs the rest.

Underneath both: transformer NER is context-sensitive by construction, a token's label depends on every other token in the sequence. That is what makes it good at prose and erratic on machine output. The fix is not a better model; it is to stop asking the model to read a table as a sentence.

## The change

`ner.Config.Segmentation` selects what counts as one sequence:

| Value | Cuts after | Recall | Cost |
|---|---|---|---|
| `SegmentWhole` (default) | nothing | 82% | 1.0x |
| `SegmentLines` | `\n` | 88% | 1.8x |
| `SegmentFields` | `\n` and `\t` | 94% | 4.3x |

Measured on generated psql/log output plus the real 28-column capture, 286 planted names, default model. Cost is inference calls. On the reproduction fixture: `whole=0/3, lines=3/3, fields=3/3`.

The default stays `SegmentWhole`: prose is the common case and finer segmentation cannot help it — a segment boundary is a hard context boundary, so an entity is never read across one. `TestLiveSegmentationProse` pins that whole and lines render prose identically, so this cannot quietly become a free win everyone should take.

## Design notes

- **Segmentation and windowing are different things and both stay.** Windowing (`windows.go`) is a *capacity* constraint — text past the token budget physically cannot be one sequence. Segmentation is a *quality* choice — it would fit, but the model reads it better in pieces. They compose: a segment longer than the budget is still windowed, so nothing is truncated under any setting.
- **Segments partition the folded text** — ordered, disjoint, covering every byte, separators attached to the segment they terminate. That is what makes the rebase `window → segment → folded → original` sound, and `TestSegmentsPartition` pins it across all four mode values.
- **Tab only.** Comma and pipe occur inside names and prose (`"Davis, Carol"`, `"a || b"`), so cutting on them would fragment the free text this engine is mainly used on. Space-aligned output needs layout detection, which is a different kind of guess — filed in `TODO.md` rather than guessed at here.
- **Word-free segments are dropped before inference.** A sweep of 56 separator-only strings (`|`, `+----+----+`, box drawing, blank lines) returned zero entities, and corpus recall is identical with and without the skip, so it is a saving and not a filter. Under `SegmentFields` it removes a large fraction of a wide table's segments.
- **An unknown value is an error, not a fallback.** A misspelled `Segmentation` would quietly analyze tabular output as one blob — the exact failure this option exists to avoid — and would look like the model just not finding the names. `normalizeSegmentation` lives in `segments.go` beside the concept, matching how `backend.go` owns backend/accelerator normalization.
- **`windowed[i]` moved to row-build time** and now keys off `len(wins) > 1` rather than `offset > 0`. Segments cannot double-report an entity — they are disjoint — so only a genuinely multi-window segment needs the merge.

## Tests

Offline (`go test ./ner`): `TestSegments` (12 cases: CRLF, blank lines, empty fields, comma/pipe left alone), `TestSegmentsPartition`, `TestHasWordRune`, `TestNormalizeSegmentation`, `TestNewRejectsUnknownSegmentation`.

Live (`ALCATRAZ_NER_LIVE=1`):

- `TestLiveSegmentationTabular` — the regression. Asserts lines and fields find 3/3, and that whole finds strictly fewer. Currently `whole=0 lines=3 fields=3`. If the model ever stops losing these names as one blob, this fails rather than silently passing, which is the right prompt to re-measure.
- `TestLiveSegmentationOffsets` — accented names (`José Núñez`, so the fold remap stacks on the segment offset). Range, `utf8.ValidString`, and every `PERSON` span inside a name or one of the flanking email cells — a rebase off by a segment start would still be in-range and rune-aligned while pointing at a UUID.
- `TestLiveSegmentationProse` — whole and lines must render identically.

The fixture (`psqlColumns`/`psqlRow`/`psqlFixture`) mirrors the capture column for column with synthesized identifiers. Value *shapes* turned out to matter as much as width: a first attempt with generic filler did not reproduce the collapse at all (whole=2/3). The sparse empty cells, the JSON metrics blob, and the name sandwiched between two lowercase addresses derived from it are what the model actually chokes on.

Full live suite green (114 tests, 0 skipped, 0 failed); all five modules build, vet and test clean.

## Caller

```go
cfg := ner.DefaultConfig()
cfg.Segmentation = ner.SegmentFields // tab-delimited query output
```

Closes ATR-205.
