### PR TITLE
feat(analyzer): score matches by the words around them (ATR-208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ module's model-backed recognizer.)
 ## How it works
 
 ```
-text  →  recognizers (regex)  →  validators (checksum)  →  dedup  →  threshold + allow list  →  results
+text  →  recognizers (regex)  →  validators (checksum)  →  context scoring  →  dedup  →  threshold + allow list  →  results
 ```
 
 The pipeline:
@@ -167,11 +167,61 @@ The pipeline:
 1. Every applicable recognizer runs its regexes over the text.
 2. A matched span is scored at the pattern's base confidence; a validator then
    either promotes it to `1.0` (verified) or drops it (failed checksum).
-3. Overlapping spans **of the same entity type** are de-duplicated (the
+3. A match supported by the words around it is boosted — see
+   [context-aware scoring](#context-aware-scoring).
+4. Overlapping spans **of the same entity type** are de-duplicated (the
    enclosing/higher-scoring span wins). Different entity types never suppress
    each other.
-4. An optional score threshold and allow list are applied.
-5. Each surviving result is annotated with the matched substring (`Result.Text`).
+5. An optional score threshold and allow list are applied.
+6. Each surviving result is annotated with the matched substring (`Result.Text`).
+
+---
+
+## Context-aware scoring
+
+A regex cannot tell a card number in a payment form from the same digits in a
+log line, so most patterns are scored well below certainty. The words around a
+match carry that missing evidence, and each recognizer declares the ones that
+matter:
+
+```go
+recognizers.Email() // base score 0.5, context words "email", "mail"
+```
+
+When one of them appears in the five words before a match, the score rises by
+`0.35` (floor `0.4`, capped at `1.0`) — Presidio's `LemmaContextAwareEnhancer`
+numbers:
+
+```go
+eng.Analyze("jane@example.com", alcatraz.Options{})        // EMAIL_ADDRESS 0.50
+eng.Analyze("email: jane@example.com", alcatraz.Options{}) // EMAIL_ADDRESS 0.85
+```
+
+This is why a threshold above `0.5` is worth setting: without context scoring
+a pattern-only `EMAIL_ADDRESS` could never exceed its base score, so such a
+threshold would quietly match nothing.
+
+Matching is case-insensitive and by **whole word**, with English plurals folded
+in (`cards` supports a `card` context, `addresses` supports `address`).
+Presidio instead asks whether the context word occurs anywhere inside a token,
+which fires on unrelated words — `ip` is inside `recipient`, `zip` and
+`script`. Multi-word entries (`"social security"`, `"codice fiscale"`) are
+matched as consecutive words. No NLP backend is required: the words are read
+straight from the text, so this works in the pattern-only engine.
+
+Scores already at `1.0` — anything a checksum validator verified — are left
+alone. Tune or switch off the behaviour per engine:
+
+```go
+eng.SetContextEnhancer(nil) // score purely on the pattern
+
+enh := analyzer.NewWordContextEnhancer()
+enh.WordsAfter = 3          // Presidio reads none; labels usually precede values
+eng.SetContextEnhancer(enh)
+```
+
+Your own recognizers get the same treatment — see
+[Make it yours](#make-it-yours).
 
 ---
 
@@ -225,6 +275,9 @@ reg.Add("en", analyzer.NewPatternRecognizer(
 
 eng := analyzer.NewEngine(reg, []string{"en"})
 ```
+
+`WithContext("employee", "emp id", "staff")` declares the words that support
+the match — see [context-aware scoring](#context-aware-scoring).
 
 The `Recognizer` interface is the seam for statistical backends too; nothing
 in the framework assumes regex. The `alcatraz/ner` module (below) plugs in
@@ -597,6 +650,10 @@ makes it precise on structured identifiers and honest about the rest:
 - **The default threshold is 0.** Some recognizers are intentionally
   low-confidence (e.g. `US_BANK_NUMBER` at 0.05 for any 8–17 digit run). Set
   `Options.Threshold` to trade recall for precision.
+- **Scores are relative, not calibrated.** A base score says how much the
+  pattern alone is worth; [context](#context-aware-scoring) adds a fixed
+  `0.35` when the surrounding words agree. Neither is a probability — pick a
+  threshold by measuring on your own text, not by reading the number.
 - **Recall over locale-perfection.** Patterns favor catching real identifiers
   over locale-perfect validation of every edge case.
 
@@ -643,9 +700,9 @@ Numbers vary by machine — reproduce them with two commands per engine; see
       same pattern as `lookaround`; one shared inference pass per `Analyze`
 - [x] `pfilter` module — privacy-filter.cpp (GGML) backend: PII-specialized
       models, long documents, GPU; purego FFI, no cgo
-- [ ] Context-word score boosting (raise a match's confidence when related
-      words appear near the span — the shared `NlpArtifacts` tokens are the
-      input for this)
+- [x] Context-word score boosting — Presidio's +0.35 within five words, whole
+      word rather than substring, no NLP backend required (lemmas still to
+      come, once the NLP seam carries tokens)
 - [ ] Zero-shot PII models (GLiNER-class): user-defined entity types at
       runtime, no retraining
 - [ ] Optional LLM-backed detection/validation — separate module, explicit
@@ -660,8 +717,9 @@ See [TODO.md](TODO.md) for the detailed plan.
 alcatraz.go        Public entry point: NewEngine + re-exported types.
 entities/          Canonical entity-type identifier constants.
 analyzer/          Framework: Result, dedup, Recognizer, Pattern, Matcher,
-                   PatternRecognizer, Registry, Engine, allow list, and the
-                   NLP seam (NlpEngine, NlpArtifacts, ArtifactRecognizer).
+                   PatternRecognizer, Registry, Engine, allow list,
+                   context-aware scoring (ContextEnhancer), and the NLP seam
+                   (NlpEngine, NlpArtifacts, ArtifactRecognizer).
 anonymizer/        Mask/replace/redact detected spans (Operator, Config).
 recognizers/       The 45 built-in recognizers, checksum helpers, loader.
 models/            Pinned model manifests and checksum-verified downloads for

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ alcatraz scan -json report.log         # machine-readable output (masked too)
 
 Exit codes are grep-style: `0` clean, `1` findings, `2` error. Flags:
 `-threshold` (default 0.4), `-entities`, `-ignore` (default `DATE_TIME,URL`),
-`-allowlist-file` (one allowed value per line, `#` comments), and `-exclude`
-(diff mode, glob patterns of paths to skip).
+`-allowlist-file` (one allowed value per line, `#` comments), `-exclude`
+(diff mode, glob patterns of paths to skip), and `-context` (default on — see
+[Context-aware scoring](#context-aware-scoring); `-context=false` scores each
+match on its pattern alone).
 
 Scanning never touches the network — no telemetry, no lookups, nothing leaves
 the process. The single exception is `alcatraz models download`, which fetches
@@ -219,6 +221,11 @@ enh := analyzer.NewWordContextEnhancer()
 enh.WordsAfter = 3          // Presidio reads none; labels usually precede values
 eng.SetContextEnhancer(enh)
 ```
+
+On the CLI, `-context=false` does the same thing. Reach for it if you read a
+threshold as a statement about pattern strength alone — "0.8 means a checksum
+validated it" — since a labelled email or phone now clears that line on the
+words around it.
 
 Your own recognizers get the same treatment — see
 [Make it yours](#make-it-yours).

--- a/TODO.md
+++ b/TODO.md
@@ -87,11 +87,17 @@ lives in a **separate module** so importers of the core never pull the dep.
 
 ## Context-aware scoring (precision follow-up)
 
-- [ ] Activate the currently-inert context words: `PatternRecognizer.WithContext`
-      stores words but does nothing. Implement context-based score boosting
-      fed from the shared `NlpArtifacts.Tokens` (Presidio boosts +0.35 when a
-      recognizer's context words appear near the span; plain lowercase token
-      matching is a fine v1, lemmas later).
+- [x] Activate the previously-inert context words: `analyzer.ContextEnhancer`
+      + the default `WordContextEnhancer`, installed by `NewEngine` and
+      swappable via `Engine.SetContextEnhancer`. Presidio's numbers (+0.35,
+      floor 0.4, five words before, capped at `MaxScore`), fed by a built-in
+      word scanner over the raw text rather than `NlpArtifacts.Tokens` — so
+      the pattern-only engine, the one with no model to fall back on, gets
+      the boost too. Matching is whole word with an English plural fold, not
+      Presidio's substring test (which fires on "ip" inside "recipient").
+- [ ] Lemma-based context matching, replacing the plural fold, once
+      `NlpArtifacts.Tokens` carries lemmas. `WordContextEnhancer.Enhance`
+      already receives the artifacts and ignores them.
 - [ ] Populate `NlpArtifacts.Tokens` in the `ner` module (hugot's aggregated
       output currently yields entity spans only).
 - [ ] Cross-recognizer overlap handling: `analyzer.RemoveDuplicates` only

--- a/analyzer/context.go
+++ b/analyzer/context.go
@@ -112,29 +112,40 @@ func (w *WordContextEnhancer) Enhance(text string, results []Result, recs []Reco
 	if len(results) == 0 {
 		return results
 	}
-	byRecognizer := contextWords(recs, results)
+	byRecognizer, maxWord := contextWords(recs, results)
 	if len(byRecognizer) == 0 {
 		return results
 	}
 
+	// The fields are exported for tuning, so read them defensively rather than
+	// trusting them: a negative window size is a caller's slip, not a request
+	// to read backwards, and it would otherwise reach make as a negative
+	// capacity and panic the whole Analyze call.
+	before, after := max(w.WordsBefore, 0), max(w.WordsAfter, 0)
+
+	// Result.Score is documented to stay within [MinScore, MaxScore]. Pulling
+	// the floor into range here keeps every score written below in range too,
+	// whatever the caller set, and without a second clamp per result.
+	floor := min(max(w.MinScore, MinScore), MaxScore)
+
 	// One window buffer for the whole call: on a chunk of log or query output
 	// this runs once per detection, and a fresh slice each time would be the
 	// bulk of what the enhancer allocates.
-	window := make([]string, 0, w.WordsBefore+w.WordsAfter)
+	window := make([]string, 0, before+after)
 
 	for i := range results {
 		want := byRecognizer[results[i].RecognizerName]
 		if len(want) == 0 || results[i].Score >= MaxScore {
 			continue
 		}
-		window = appendWordsBefore(window[:0], text, results[i].Start, w.WordsBefore)
-		window = appendWordsAfter(window, text, results[i].End, w.WordsAfter)
+		window = appendWordsBefore(window[:0], text, results[i].Start, before, maxWord)
+		window = appendWordsAfter(window, text, results[i].End, after, maxWord)
 		if !supported(window, want) {
 			continue
 		}
 		score := results[i].Score + w.Boost
-		if score < w.MinScore {
-			score = w.MinScore
+		if score < floor {
+			score = floor
 		}
 		if score > MaxScore {
 			score = MaxScore
@@ -153,7 +164,10 @@ func (w *WordContextEnhancer) Enhance(text string, results []Result, recs []Reco
 // call typically has dozens of recognizers registered and results from one or
 // two of them, so doing it the other way round would spend the bulk of the
 // work on entries nothing will ever look up.
-func contextWords(recs []Recognizer, results []Result) map[string][][]string {
+//
+// The second return is the longest window word that could still match one of
+// those phrases, in bytes; see foldWord for what the scanners do with it.
+func contextWords(recs []Recognizer, results []Result) (map[string][][]string, int) {
 	byRecognizer := make(map[string][][]string, 4)
 	for _, r := range results {
 		if r.Score < MaxScore {
@@ -161,10 +175,10 @@ func contextWords(recs []Recognizer, results []Result) map[string][][]string {
 		}
 	}
 	if len(byRecognizer) == 0 {
-		return nil
+		return nil, 0
 	}
 
-	found := false
+	longest := 0
 	for _, rec := range recs {
 		cr, ok := rec.(ContextualRecognizer)
 		if !ok {
@@ -175,19 +189,25 @@ func contextWords(recs []Recognizer, results []Result) map[string][][]string {
 		}
 		var phrases [][]string
 		for _, entry := range cr.Context() {
-			if words := splitWords(entry); len(words) > 0 {
-				phrases = append(phrases, words)
+			words := splitWords(entry)
+			if len(words) == 0 {
+				continue
 			}
+			for _, word := range words {
+				longest = max(longest, len(word))
+			}
+			phrases = append(phrases, words)
 		}
 		if len(phrases) > 0 {
 			byRecognizer[rec.Name()] = phrases
-			found = true
 		}
 	}
-	if !found {
-		return nil
+	if longest == 0 {
+		return nil, 0
 	}
-	return byRecognizer
+	// wordMatches accepts at most two trailing bytes past the context word,
+	// for the plural fold.
+	return byRecognizer, longest + 2
 }
 
 // supported reports whether any of the recognizer's context phrases occurs in
@@ -229,6 +249,10 @@ func containsPhrase(window, phrase []string) bool {
 // inflection that shows up in front of a real match — without accepting the
 // unrelated words a substring test would. Anything beyond English plurals
 // needs real lemmas, which is why the context lists spell their variants out.
+//
+// Every case here is bounded by len(context)+2, which is what lets foldWord
+// leave a longer window word uncased: no amount of casing can bring it into
+// range. Loosening the bound means loosening foldWord with it.
 func wordMatches(word, context string) bool {
 	switch {
 	case word == context:
@@ -242,9 +266,31 @@ func wordMatches(word, context string) bool {
 	}
 }
 
+// foldWord lower-cases a window word so it can be compared with the
+// lower-cased context words, unless it is longer than maxWord — the longest
+// word wordMatches could still accept — in which case the copy is dead weight
+// and the word is passed through as a slice of the text.
+//
+// This is what keeps a base64 blob or a long hash sitting in front of a match
+// from being copied in full just to be rejected on length. Measured on a 1 MiB
+// opaque run between a label and an email, it is the difference between
+// 1,057,166 and 2,323 bytes allocated per Analyze call.
+//
+// Note what is *not* bounded: the scanners still walk the run to find its far
+// edge. Traversal is free next to the regex pass that found the match in the
+// first place (596 ms/op either way in the same measurement), and giving up
+// mid-run would silently drop a legitimate label sitting behind the blob.
+func foldWord(s string, maxWord int) string {
+	if len(s) > maxWord {
+		return s
+	}
+	return strings.ToLower(s)
+}
+
 // appendWordsBefore appends up to n words ending before byte offset end to
-// dst, in reading order, and returns the extended slice.
-func appendWordsBefore(dst []string, text string, end, n int) []string {
+// dst, in reading order, and returns the extended slice. maxWord is the
+// longest word worth lower-casing; see foldWord.
+func appendWordsBefore(dst []string, text string, end, n, maxWord int) []string {
 	if n <= 0 || end <= 0 {
 		return dst
 	}
@@ -290,7 +336,7 @@ func appendWordsBefore(dst []string, text string, end, n int) []string {
 			i -= size
 		}
 		if i < wordEnd {
-			dst = append(dst, strings.ToLower(text[i:wordEnd]))
+			dst = append(dst, foldWord(text[i:wordEnd], maxWord))
 		}
 	}
 
@@ -304,7 +350,7 @@ func appendWordsBefore(dst []string, text string, end, n int) []string {
 // appendWordsAfter appends up to n words starting at or after byte offset
 // start to dst and returns the extended slice. A word the boundary cuts in
 // half is skipped, mirroring appendWordsBefore.
-func appendWordsAfter(dst []string, text string, start, n int) []string {
+func appendWordsAfter(dst []string, text string, start, n, maxWord int) []string {
 	if n <= 0 || start >= len(text) {
 		return dst
 	}
@@ -342,7 +388,7 @@ func appendWordsAfter(dst []string, text string, start, n int) []string {
 			i += size
 		}
 		if wordStart < i {
-			dst = append(dst, strings.ToLower(text[wordStart:i]))
+			dst = append(dst, foldWord(text[wordStart:i], maxWord))
 		}
 	}
 	return dst

--- a/analyzer/context.go
+++ b/analyzer/context.go
@@ -1,0 +1,384 @@
+package analyzer
+
+// This file implements context-aware scoring: raising a detection's score when
+// a word that hints at its entity type appears just before it.
+//
+// A regex alone cannot tell "1234-5678-9012-3456" in a payment form from the
+// same digits in a log line, so most pattern recognizers are scored well below
+// certainty. The words around a match carry the missing evidence, and
+// recognizers already declare which ones matter via
+// PatternRecognizer.WithContext. This turns those words into score.
+//
+// The rule follows Presidio's LemmaContextAwareEnhancer: +0.35 when a
+// recognizer's own context word appears within the five words before the
+// match, raised to at least 0.4, capped at MaxScore. Those numbers are the
+// reason a pattern-based EMAIL_ADDRESS can reach 0.85 there and could only
+// ever reach 0.5 here.
+//
+// Two deliberate differences from Presidio, both because this package has no
+// NLP dependency to lean on:
+//
+//   - Words come from a built-in scanner over the raw text, not from spaCy
+//     tokens, so context scoring works in the pattern-only engine — which is
+//     where it matters, since that is the path with no model to fall back on.
+//   - Matching is by whole word, not substring. Presidio asks whether the
+//     context word occurs anywhere inside a token, which fires on unrelated
+//     words: "ip" is inside "recipient", "zip" and "script", so any address
+//     near them would be boosted. Whole-word matching with a plural fold
+//     ("card" matches "cards", "address" matches "addresses") covers the
+//     inflection that Presidio's substring rule was there to absorb, without
+//     the false positives. Real lemmas are a follow-up, once the NLP seam
+//     carries tokens (see TODO.md).
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Presidio's LemmaContextAwareEnhancer defaults, reproduced so a caller can
+// see what the default enhancer does without reading its constructor.
+const (
+	// DefaultContextBoost is added to a result supported by a context word.
+	DefaultContextBoost = 0.35
+	// DefaultContextMinScore is the floor a supported result is raised to,
+	// so a very weak pattern still lands somewhere usable when the
+	// surrounding text agrees with it.
+	DefaultContextMinScore = 0.4
+	// DefaultContextWordsBefore is how many words before a match are read.
+	DefaultContextWordsBefore = 5
+	// DefaultContextWordsAfter is how many words after a match are read.
+	// Presidio reads none: a label almost always precedes its value.
+	DefaultContextWordsAfter = 0
+)
+
+// ContextualRecognizer is an optional extension of Recognizer for detectors
+// that publish words hinting at their entity type nearby. PatternRecognizer
+// implements it through WithContext. The engine's ContextEnhancer detects it
+// by type assertion; a recognizer without context words is left alone.
+type ContextualRecognizer interface {
+	Recognizer
+	// Context returns the words that support this recognizer's results when
+	// they appear near a match. Matching is case-insensitive.
+	Context() []string
+}
+
+// ContextEnhancer adjusts result scores using the text around each match. The
+// engine runs it once per Analyze call, after every recognizer and before
+// de-duplication and the score threshold — so a boost can decide which of two
+// overlapping spans wins, and a result boosted over the threshold is kept.
+//
+// Implementations may modify and return results in place.
+type ContextEnhancer interface {
+	// Enhance returns results with scores adjusted for context. recs are the
+	// recognizers that ran, so an implementation can look up the context
+	// words behind a result's RecognizerName. artifacts holds the shared NLP
+	// pass when one ran, and is nil otherwise.
+	Enhance(text string, results []Result, recs []Recognizer, artifacts *NlpArtifacts) []Result
+}
+
+// WordContextEnhancer is the default ContextEnhancer: it scans the words
+// immediately around each match and boosts the result when one of them is a
+// context word of the recognizer that produced it.
+//
+// The zero value does nothing useful; use NewWordContextEnhancer and adjust
+// the fields from there.
+type WordContextEnhancer struct {
+	// Boost is added to the score of a supported result.
+	Boost float64
+	// MinScore is the floor a supported result is raised to. A result already
+	// scoring above it keeps its boosted score.
+	MinScore float64
+	// WordsBefore and WordsAfter size the window read around a match, in
+	// words. The word a match starts inside is never part of its own context.
+	WordsBefore int
+	WordsAfter  int
+}
+
+// NewWordContextEnhancer returns the default enhancer, configured with
+// Presidio's numbers.
+func NewWordContextEnhancer() *WordContextEnhancer {
+	return &WordContextEnhancer{
+		Boost:       DefaultContextBoost,
+		MinScore:    DefaultContextMinScore,
+		WordsBefore: DefaultContextWordsBefore,
+		WordsAfter:  DefaultContextWordsAfter,
+	}
+}
+
+// Enhance implements ContextEnhancer. It ignores artifacts: words are read
+// from the text directly, so context scoring does not require an NLP backend.
+func (w *WordContextEnhancer) Enhance(text string, results []Result, recs []Recognizer, _ *NlpArtifacts) []Result {
+	if len(results) == 0 {
+		return results
+	}
+	byRecognizer := contextWords(recs, results)
+	if len(byRecognizer) == 0 {
+		return results
+	}
+
+	// One window buffer for the whole call: on a chunk of log or query output
+	// this runs once per detection, and a fresh slice each time would be the
+	// bulk of what the enhancer allocates.
+	window := make([]string, 0, w.WordsBefore+w.WordsAfter)
+
+	for i := range results {
+		want := byRecognizer[results[i].RecognizerName]
+		if len(want) == 0 || results[i].Score >= MaxScore {
+			continue
+		}
+		window = appendWordsBefore(window[:0], text, results[i].Start, w.WordsBefore)
+		window = appendWordsAfter(window, text, results[i].End, w.WordsAfter)
+		if !supported(window, want) {
+			continue
+		}
+		score := results[i].Score + w.Boost
+		if score < w.MinScore {
+			score = w.MinScore
+		}
+		if score > MaxScore {
+			score = MaxScore
+		}
+		results[i].Score = score
+	}
+	return results
+}
+
+// contextWords maps recognizer name to its context words, each pre-split into
+// lower-case words so a multi-word entry ("social security", "codice
+// fiscale") is matched as a phrase rather than as a string that no single
+// word can equal.
+//
+// Only recognizers that actually produced a boostable result are split. A
+// call typically has dozens of recognizers registered and results from one or
+// two of them, so doing it the other way round would spend the bulk of the
+// work on entries nothing will ever look up.
+func contextWords(recs []Recognizer, results []Result) map[string][][]string {
+	byRecognizer := make(map[string][][]string, 4)
+	for _, r := range results {
+		if r.Score < MaxScore {
+			byRecognizer[r.RecognizerName] = nil
+		}
+	}
+	if len(byRecognizer) == 0 {
+		return nil
+	}
+
+	found := false
+	for _, rec := range recs {
+		cr, ok := rec.(ContextualRecognizer)
+		if !ok {
+			continue
+		}
+		if _, want := byRecognizer[rec.Name()]; !want {
+			continue
+		}
+		var phrases [][]string
+		for _, entry := range cr.Context() {
+			if words := splitWords(entry); len(words) > 0 {
+				phrases = append(phrases, words)
+			}
+		}
+		if len(phrases) > 0 {
+			byRecognizer[rec.Name()] = phrases
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return byRecognizer
+}
+
+// supported reports whether any of the recognizer's context phrases occurs in
+// the window as a run of consecutive words.
+func supported(window []string, phrases [][]string) bool {
+	for _, phrase := range phrases {
+		if containsPhrase(window, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsPhrase reports whether phrase appears in window as consecutive
+// words, comparing with wordMatches.
+func containsPhrase(window, phrase []string) bool {
+	if len(phrase) == 0 || len(phrase) > len(window) {
+		return false
+	}
+	for i := 0; i+len(phrase) <= len(window); i++ {
+		all := true
+		for j, p := range phrase {
+			if !wordMatches(window[i+j], p) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// wordMatches reports whether a window word satisfies a context word.
+//
+// The plural fold is the whole of the stemming done here. It is what lets
+// "cards" support a "card" context and "addresses" support "address" — the
+// inflection that shows up in front of a real match — without accepting the
+// unrelated words a substring test would. Anything beyond English plurals
+// needs real lemmas, which is why the context lists spell their variants out.
+func wordMatches(word, context string) bool {
+	switch {
+	case word == context:
+		return true
+	case len(word) == len(context)+1:
+		return strings.HasPrefix(word, context) && word[len(context)] == 's'
+	case len(word) == len(context)+2:
+		return strings.HasPrefix(word, context) && word[len(context):] == "es"
+	default:
+		return false
+	}
+}
+
+// appendWordsBefore appends up to n words ending before byte offset end to
+// dst, in reading order, and returns the extended slice.
+func appendWordsBefore(dst []string, text string, end, n int) []string {
+	if n <= 0 || end <= 0 {
+		return dst
+	}
+	if end > len(text) {
+		end = len(text)
+	}
+	// A word cut in half by the boundary is part of the match, not of its
+	// context: in "card1234" the match is the digits and "card" is only the
+	// front of the word they sit in.
+	if end < len(text) {
+		if r, _ := utf8.DecodeRuneInString(text[end:]); isWordRune(r) {
+			for end > 0 {
+				r, size := utf8.DecodeLastRuneInString(text[:end])
+				if !isWordRune(r) {
+					break
+				}
+				end -= size
+			}
+		}
+	}
+	if end <= 0 {
+		return dst
+	}
+
+	base := len(dst)
+	i := end
+	for i > 0 && len(dst)-base < n {
+		// skip back over the separators before the next word
+		for i > 0 {
+			r, size := utf8.DecodeLastRuneInString(text[:i])
+			if isWordRune(r) {
+				break
+			}
+			i -= size
+		}
+		// consume the word
+		wordEnd := i
+		for i > 0 {
+			r, size := utf8.DecodeLastRuneInString(text[:i])
+			if !isWordRune(r) {
+				break
+			}
+			i -= size
+		}
+		if i < wordEnd {
+			dst = append(dst, strings.ToLower(text[i:wordEnd]))
+		}
+	}
+
+	// collected back to front; restore reading order
+	for l, r := base, len(dst)-1; l < r; l, r = l+1, r-1 {
+		dst[l], dst[r] = dst[r], dst[l]
+	}
+	return dst
+}
+
+// appendWordsAfter appends up to n words starting at or after byte offset
+// start to dst and returns the extended slice. A word the boundary cuts in
+// half is skipped, mirroring appendWordsBefore.
+func appendWordsAfter(dst []string, text string, start, n int) []string {
+	if n <= 0 || start >= len(text) {
+		return dst
+	}
+	if start < 0 {
+		start = 0
+	}
+
+	base := len(dst)
+	i := start
+	if start > 0 {
+		if r, _ := utf8.DecodeLastRuneInString(text[:start]); isWordRune(r) {
+			for i < len(text) {
+				r, size := utf8.DecodeRuneInString(text[i:])
+				if !isWordRune(r) {
+					break
+				}
+				i += size
+			}
+		}
+	}
+	for i < len(text) && len(dst)-base < n {
+		for i < len(text) {
+			r, size := utf8.DecodeRuneInString(text[i:])
+			if isWordRune(r) {
+				break
+			}
+			i += size
+		}
+		wordStart := i
+		for i < len(text) {
+			r, size := utf8.DecodeRuneInString(text[i:])
+			if !isWordRune(r) {
+				break
+			}
+			i += size
+		}
+		if wordStart < i {
+			dst = append(dst, strings.ToLower(text[wordStart:i]))
+		}
+	}
+	return dst
+}
+
+// splitWords returns the lower-cased words of s, using the same word rule as
+// the window scanners so a context entry and the text are cut alike.
+func splitWords(s string) []string {
+	var words []string
+	start := -1
+	for i, r := range s {
+		if isWordRune(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			words = append(words, strings.ToLower(s[start:i]))
+			start = -1
+		}
+	}
+	if start >= 0 {
+		words = append(words, strings.ToLower(s[start:]))
+	}
+	return words
+}
+
+// isWordRune reports whether r can be part of a word.
+//
+// Letters and digits, which keeps "ipv4" and "2fa" whole while cutting
+// "e-mail" into "e" and "mail" and "user_name" into "user" and "name" — both
+// splits are wanted, since the halves are the words a context list names.
+// Being rune-based rather than ASCII-based is what lets non-Latin context
+// words ("주민등록번호", "บัตรประชาชน") work at all; combining marks count too,
+// or a Thai vowel sign or a decomposed accent would split a word in half.
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
+}

--- a/analyzer/context_test.go
+++ b/analyzer/context_test.go
@@ -2,8 +2,15 @@ package analyzer
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// testMaxWord is the word-length bound the scanners get in tests that are not
+// about the bound itself: comfortably past every word they scan, so it never
+// changes what they collect. Enhance derives the real value from the context
+// words in play (contextWords).
+const testMaxWord = 64
 
 // ctxRecognizer reports one fixed span, so a test can choose the exact score
 // and context words the enhancer will see.
@@ -114,7 +121,7 @@ func TestWordsBefore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := appendWordsBefore(nil, tt.text, tt.end, tt.n)
+			got := appendWordsBefore(nil, tt.text, tt.end, tt.n, testMaxWord)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("appendWordsBefore(nil, %q, %d, %d) = %q, want %q",
 					tt.text, tt.end, tt.n, got, tt.want)
@@ -142,7 +149,7 @@ func TestWordsAfter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := appendWordsAfter(nil, tt.text, tt.start, tt.n)
+			got := appendWordsAfter(nil, tt.text, tt.start, tt.n, testMaxWord)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("appendWordsAfter(nil, %q, %d, %d) = %q, want %q",
 					tt.text, tt.start, tt.n, got, tt.want)
@@ -158,26 +165,178 @@ func TestWordsAfter(t *testing.T) {
 func TestAppendWordsIntoExistingSlice(t *testing.T) {
 	dst := []string{"keep"}
 
-	dst = appendWordsBefore(dst, "one two 1234", 8, 5)
+	dst = appendWordsBefore(dst, "one two 1234", 8, 5, testMaxWord)
 	if want := []string{"keep", "one", "two"}; !reflect.DeepEqual(dst, want) {
 		t.Fatalf("after appendWordsBefore: %q, want %q", dst, want)
 	}
 
-	dst = appendWordsAfter(dst, "one two 1234", 12, 2)
+	dst = appendWordsAfter(dst, "one two 1234", 12, 2, testMaxWord)
 	if want := []string{"keep", "one", "two"}; !reflect.DeepEqual(dst, want) {
 		t.Fatalf("after appendWordsAfter past the end: %q, want %q", dst, want)
 	}
 
-	dst = appendWordsAfter(dst, "1234 three four", 4, 2)
+	dst = appendWordsAfter(dst, "1234 three four", 4, 2, testMaxWord)
 	if want := []string{"keep", "one", "two", "three", "four"}; !reflect.DeepEqual(dst, want) {
 		t.Fatalf("after appendWordsAfter: %q, want %q", dst, want)
 	}
 
 	// Truncating to zero and refilling is what the enhancer does per result:
 	// the buffer's contents must not leak from one result into the next.
-	dst = appendWordsBefore(dst[:0], "my email 1234", 9, 5)
+	dst = appendWordsBefore(dst[:0], "my email 1234", 9, 5, testMaxWord)
 	if want := []string{"my", "email"}; !reflect.DeepEqual(dst, want) {
 		t.Fatalf("after reuse: %q, want %q", dst, want)
+	}
+}
+
+// TestFoldWord covers the bound that keeps a long opaque run — a base64 blob,
+// a hash, a JWT — from being copied by strings.ToLower only to be thrown away
+// on length by wordMatches.
+func TestFoldWord(t *testing.T) {
+	tests := []struct {
+		name    string
+		word    string
+		maxWord int
+		want    string
+	}{
+		{"short word is lower-cased", "Email", 7, "email"},
+		{"word exactly at the bound is lower-cased", "Address", 7, "address"},
+		{"word past the bound is left alone", "AddressX", 7, "AddressX"},
+		{"multi-byte under the bound", "JOSÉ", 7, "josé"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := foldWord(tt.word, tt.maxWord); got != tt.want {
+				t.Errorf("foldWord(%q, %d) = %q, want %q",
+					tt.word, tt.maxWord, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppendWordsSkipsCasingLongRuns is the scanner half of TestFoldWord: an
+// over-long run still takes its slot in the window — dropping it would shift
+// the words behind it — but arrives uncased, i.e. uncopied.
+func TestAppendWordsSkipsCasingLongRuns(t *testing.T) {
+	const run = "AbCdEfGhIjKlMnOp"
+	text := "Label " + run + " 1234 " + run + " Tail"
+
+	before := appendWordsBefore(nil, text, len("Label "+run+" "), 5, 8)
+	if want := []string{"label", run}; !reflect.DeepEqual(before, want) {
+		t.Fatalf("appendWordsBefore = %q, want %q", before, want)
+	}
+	after := appendWordsAfter(nil, text, len("Label "+run+" 1234"), 5, 8)
+	if want := []string{run, "tail"}; !reflect.DeepEqual(after, want) {
+		t.Fatalf("appendWordsAfter = %q, want %q", after, want)
+	}
+	// Uncased is safe only because nothing that long can match anyway.
+	if wordMatches(run, strings.ToLower(run)) {
+		t.Error("a word past the bound reached wordMatches and matched")
+	}
+}
+
+// TestContextWordsBound pins the bound Enhance hands the scanners: the longest
+// context word in play plus the two bytes wordMatches allows for the plural
+// fold. Deriving it from the words themselves is what keeps a caller's long
+// custom context word working instead of silently never matching.
+func TestContextWordsBound(t *testing.T) {
+	rec := &ctxRecognizer{
+		name: "R", entity: "TEST", span: [2]int{0, 4}, score: 0.3,
+		context: []string{"iban", "henkilötunnus"}, // 4 and 14 bytes
+	}
+	results := []Result{{RecognizerName: "R", Score: 0.3}}
+
+	_, maxWord := contextWords([]Recognizer{rec}, results)
+	if want := len("henkilötunnus") + 2; maxWord != want {
+		t.Errorf("maxWord = %d, want %d", maxWord, want)
+	}
+}
+
+// TestLongRunDoesNotHideContext is why the scanners bound copying rather than
+// traversal: abandoning a scan on a long run would lose the label sitting
+// behind it, which is exactly the shape of a logged blob with a field name in
+// front of it.
+func TestLongRunDoesNotHideContext(t *testing.T) {
+	blob := strings.Repeat("aBcD1234", 512) // 4 KiB, no separators
+	text := "card " + blob + " 1234"
+	rec := &ctxRecognizer{
+		name: "R", entity: "TEST",
+		span:  [2]int{len(text) - 4, len(text)},
+		score: 0.3, context: []string{"card"},
+	}
+
+	got := NewWordContextEnhancer().Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+	if len(got) != 1 || !nearly(got[0].Score, 0.65) {
+		t.Fatalf("got %+v, want a single 0.65 result", got)
+	}
+}
+
+// TestWordContextEnhancerNegativeWindow: the window fields are exported, and a
+// negative one used to reach make as a negative capacity and panic Analyze.
+func TestWordContextEnhancerNegativeWindow(t *testing.T) {
+	const text = "my card 1234"
+	rec := &ctxRecognizer{
+		name: "R", entity: "TEST", span: [2]int{8, 12}, score: 0.3,
+		context: []string{"card"},
+	}
+
+	tests := []struct {
+		name          string
+		before, after int
+		want          float64
+	}{
+		{"negative before", -5, 0, 0.3},
+		{"negative after", 5, -5, 0.65},
+		{"both negative", -5, -5, 0.3},
+		{"negative sum", -10, 1, 0.3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWordContextEnhancer()
+			w.WordsBefore, w.WordsAfter = tt.before, tt.after
+			got := w.Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+			if len(got) != 1 || !nearly(got[0].Score, tt.want) {
+				t.Fatalf("got %+v, want a single %v result", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWordContextEnhancerClampsToScoreRange: Boost and MinScore are exported
+// too, and Result.Score is documented to stay within [MinScore, MaxScore]
+// whatever they are set to.
+func TestWordContextEnhancerClampsToScoreRange(t *testing.T) {
+	const text = "my card 1234"
+	rec := &ctxRecognizer{
+		name: "R", entity: "TEST", span: [2]int{8, 12}, score: 0.3,
+		context: []string{"card"},
+	}
+
+	tests := []struct {
+		name           string
+		boost, minimum float64
+		want           float64
+	}{
+		{"floor below MinScore cannot take a score negative", -1, -5, MinScore},
+		{"negative boost cannot go below the floor", -5, 0.4, 0.4},
+		{"negative boost with a zero floor stops at MinScore", -5, 0, MinScore},
+		{"floor above MaxScore is pulled down", 0, 5, MaxScore},
+		{"huge boost is capped", 99, 0.4, MaxScore},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWordContextEnhancer()
+			w.Boost, w.MinScore = tt.boost, tt.minimum
+			got := w.Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+			if len(got) != 1 {
+				t.Fatalf("got %d results, want 1", len(got))
+			}
+			if !nearly(got[0].Score, tt.want) {
+				t.Errorf("score = %v, want %v", got[0].Score, tt.want)
+			}
+			if got[0].Score < MinScore || got[0].Score > MaxScore {
+				t.Errorf("score %v is outside [%v, %v]", got[0].Score, MinScore, MaxScore)
+			}
+		})
 	}
 }
 

--- a/analyzer/context_test.go
+++ b/analyzer/context_test.go
@@ -1,0 +1,499 @@
+package analyzer
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ctxRecognizer reports one fixed span, so a test can choose the exact score
+// and context words the enhancer will see.
+type ctxRecognizer struct {
+	name    string
+	entity  string
+	span    [2]int
+	score   float64
+	context []string
+}
+
+func (r *ctxRecognizer) Name() string                { return r.name }
+func (r *ctxRecognizer) SupportedEntities() []string { return []string{r.entity} }
+func (r *ctxRecognizer) SupportedLanguage() string   { return "en" }
+func (r *ctxRecognizer) Context() []string           { return r.context }
+
+func (r *ctxRecognizer) Analyze(text string, entities []string) []Result {
+	if entities != nil && !supportsAny(r.SupportedEntities(), entities) {
+		return nil
+	}
+	return []Result{{
+		EntityType:     r.entity,
+		Start:          r.span[0],
+		End:            r.span[1],
+		Score:          r.score,
+		RecognizerName: r.name,
+	}}
+}
+
+// plainRecognizer is the same detector without Context, i.e. a recognizer that
+// is not a ContextualRecognizer at all.
+type plainRecognizer struct {
+	name   string
+	entity string
+	span   [2]int
+	score  float64
+}
+
+func (r *plainRecognizer) Name() string                { return r.name }
+func (r *plainRecognizer) SupportedEntities() []string { return []string{r.entity} }
+func (r *plainRecognizer) SupportedLanguage() string   { return "en" }
+
+func (r *plainRecognizer) Analyze(text string, entities []string) []Result {
+	if entities != nil && !supportsAny(r.SupportedEntities(), entities) {
+		return nil
+	}
+	return []Result{{
+		EntityType:     r.entity,
+		Start:          r.span[0],
+		End:            r.span[1],
+		Score:          r.score,
+		RecognizerName: r.name,
+	}}
+}
+
+func TestSplitWords(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single word", "email", []string{"email"}},
+		{"lower-cased", "Codice Fiscale", []string{"codice", "fiscale"}},
+		{"phrase", "social security", []string{"social", "security"}},
+		{"accented phrase", "cadastro de pessoas físicas",
+			[]string{"cadastro", "de", "pessoas", "físicas"}},
+		{"hyphen splits", "e-mail", []string{"e", "mail"}},
+		{"underscore splits", "user_name", []string{"user", "name"}},
+		{"digits stay in the word", "ipv4", []string{"ipv4"}},
+		{"punctuation dropped", "  ssn: ", []string{"ssn"}},
+		{"empty", "", nil},
+		{"separators only", " -_/ ", nil},
+		{"non-latin is one word", "주민등록번호", []string{"주민등록번호"}},
+		{"thai is one word", "บัตรประชาชน", []string{"บัตรประชาชน"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splitWords(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitWords(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWordsBefore(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		end  int
+		n    int
+		want []string
+	}{
+		{"reading order preserved", "one two three four x", 19, 5,
+			[]string{"one", "two", "three", "four"}},
+		{"limited to n", "one two three four five six x", 28, 3,
+			[]string{"four", "five", "six"}},
+		{"stops at the start of the text", "one two x", 8, 5, []string{"one", "two"}},
+		{"lower-cases", "Email: x", 7, 5, []string{"email"}},
+		{"skips separators", "email:   \t x", 11, 5, []string{"email"}},
+		{"word cut by the boundary is excluded", "email address", 9, 5, []string{"email"}},
+		{"boundary inside the first word yields nothing", "email", 3, 5, nil},
+		{"boundary at the start yields nothing", "email x", 0, 5, nil},
+		{"n of zero yields nothing", "email x", 7, 0, nil},
+		{"end of text is not a cut word", "my email", 8, 5, []string{"my", "email"}},
+		{"offset past the end is clamped", "my email", 999, 5, []string{"my", "email"}},
+		{"multi-byte words", "e-mail do José: x", 16, 5,
+			[]string{"e", "mail", "do", "josé"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendWordsBefore(nil, tt.text, tt.end, tt.n)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendWordsBefore(nil, %q, %d, %d) = %q, want %q",
+					tt.text, tt.end, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWordsAfter(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		start int
+		n     int
+		want  []string
+	}{
+		{"reading order", "x is a phone number", 1, 5,
+			[]string{"is", "a", "phone", "number"}},
+		{"limited to n", "x one two three", 1, 2, []string{"one", "two"}},
+		{"word cut by the boundary is excluded", "address line", 3, 5, []string{"line"}},
+		{"start of text is not a cut word", "phone here", 0, 1, []string{"phone"}},
+		{"start at the end yields nothing", "phone", 5, 5, nil},
+		{"n of zero yields nothing", "x phone", 1, 0, nil},
+		{"negative start is clamped", "phone here", -1, 1, []string{"phone"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendWordsAfter(nil, tt.text, tt.start, tt.n)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendWordsAfter(nil, %q, %d, %d) = %q, want %q",
+					tt.text, tt.start, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppendWordsIntoExistingSlice covers how Enhance actually calls the two
+// scanners: one buffer, reused across results and filled twice per result. The
+// reversal in appendWordsBefore must touch only what that call appended, and
+// neither may drop what is already there.
+func TestAppendWordsIntoExistingSlice(t *testing.T) {
+	dst := []string{"keep"}
+
+	dst = appendWordsBefore(dst, "one two 1234", 8, 5)
+	if want := []string{"keep", "one", "two"}; !reflect.DeepEqual(dst, want) {
+		t.Fatalf("after appendWordsBefore: %q, want %q", dst, want)
+	}
+
+	dst = appendWordsAfter(dst, "one two 1234", 12, 2)
+	if want := []string{"keep", "one", "two"}; !reflect.DeepEqual(dst, want) {
+		t.Fatalf("after appendWordsAfter past the end: %q, want %q", dst, want)
+	}
+
+	dst = appendWordsAfter(dst, "1234 three four", 4, 2)
+	if want := []string{"keep", "one", "two", "three", "four"}; !reflect.DeepEqual(dst, want) {
+		t.Fatalf("after appendWordsAfter: %q, want %q", dst, want)
+	}
+
+	// Truncating to zero and refilling is what the enhancer does per result:
+	// the buffer's contents must not leak from one result into the next.
+	dst = appendWordsBefore(dst[:0], "my email 1234", 9, 5)
+	if want := []string{"my", "email"}; !reflect.DeepEqual(dst, want) {
+		t.Fatalf("after reuse: %q, want %q", dst, want)
+	}
+}
+
+// TestWordMatches pins the whole-word rule that replaces Presidio's substring
+// test. The "recipient"/"zip"/"script" cases are the reason for the divergence.
+func TestWordMatches(t *testing.T) {
+	tests := []struct {
+		word, context string
+		want          bool
+	}{
+		{"email", "email", true},
+		{"emails", "email", true},
+		{"card", "card", true},
+		{"cards", "card", true},
+		{"address", "address", true},
+		{"addresses", "address", true},
+		{"ips", "ip", true},
+		{"boxes", "box", true},
+
+		{"email", "emails", false},
+		{"recipient", "ip", false},
+		{"zip", "ip", false},
+		{"script", "ip", false},
+		{"mailbox", "mail", false},
+		{"e", "email", false},
+		{"", "email", false},
+		{"email", "", false},
+
+		// +1/+2 in length is necessary but not sufficient: the suffix has to
+		// be the plural and the prefix has to be the context word.
+		{"emailx", "email", false},
+		{"emailxy", "email", false},
+		{"xmails", "email", false},
+	}
+	for _, tt := range tests {
+		if got := wordMatches(tt.word, tt.context); got != tt.want {
+			t.Errorf("wordMatches(%q, %q) = %v, want %v", tt.word, tt.context, got, tt.want)
+		}
+	}
+}
+
+func TestContainsPhrase(t *testing.T) {
+	window := []string{"his", "social", "security", "number", "is"}
+	tests := []struct {
+		name   string
+		phrase []string
+		want   bool
+	}{
+		{"single word present", []string{"number"}, true},
+		{"single word absent", []string{"ssn"}, false},
+		{"contiguous phrase", []string{"social", "security"}, true},
+		{"phrase at the start", []string{"his", "social"}, true},
+		{"phrase at the end", []string{"number", "is"}, true},
+		{"non-contiguous words are not a phrase", []string{"social", "number"}, false},
+		{"reversed phrase", []string{"security", "social"}, false},
+		{"phrase longer than the window", []string{"a", "b", "c", "d", "e", "f"}, false},
+		{"empty phrase never matches", nil, false},
+		{"whole window", window, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsPhrase(window, tt.phrase); got != tt.want {
+				t.Errorf("containsPhrase(%q, %q) = %v, want %v",
+					window, tt.phrase, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWordContextEnhancerScores(t *testing.T) {
+	// The span is the digits of "my card 1234", so "my" and "card" are the
+	// context and the enhancer must not read the match itself.
+	const text = "my card 1234"
+	span := [2]int{8, 12}
+
+	tests := []struct {
+		name    string
+		score   float64
+		context []string
+		want    float64
+	}{
+		{"boost applied", 0.3, []string{"card"}, 0.65},
+		{"floor lifts a very weak match", 0.01, []string{"card"}, DefaultContextMinScore},
+		{"capped at MaxScore", 0.8, []string{"card"}, MaxScore},
+		{"already at MaxScore is untouched", MaxScore, []string{"card"}, MaxScore},
+		{"one of several context words is enough", 0.3,
+			[]string{"iban", "card", "bank"}, 0.65},
+		{"case-insensitive", 0.3, []string{"CARD"}, 0.65},
+		{"context word is itself plural", 0.3, []string{"cards"}, 0.3},
+		{"no matching context word", 0.3, []string{"iban", "bank"}, 0.3},
+		{"empty context list", 0.3, nil, 0.3},
+		{"context word is the match itself", 0.3, []string{"1234"}, 0.3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &ctxRecognizer{
+				name: "R", entity: "TEST", span: span, score: tt.score, context: tt.context,
+			}
+			got := NewWordContextEnhancer().Enhance(
+				text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+			if len(got) != 1 {
+				t.Fatalf("got %d results, want 1", len(got))
+			}
+			if !nearly(got[0].Score, tt.want) {
+				t.Errorf("score = %v, want %v", got[0].Score, tt.want)
+			}
+		})
+	}
+}
+
+// TestWordContextEnhancerIgnoresPlainRecognizer covers a recognizer that never
+// declared context words: it is not a ContextualRecognizer, so it is skipped.
+func TestWordContextEnhancerIgnoresPlainRecognizer(t *testing.T) {
+	const text = "my card 1234"
+	rec := &plainRecognizer{name: "R", entity: "TEST", span: [2]int{8, 12}, score: 0.3}
+
+	got := NewWordContextEnhancer().Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+	if len(got) != 1 || !nearly(got[0].Score, 0.3) {
+		t.Fatalf("got %+v, want a single untouched 0.3 result", got)
+	}
+}
+
+// TestWordContextEnhancerScopesContextToItsRecognizer pins that a result is
+// only boosted by the words its own recognizer declared, never by another's.
+func TestWordContextEnhancerScopesContextToItsRecognizer(t *testing.T) {
+	const text = "my card 1234"
+	mine := &ctxRecognizer{
+		name: "mine", entity: "MINE", span: [2]int{8, 12}, score: 0.3,
+		context: []string{"iban"},
+	}
+	theirs := &ctxRecognizer{
+		name: "theirs", entity: "THEIRS", span: [2]int{8, 12}, score: 0.3,
+		context: []string{"card"},
+	}
+
+	results := append(mine.Analyze(text, nil), theirs.Analyze(text, nil)...)
+	got := NewWordContextEnhancer().Enhance(
+		text, results, []Recognizer{mine, theirs}, nil)
+	if len(got) != 2 {
+		t.Fatalf("got %d results, want 2", len(got))
+	}
+	if !nearly(got[0].Score, 0.3) {
+		t.Errorf("mine: score = %v, want 0.3 (its own context word is absent)", got[0].Score)
+	}
+	if !nearly(got[1].Score, 0.65) {
+		t.Errorf("theirs: score = %v, want 0.65", got[1].Score)
+	}
+}
+
+func TestWordContextEnhancerWindowSize(t *testing.T) {
+	// "card" sits progressively further from the match; the default window is
+	// five words, so the six-words-away case must not boost.
+	tests := []struct {
+		name string
+		text string
+		want float64
+	}{
+		{"adjacent", "card 1234", 0.65},
+		{"five words away", "card a b c d 1234", 0.65},
+		{"six words away", "card a b c d e 1234", 0.3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := len(tt.text) - 4 // the trailing "1234"
+			rec := &ctxRecognizer{
+				name: "R", entity: "TEST",
+				span: [2]int{start, start + 4}, score: 0.3, context: []string{"card"},
+			}
+			got := NewWordContextEnhancer().Enhance(
+				tt.text, rec.Analyze(tt.text, nil), []Recognizer{rec}, nil)
+			if !nearly(got[0].Score, tt.want) {
+				t.Errorf("score = %v, want %v (text %q)", got[0].Score, tt.want, tt.text)
+			}
+		})
+	}
+}
+
+func TestWordContextEnhancerWordsAfter(t *testing.T) {
+	// Presidio reads nothing after the match — a label almost always precedes
+	// its value — but the window is configurable.
+	const text = "1234 card"
+	rec := &ctxRecognizer{
+		name: "R", entity: "TEST", span: [2]int{0, 4}, score: 0.3, context: []string{"card"},
+	}
+
+	got := NewWordContextEnhancer().Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+	if !nearly(got[0].Score, 0.3) {
+		t.Errorf("score = %v, want 0.3: nothing after the match is read by default",
+			got[0].Score)
+	}
+
+	enh := NewWordContextEnhancer()
+	enh.WordsAfter = 2
+	got = enh.Enhance(text, rec.Analyze(text, nil), []Recognizer{rec}, nil)
+	if !nearly(got[0].Score, 0.65) {
+		t.Errorf("score = %v, want 0.65 with WordsAfter=2", got[0].Score)
+	}
+}
+
+func TestWordContextEnhancerPhrase(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		ctx  []string
+		want float64
+	}{
+		{"phrase present", "his social security is 078-05-1120",
+			[]string{"social security"}, 0.65},
+		{"phrase split by another word", "social number security 078-05-1120",
+			[]string{"social security"}, 0.3},
+		{"phrase falls outside the window", "social security a b c d 078-05-1120",
+			[]string{"social security"}, 0.3},
+		{"plural inside a phrase is not folded", "his social securities 078-05-1120",
+			[]string{"social security"}, 0.3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := len(tt.text) - len("078-05-1120")
+			rec := &ctxRecognizer{
+				name: "R", entity: "TEST",
+				span: [2]int{start, len(tt.text)}, score: 0.3, context: tt.ctx,
+			}
+			got := NewWordContextEnhancer().Enhance(
+				tt.text, rec.Analyze(tt.text, nil), []Recognizer{rec}, nil)
+			if !nearly(got[0].Score, tt.want) {
+				t.Errorf("score = %v, want %v (text %q)", got[0].Score, tt.want, tt.text)
+			}
+		})
+	}
+}
+
+func TestEngineAppliesContextEnhancer(t *testing.T) {
+	const text = "my card 1234"
+	newEngine := func() *Engine {
+		reg := NewRegistry("en")
+		reg.Add("en", &ctxRecognizer{
+			name: "R", entity: "TEST", span: [2]int{8, 12}, score: 0.3,
+			context: []string{"card"},
+		})
+		return NewEngine(reg, []string{"en"})
+	}
+
+	t.Run("on by default", func(t *testing.T) {
+		got := newEngine().Analyze(text, Options{})
+		if len(got) != 1 || !nearly(got[0].Score, 0.65) {
+			t.Fatalf("got %+v, want a single 0.65 result", got)
+		}
+	})
+
+	t.Run("nil enhancer disables boosting", func(t *testing.T) {
+		eng := newEngine()
+		eng.SetContextEnhancer(nil)
+		got := eng.Analyze(text, Options{})
+		if len(got) != 1 || !nearly(got[0].Score, 0.3) {
+			t.Fatalf("got %+v, want a single 0.3 result", got)
+		}
+	})
+
+	// The reason the enhancer runs before the threshold: a result boosted over
+	// it has to survive to be returned.
+	t.Run("boost is applied before the threshold", func(t *testing.T) {
+		threshold := 0.6
+		if got := newEngine().Analyze(text, Options{Threshold: &threshold}); len(got) != 1 {
+			t.Fatalf("got %d results, want the boosted result kept", len(got))
+		}
+
+		eng := newEngine()
+		eng.SetContextEnhancer(nil)
+		if got := eng.Analyze(text, Options{Threshold: &threshold}); len(got) != 0 {
+			t.Fatalf("got %+v, want the unboosted result dropped", got)
+		}
+	})
+
+	t.Run("batch analysis boosts per text", func(t *testing.T) {
+		got := newEngine().AnalyzeBatch([]string{text, "no hint 1234"}, Options{})
+		if len(got) != 2 {
+			t.Fatalf("got %d result slices, want 2", len(got))
+		}
+		if len(got[0]) != 1 || !nearly(got[0][0].Score, 0.65) {
+			t.Errorf("text with context: got %+v, want 0.65", got[0])
+		}
+		if len(got[1]) != 1 || !nearly(got[1][0].Score, 0.3) {
+			t.Errorf("text without context: got %+v, want 0.3", got[1])
+		}
+	})
+}
+
+// TestEngineContextBoostDecidesOverlap is why the enhancer runs before
+// RemoveDuplicates: of two overlapping same-entity spans, the one the
+// surrounding text supports wins, even though it scores lower on the pattern
+// alone.
+func TestEngineContextBoostDecidesOverlap(t *testing.T) {
+	const text = "card 1234"
+	reg := NewRegistry("en")
+	reg.Add("en", &ctxRecognizer{
+		name: "weak-but-supported", entity: "TEST",
+		span: [2]int{5, 9}, score: 0.4, context: []string{"card"},
+	})
+	reg.Add("en", &ctxRecognizer{
+		name: "strong-but-unsupported", entity: "TEST",
+		span: [2]int{5, 9}, score: 0.6, context: []string{"iban"},
+	})
+
+	got := NewEngine(reg, []string{"en"}).Analyze(text, Options{})
+	if len(got) != 1 {
+		t.Fatalf("got %d results, want 1 after de-duplication", len(got))
+	}
+	if got[0].RecognizerName != "weak-but-supported" || !nearly(got[0].Score, 0.75) {
+		t.Errorf("got %s at %v, want weak-but-supported at 0.75",
+			got[0].RecognizerName, got[0].Score)
+	}
+}
+
+// nearly compares scores without depending on exact float equality.
+func nearly(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	return d < eps && d > -eps
+}

--- a/analyzer/engine.go
+++ b/analyzer/engine.go
@@ -28,15 +28,20 @@ type Engine struct {
 	threshold float64
 	languages []string
 	nlp       NlpEngine
+	context   ContextEnhancer
 }
 
 // NewEngine builds an engine over the given registry. languages records the
 // engine's configured languages for reference; analysis language is chosen per
 // call via Options.
+//
+// Context-aware scoring is on by default (see SetContextEnhancer), matching
+// Presidio.
 func NewEngine(registry *Registry, languages []string) *Engine {
 	return &Engine{
 		registry:  registry,
 		languages: append([]string(nil), languages...),
+		context:   NewWordContextEnhancer(),
 	}
 }
 
@@ -50,6 +55,13 @@ func (e *Engine) SetThreshold(t float64) { e.threshold = t }
 // recognizer. Without it, ArtifactRecognizers fall back to their plain
 // Analyze method. Call during setup, before the engine is used concurrently.
 func (e *Engine) SetNlpEngine(n NlpEngine) { e.nlp = n }
+
+// SetContextEnhancer replaces the context-aware score enhancer, which raises
+// a result's score when a word the recognizer declared via WithContext appears
+// near the match. NewEngine installs NewWordContextEnhancer; pass nil to score
+// purely on the pattern. Call during setup, before the engine is used
+// concurrently.
+func (e *Engine) SetContextEnhancer(c ContextEnhancer) { e.context = c }
 
 // Languages returns the engine's configured languages.
 func (e *Engine) Languages() []string { return append([]string(nil), e.languages...) }
@@ -144,6 +156,13 @@ func (e *Engine) analyzeWithArtifacts(text string, o Options, recs []Recognizer,
 			continue
 		}
 		all = append(all, rec.Analyze(text, o.Entities)...)
+	}
+
+	// Before de-duplication and the threshold, both of which decide what to
+	// keep by score: a boost can settle which of two overlapping spans wins,
+	// and a result boosted past the threshold has to survive to be seen.
+	if e.context != nil {
+		all = e.context.Enhance(text, all, recs, artifacts)
 	}
 
 	results := RemoveDuplicates(all)

--- a/analyzer/pattern_recognizer.go
+++ b/analyzer/pattern_recognizer.go
@@ -36,10 +36,15 @@ func NewPatternRecognizer(name, entity, language string, patterns []*Pattern) *P
 	}
 }
 
-// WithContext attaches context words that hint at the entity nearby. They are
-// retained for future context-aware scoring (which requires an NLP backend)
-// and are inert in the pattern-only engine. Returns the recognizer for
-// chaining.
+// WithContext attaches words that hint at this entity when they appear near a
+// match — the labels a value is usually written under ("ssn", "codice
+// fiscale"). The engine's ContextEnhancer raises a result's score when one of
+// them is in the surrounding words, so a pattern too weak to trust on its own
+// reaches a usable score in text that agrees with it. Matching is
+// case-insensitive and by whole word, so multi-word entries are matched as
+// phrases. No NLP backend is required.
+//
+// Returns the recognizer for chaining.
 func (pr *PatternRecognizer) WithContext(words ...string) *PatternRecognizer {
 	pr.context = words
 	return pr

--- a/cmd/alcatraz/context_test.go
+++ b/cmd/alcatraz/context_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanContextFlag covers the -context flag end to end, through run.
+//
+// The threshold is 0.8, the value downstream CI wrappers default to. A
+// labelled email scores 0.5 on its pattern alone and 0.85 once the words in
+// front of it are read, so the flag is the difference between a clean scan and
+// a failing one — which is the whole reason non-Go callers need a way to say
+// "pattern strength only".
+func TestScanContextFlag(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "notes.txt")
+	if err := os.WriteFile(file, []byte("email: jane@example.com\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		flag string
+		want int // exit code: 1 = findings, 0 = none
+	}{
+		{"context on by default", "-context=true", 1},
+		{"context off keeps pattern-only scores", "-context=false", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := runQuiet(t, []string{"scan", "-threshold", "0.8", tt.flag, file})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code != tt.want {
+				t.Errorf("exit code = %d, want %d", code, tt.want)
+			}
+		})
+	}
+}
+
+// TestHookContextFlag pins that the hook flag set accepts -context too: the
+// hook is how Claude Code calls the scanner, and it parses its own flags.
+func TestHookContextFlag(t *testing.T) {
+	for _, event := range []string{"claude-post", "claude-prompt"} {
+		t.Run(event, func(t *testing.T) {
+			stdin := os.Stdin
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.Close()
+			os.Stdin = r
+			defer func() { os.Stdin = stdin; r.Close() }()
+
+			if _, err := runQuiet(t, []string{"hook", event, "-context=false"}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// runQuiet calls run with stdout swallowed: these tests assert on exit codes,
+// and the findings report would otherwise land in the test log.
+func runQuiet(t *testing.T, args []string) (int, error) {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer devnull.Close()
+
+	saved := os.Stdout
+	os.Stdout = devnull
+	defer func() { os.Stdout = saved }()
+
+	return run(args)
+}

--- a/cmd/alcatraz/hook.go
+++ b/cmd/alcatraz/hook.go
@@ -83,6 +83,7 @@ func runHook(args []string) (int, error) {
 	threshold := fs.Float64("threshold", 0.5, "minimum confidence score in [0,1]")
 	entities := fs.String("entities", "", "comma-separated entity types to restrict to (empty = all)")
 	ignore := fs.String("ignore", "DATE_TIME,URL,IP_ADDRESS", "comma-separated entity types to drop as noise")
+	useContext := fs.Bool("context", true, "score a match higher when a word naming its entity type precedes it (-context=false for pattern-only scores)")
 	var skipTools, chain, mode *string
 	switch event {
 	case "claude-post":
@@ -100,6 +101,9 @@ func runHook(args []string) (int, error) {
 	}
 
 	s := newScanner(*threshold, splitList(*entities), splitList(*ignore), nil)
+	if !*useContext {
+		s.disableContext()
+	}
 
 	input, err := io.ReadAll(io.LimitReader(os.Stdin, maxHookBytes+1))
 	if err != nil {

--- a/cmd/alcatraz/main.go
+++ b/cmd/alcatraz/main.go
@@ -65,6 +65,7 @@ func run(args []string) (int, error) {
 	allowlistFile := fs.String("allowlist-file", "", "file with allowed values, one per line (# comments ok)")
 	jsonOut := fs.Bool("json", false, "emit the findings as JSON instead of text")
 	exclude := fs.String("exclude", "", "comma-separated glob patterns of diff paths to skip (diff only)")
+	useContext := fs.Bool("context", true, "score a match higher when a word naming its entity type precedes it (-context=false for pattern-only scores)")
 	if err := fs.Parse(rest); err != nil {
 		return 0, err
 	}
@@ -75,6 +76,9 @@ func run(args []string) (int, error) {
 	}
 	s := newScanner(*threshold, splitList(*entities), splitList(*ignore), allowList)
 	s.exclude = splitList(*exclude)
+	if !*useContext {
+		s.disableContext()
+	}
 
 	var findings []Finding
 	switch cmd {

--- a/cmd/alcatraz/scan.go
+++ b/cmd/alcatraz/scan.go
@@ -50,6 +50,17 @@ func newScanner(threshold float64, entities, ignore, allowList []string) *scanne
 	}
 }
 
+// disableContext turns off context-aware scoring, restoring the scores a
+// pattern gets on its own.
+//
+// This exists for callers who read a threshold as a statement about pattern
+// strength alone — "0.8 means checksum-validated" — since context can lift a
+// labelled email or phone from 0.5 to 0.85 and over that line. The Go API says
+// the same thing with Engine.SetContextEnhancer(nil).
+func (s *scanner) disableContext() {
+	s.engine.SetContextEnhancer(nil)
+}
+
 // excluded reports whether a diff path matches any exclude pattern. Patterns
 // match the full path or its basename; "dir/**" matches everything under dir.
 func (s *scanner) excluded(file string) bool {

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,92 @@
+package alcatraz_test
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/entities"
+)
+
+// scoreOf returns the score of the first result of the given type, or -1.
+func scoreOf(results []alcatraz.Result, entityType string) float64 {
+	for _, r := range results {
+		if r.EntityType == entityType {
+			return r.Score
+		}
+	}
+	return -1
+}
+
+// TestContextBoostWithBuiltinRecognizers is the end-to-end shape of ATR-208:
+// with the real recognizer set, a label next to a value lifts a pattern-only
+// detection from its base score to Presidio's 0.85.
+func TestContextBoostWithBuiltinRecognizers(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		entity string
+		want   float64
+	}{
+		{"bare email scores on the pattern alone",
+			"jane@example.com", entities.EmailAddress, 0.5},
+		{"labelled email is boosted",
+			"email: jane@example.com", entities.EmailAddress, 0.85},
+		{"a plural label still counts",
+			"Emails: jane@example.com", entities.EmailAddress, 0.85},
+		{"a word merely containing the label does not",
+			"the recipient is jane@example.com", entities.EmailAddress, 0.5},
+		{"bare phone number",
+			"call me on 555-123-4567", entities.PhoneNumber, 0.5},
+		{"labelled phone number",
+			"my phone is 555-123-4567", entities.PhoneNumber, 0.85},
+		// A checksum-validated entity is already at MaxScore, so context
+		// cannot and need not raise it.
+		{"validated SSN is unaffected",
+			"536-90-4399", entities.USSSN, alcatraz.MaxScore},
+		{"labelled SSN is unaffected",
+			"ssn: 536-90-4399", entities.USSSN, alcatraz.MaxScore},
+	}
+
+	eng := alcatraz.NewEngine()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scoreOf(eng.Analyze(tt.text, alcatraz.Options{}), tt.entity)
+			if diff := got - tt.want; diff > 1e-9 || diff < -1e-9 {
+				t.Errorf("%s score = %v, want %v (text %q)",
+					tt.entity, got, tt.want, tt.text)
+			}
+		})
+	}
+}
+
+// TestContextBoostClearsThreshold is the reason ATR-208 was filed: a caller
+// running a threshold above the pattern ceiling used to match nothing at all,
+// however clearly the text labelled the value.
+func TestContextBoostClearsThreshold(t *testing.T) {
+	threshold := 0.6
+	eng := alcatraz.NewEngine()
+
+	got := eng.Analyze("email: jane@example.com", alcatraz.Options{Threshold: &threshold})
+	if !hasEntity(got, entities.EmailAddress, "jane@example.com") {
+		t.Errorf("labelled email should clear a %.2f threshold, got %+v", threshold, got)
+	}
+
+	// The threshold still does its job on text with nothing to support it.
+	got = eng.Analyze("jane@example.com", alcatraz.Options{Threshold: &threshold})
+	if hasEntity(got, entities.EmailAddress, "jane@example.com") {
+		t.Errorf("bare email should not clear a %.2f threshold, got %+v", threshold, got)
+	}
+}
+
+// TestContextEnhancerCanBeDisabled keeps the pattern-only scores reachable for
+// a caller that has tuned its thresholds against them.
+func TestContextEnhancerCanBeDisabled(t *testing.T) {
+	eng := alcatraz.NewEngine()
+	eng.SetContextEnhancer(nil)
+
+	got := scoreOf(eng.Analyze("email: jane@example.com", alcatraz.Options{}),
+		entities.EmailAddress)
+	if diff := got - 0.5; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("score = %v, want the unboosted 0.5", got)
+	}
+}


### PR DESCRIPTION
Closes ATR-208.

## The problem

`PatternRecognizer.WithContext` has existed since the port and 45 built-in recognizers call it. Nothing ever read the result. The doc comment was honest about it:

> They are retained for future context-aware scoring (which requires an NLP backend) and are inert in the pattern-only engine.

So a pattern-only `EMAIL_ADDRESS` was pinned at its `0.5` base score however plainly the text labelled it, and a caller running `Options.Threshold` above `0.5` matched nothing at all. Presidio reaches `0.85` on the same input.

```go
eng.Analyze("email: jane@example.com", alcatraz.Options{}) // was 0.50, now 0.85
eng.Analyze("jane@example.com", alcatraz.Options{})        // still 0.50
```

## The change

`analyzer.ContextEnhancer` is a new seam; `WordContextEnhancer` is the default implementation, installed by `NewEngine` and swappable — or removable — through `Engine.SetContextEnhancer`.

It reproduces Presidio's `LemmaContextAwareEnhancer`: **+0.35** when one of the recognizer's own context words appears in the **five words before** the match, floored at **0.4**, capped at `MaxScore`.

### Two deliberate departures from Presidio

Both follow from this package having no NLP dependency to lean on.

**Words come from a built-in rune scanner over the raw text, not from spaCy tokens.** Reading `NlpArtifacts.Tokens` would have left the boost inert on the pattern-only path — which is exactly the path the bug is about, and the one with no model to fall back on. `Enhance` still receives the artifacts and will use lemmas once the NLP seam carries tokens (tracked in `TODO.md`).

**Matching is whole word, not substring.** Presidio asks whether the context word occurs anywhere inside a token, so an IP address next to `recipient`, `zip` or `script` gets boosted by the `ip` context word. Whole-word matching with an English plural fold (`cards` supports `card`, `addresses` supports `address`) covers the inflection the substring test was there to absorb, without the false positives. Multi-word entries (`"social security"`, `"codice fiscale"`) match as consecutive words. `analyzer/context_test.go:TestWordMatches` pins all three false-positive cases.

### Where it sits in the pipeline

After the recognizers, **before** `RemoveDuplicates` and the threshold. Both of those decide what to keep by score, so:

- a boost can settle which of two overlapping same-entity spans wins — `TestEngineContextBoostDecidesOverlap` has a supported `0.4` span beat an unsupported `0.6` one at identical coordinates;
- a result boosted past the threshold has to survive to be returned — `TestContextBoostClearsThreshold`.

### What it leaves alone

- Results already at `MaxScore` (anything a checksum validator verified — US_SSN, credit cards) are skipped: context can neither raise them nor is it needed.
- A recognizer that never called `WithContext` isn't a `ContextualRecognizer` and is never consulted.
- A result is only ever boosted by the words *its own* recognizer declared.

## Cost

Context words are split per call only for recognizers that actually produced a boostable result — typically one or two of the ~45 registered — and the word window is a single buffer reused across results.

Benchmarked over 200 log lines (400 detections), enhancer on vs. `SetContextEnhancer(nil)`:

```
BenchmarkCtxOn-15     16.0 ms/op   483656 B/op   1533 allocs/op
BenchmarkCtxOff-15    16.1 ms/op   483028 B/op   1312 allocs/op
```

No measurable time cost. The ~220 remaining allocations are `strings.ToLower` on the one uppercase word (`INFO`) in each synthetic log line.

## Tests

- `analyzer/context_test.go` — unit coverage for the word scanners (multi-byte, Thai combining marks, boundary-straddling words, buffer reuse), the whole-word rule, phrase matching, boost/floor/cap/skip behaviour, recognizer scoping, window size, and engine wiring including the two ordering guarantees above.
- `context_test.go` (root) — end-to-end against the real recognizer set: bare vs. labelled email and phone, the plural label, the `recipient` non-match, validated SSN unaffected, threshold clearance, and `SetContextEnhancer(nil)` restoring the old scores.
- `cmd/alcatraz/context_test.go` — the `-context` flag through `run`: a labelled email at threshold `0.8` exits `1` with context and `0` without, which is the CI outcome the flag exists for.

Root module and all four sub-modules: `gofmt`, `go vet`, `go test` clean.


## Opting out

Context scoring changes what a threshold means. A labelled `EMAIL_ADDRESS` now reaches `0.85`, so a caller reading `0.8` as "a checksum validated this" gets a different answer than before — though only because `0.8` previously meant that *by accident*: the pattern-only ceiling was `0.5`, so any threshold above it quietly matched nothing.

Both surfaces can turn it off:

```go
eng.SetContextEnhancer(nil)  // Go API
```

```
alcatraz scan  -context=false   # also on diff and hook
```

## Review follow-up (1cf3449)

- **Negative `WordsBefore`/`WordsAfter` panicked `Analyze`.** The fields are exported; they reached `make` as a negative capacity. Now read as `max(field, 0)`.
- **A sub-zero `MinScore` or negative `Boost` could write a `Result.Score` outside `[MinScore, MaxScore]`.** The floor is pulled into range once at the top of `Enhance`, which keeps every score written below it in range.
- **A long opaque run in front of a match was copied in full by `strings.ToLower`** just to be rejected on length. On a 1 MiB run: `1,057,166 B/op` → `4,801` (against `4,232` with the enhancer off). The bound is derived from the context words in play — `wordMatches` accepts at most `len(context)+2` bytes — rather than being a constant that would silently stop matching a caller's longer custom context word. Only *copying* is bounded, not traversal: walking is free next to the regex pass (`579` vs `586` ms/op), and giving up mid-run would drop a legitimate label sitting behind the blob.

## Caveat — this does **not** fix ATR-205

Presidio's window is five words *before* the match. In tabular `psql` output the column name is on a different line, far outside it. This ticket is a precision improvement in prose and log text; it is not a fix for the header-row case.

