### PR TITLE
feat(br): six more Brazilian identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### PII detection for Go. In-process, dependency-free.
 
-Emails, credit cards, national IDs: **45 entity types across 12 countries**,
+Emails, credit cards, national IDs: **51 entity types across 12 countries**,
 detected with a function call. No service, no network, no models to download.
 
 [![CI](https://github.com/hoophq/alcatraz/actions/workflows/test.yml/badge.svg)](https://github.com/hoophq/alcatraz/actions/workflows/test.yml)
@@ -39,7 +39,7 @@ library you `go get` and invoke in-process.
 
 ## Why Alcatraz
 
-- ✅ **Checksum-verified.** 25 of the 45 recognizers carry a real checksum
+- ✅ **Checksum-verified.** 29 of the 52 recognizers carry a real checksum
   validator: Luhn (credit cards), ISO 7064 mod-97 (IBAN), Verhoeff (Aadhaar),
   the Brazilian mod-11 schemes (CPF, CNPJ, CNH, PIS), and more. A 16-digit
   number that fails Luhn is *dropped*, not flagged.
@@ -116,7 +116,7 @@ reference and Claude Code hook setup: **[docs/cli.md](docs/cli.md)**.
 |---|---|
 | Install, quickstart, engine reuse | [docs/install.md](docs/install.md) |
 | CLI flags, exit codes, hooks | [docs/cli.md](docs/cli.md) |
-| The 45 entity types | [docs/entities.md](docs/entities.md) |
+| The 51 entity types | [docs/entities.md](docs/entities.md) |
 | The detection pipeline | [docs/how-it-works.md](docs/how-it-works.md) |
 | Why a bare email scores 0.5 | [docs/context-scoring.md](docs/context-scoring.md) |
 | Mask, replace, redact | [docs/anonymize.md](docs/anonymize.md) |
@@ -147,7 +147,7 @@ analyzer/          Framework: Result, dedup, Recognizer, Pattern, Matcher,
                    context-aware scoring (ContextEnhancer), and the NLP seam
                    (NlpEngine, NlpArtifacts, ArtifactRecognizer).
 anonymizer/        Mask/replace/redact detected spans (Operator, Config).
-recognizers/       The 45 built-in recognizers, checksum helpers, loader.
+recognizers/       The 51 built-in recognizers, checksum helpers, loader.
 models/            Pinned model manifests and checksum-verified downloads for
                    the optional NER backends. In the root module, stdlib only,
                    so the CLI fetches models without the model runtime.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -14,7 +14,7 @@ confirm an identifier rather than matching its shape. Constants live in the
 | Italy | `IT_FISCAL_CODE`✓, `IT_VAT_CODE`✓, `IT_IDENTITY_CARD`, `IT_DRIVER_LICENSE`, `IT_PASSPORT` |
 | Spain | `ES_NIF`✓, `ES_NIE`✓ |
 | Singapore | `SG_FIN`✓, `SG_UEN` |
-| Brazil | `BR_CPF`✓, `BR_CNPJ`✓, `BR_RG`, `BR_CNH`✓, `BR_PIS`✓ |
+| Brazil | `BR_CPF`✓, `BR_CNPJ`✓, `BR_RG`, `BR_CNH`✓, `BR_PIS`✓, `BR_CNS`✓, `BR_TITULO_ELEITORAL`✓, `BR_RENAVAM`✓, `BR_CEP`, `BR_PLACA`, `BR_PIX_KEY` |
 | Other | `PL_PESEL`✓, `KR_RRN`✓, `FI_PERSONAL_IDENTITY_CODE`✓, `TH_TNIN`✓ |
 
 Every built-in detects a **language-independent** structured identifier: an

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -73,11 +73,17 @@ const (
 
 // Brazil.
 const (
-	BRCPF  = "BR_CPF"
-	BRCNPJ = "BR_CNPJ"
-	BRRG   = "BR_RG"
-	BRCNH  = "BR_CNH"
-	BRPIS  = "BR_PIS" // also PASEP / NIS / NIT
+	BRCPF     = "BR_CPF"
+	BRCNPJ    = "BR_CNPJ"
+	BRRG      = "BR_RG"
+	BRCNH     = "BR_CNH"
+	BRPIS     = "BR_PIS" // also PASEP / NIS / NIT
+	BRCNS     = "BR_CNS" // Cartão Nacional de Saúde
+	BRTitulo  = "BR_TITULO_ELEITORAL"
+	BRRenavam = "BR_RENAVAM"
+	BRCEP     = "BR_CEP"
+	BRPlaca   = "BR_PLACA"
+	BRPixKey  = "BR_PIX_KEY"
 )
 
 // Other national identifiers.

--- a/recognizers/brazil.go
+++ b/recognizers/brazil.go
@@ -318,11 +318,17 @@ func BRCEP() analyzer.Recognizer {
 // gated on an explicit CEP word before the number rather than on a structural
 // test: a passing validator is promoted to MaxScore, so a validator here would
 // mask every eight-digit number in a response at full confidence.
+//
+// The score is high because a context validator only filters, it does not
+// raise the score the way WithContext does. A low score would leave the
+// recognizer unreachable to any caller whose threshold sits above it, even
+// though the label gate had already passed — the gate, not the score, is what
+// establishes confidence here.
 func BRCEPUnformatted() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"BrCepUnformattedRecognizer", entities.BRCEP, "pt",
 		[]*analyzer.Pattern{
-			analyzer.MustPattern("BR CEP (unformatted)", `\b\d{8}\b`, 0.4),
+			analyzer.MustPattern("BR CEP (unformatted)", `\b\d{8}\b`, 0.8),
 		},
 	).WithContextValidator(func(text string, start, _ int) bool {
 		return labelBefore(text, start, "cep", "codigo postal", "código postal", "postal code", "zip")
@@ -354,15 +360,19 @@ func BRPlaca() analyzer.Recognizer {
 // this is gated on a PIX word just before the value. The gate is a context
 // validator rather than a low score plus WithContext because a pattern scored
 // under the caller's threshold is dropped before the context bonus can lift it.
+//
+// The bare word "chave" is not accepted: it is Portuguese for "key", so
+// "chave primária" ahead of a row id would mask an ordinary UUID. Only "pix",
+// "evp" and the phrase "chave pix" count.
 func BRPixKey() analyzer.Recognizer {
 	return analyzer.NewPatternRecognizer(
 		"BrPixKeyRecognizer", entities.BRPixKey, "pt",
 		[]*analyzer.Pattern{
 			analyzer.MustPattern("BR PIX EVP key",
-				`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b`, 0.5),
+				`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b`, 0.8),
 		},
 	).WithContextValidator(func(text string, start, _ int) bool {
-		return labelBefore(text, start, "pix", "chave", "evp")
+		return labelBefore(text, start, "pix", "evp", "chave pix")
 	})
 }
 

--- a/recognizers/brazil.go
+++ b/recognizers/brazil.go
@@ -1,6 +1,9 @@
 package recognizers
 
 import (
+	"strings"
+	"unicode"
+
 	"github.com/hoophq/alcatraz/analyzer"
 	"github.com/hoophq/alcatraz/entities"
 )
@@ -147,4 +150,256 @@ func allEqual(ds []int) bool {
 		}
 	}
 	return len(ds) > 0
+}
+
+// BRCNS detects the Cartão Nacional de Saúde, Brazil's health-card number: 15
+// digits validated by a mod-11 rule that differs by range.
+//
+// A definitive card (leading 1 or 2) is a PIS/PASEP number in the first eleven
+// digits followed by a three-digit control block and a check digit: the block
+// is "000", or "001" where the first computed digit came out as 10 and the sum
+// is adjusted by 2. Checking only that the whole 15-digit weighted sum is a
+// multiple of 11 is not enough — the control block can be corrupted while
+// preserving that sum, which would mask an arbitrary 15-digit number.
+//
+// A provisional card (leading 7, 8 or 9) carries no PIS base and its rule is
+// exactly the weighted-sum test.
+func BRCNS() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrCnsRecognizer", entities.BRCNS, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR CNS (formatted)", `\b\d{3} \d{4} \d{4} \d{4}\b`, 0.4),
+			analyzer.MustPattern("BR CNS", `\b\d{15}\b`, 0.3),
+		},
+	).WithContext("cns", "cartão nacional de saúde", "cartao nacional de saude", "sus").
+		WithValidator(validateBRCNS)
+}
+
+func validateBRCNS(s string) bool {
+	ds, ok := digitsExactly(s, 15)
+	if !ok {
+		return false
+	}
+	switch ds[0] {
+	case 1, 2:
+		return validDefinitiveBRCNS(ds)
+	case 7, 8, 9:
+		return weightedSum15(ds)%11 == 0
+	default:
+		return false
+	}
+}
+
+// validDefinitiveBRCNS recomputes the control block and check digit from the
+// PIS/PASEP base and requires an exact match.
+func validDefinitiveBRCNS(ds []int) bool {
+	sum := 0
+	for i := 0; i < 11; i++ {
+		sum += ds[i] * (15 - i)
+	}
+	dv := 11 - sum%11
+	if dv == 11 {
+		dv = 0
+	}
+	block := 0
+	if dv == 10 {
+		// The +2 lands the eleventh digit's weight at 6 instead of 5, which is
+		// what the "001" block records.
+		dv = 11 - (sum+2)%11
+		block = 1
+	}
+	return ds[11] == 0 && ds[12] == 0 && ds[13] == block && ds[14] == dv
+}
+
+// weightedSum15 is the CNS weighting: digit i counts (15-i) times.
+func weightedSum15(ds []int) int {
+	sum := 0
+	for i, d := range ds {
+		sum += d * (15 - i)
+	}
+	return sum
+}
+
+// BRTitulo detects a voter registration (título eleitoral): 12 digits whose
+// last two are check digits over the sequence and the issuing electoral region.
+func BRTitulo() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrTituloEleitoralRecognizer", entities.BRTitulo, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR título eleitoral (formatted)", `\b\d{4} \d{4} \d{4}\b`, 0.4),
+			analyzer.MustPattern("BR título eleitoral", `\b\d{12}\b`, 0.3),
+		},
+	).WithContext("título", "titulo", "eleitor", "eleitoral", "tse").
+		WithValidator(validateBRTitulo)
+}
+
+func validateBRTitulo(s string) bool {
+	ds, ok := digitsExactly(s, 12)
+	if !ok {
+		return false
+	}
+	if uf := ds[8]*10 + ds[9]; uf < 1 || uf > 28 { // 01-28 are the electoral regions
+		return false
+	}
+	sum := 0
+	for i := 0; i < 8; i++ {
+		sum += ds[i] * (i + 2)
+	}
+	dv1 := sum % 11
+	if dv1 == 10 {
+		dv1 = 0
+	}
+	if dv1 != ds[10] {
+		return false
+	}
+	dv2 := (ds[8]*7 + ds[9]*8 + dv1*9) % 11
+	if dv2 == 10 {
+		dv2 = 0
+	}
+	return dv2 == ds[11]
+}
+
+// BRRenavam detects a vehicle registration: 11 digits with a mod-11 check
+// digit.
+//
+// PIS shares the length and the weights, so every valid RENAVAM is also a
+// structurally valid PIS and vice versa. No validator can separate them; only
+// the surrounding word can. Both recognizers therefore fire on a bare number
+// and whichever scores first wins, which is correct for masking (the value is
+// blanked either way) and honest for detection (in a context-free dump the
+// engine genuinely cannot know which one it found).
+func BRRenavam() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrRenavamRecognizer", entities.BRRenavam, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR RENAVAM", `\b\d{11}\b`, 0.3),
+		},
+	).WithContext("renavam", "veículo", "veiculo", "detran", "crlv").
+		WithValidator(validateBRRenavam)
+}
+
+func validateBRRenavam(s string) bool {
+	ds, ok := digitsExactly(s, 11)
+	if !ok || allEqual(ds) {
+		return false
+	}
+	weights := []int{3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	sum := 0
+	for i := 0; i < 10; i++ {
+		sum += ds[i] * weights[i]
+	}
+	dv := 11 - sum%11
+	if dv >= 10 {
+		dv = 0
+	}
+	return dv == ds[10]
+}
+
+// BRCEP detects a postal code in its hyphenated form.
+//
+// Only XXXXX-XXX is matched, and there is no validator: a passing validator
+// promotes the match to MaxScore, and a CEP has no check digit, so any
+// structural test would be promoting a guess. The hyphen is the evidence —
+// five digits, a hyphen, three digits is not a shape ordinary numbers take.
+// The unformatted form is BRCEPUnformatted.
+func BRCEP() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrCepRecognizer", entities.BRCEP, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR CEP", `\b\d{5}-\d{3}\b`, 0.5),
+		},
+	).WithContext("cep", "código postal", "codigo postal", "endereço", "endereco")
+}
+
+// BRCEPUnformatted detects a CEP written as eight bare digits.
+//
+// Separate from BRCEP because eight digits is also an order id, a reference
+// number and a yyyymmdd date, and nothing about the digits says which. It is
+// gated on an explicit CEP word before the number rather than on a structural
+// test: a passing validator is promoted to MaxScore, so a validator here would
+// mask every eight-digit number in a response at full confidence.
+func BRCEPUnformatted() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrCepUnformattedRecognizer", entities.BRCEP, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR CEP (unformatted)", `\b\d{8}\b`, 0.4),
+		},
+	).WithContextValidator(func(text string, start, _ int) bool {
+		return labelBefore(text, start, "cep", "codigo postal", "código postal", "postal code", "zip")
+	})
+}
+
+// BRPlaca detects a vehicle plate in both the Mercosur layout (ABC1D23) and the
+// legacy one (ABC-1234). Neither shape occurs by accident in prose, so both
+// score on the pattern.
+//
+// Case-insensitive: a plate is uppercase on the car, but a database dump or a
+// free-text note routinely stores it lowercase, and a missed detection there is
+// a leak.
+func BRPlaca() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrPlacaRecognizer", entities.BRPlaca, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR placa Mercosul", `(?i)\b[a-z]{3}\d[a-z]\d{2}\b`, 0.6),
+			analyzer.MustPattern("BR placa (legacy)", `(?i)\b[a-z]{3}-\d{4}\b`, 0.6),
+		},
+	).WithContext("placa", "veículo", "veiculo", "carro")
+}
+
+// BRPixKey detects a PIX random key (EVP): a UUID the Central Bank issues as a
+// payment address. The other PIX key kinds are a CPF, an email or a phone,
+// which alcatraz already detects under their own entities.
+//
+// A bare UUID is not a payment key — most UUIDs in a database are row ids — so
+// this is gated on a PIX word just before the value. The gate is a context
+// validator rather than a low score plus WithContext because a pattern scored
+// under the caller's threshold is dropped before the context bonus can lift it.
+func BRPixKey() analyzer.Recognizer {
+	return analyzer.NewPatternRecognizer(
+		"BrPixKeyRecognizer", entities.BRPixKey, "pt",
+		[]*analyzer.Pattern{
+			analyzer.MustPattern("BR PIX EVP key",
+				`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b`, 0.5),
+		},
+	).WithContextValidator(func(text string, start, _ int) bool {
+		return labelBefore(text, start, "pix", "chave", "evp")
+	})
+}
+
+// labelBefore reports whether one of labels appears as a whole word in the few
+// characters before start.
+//
+// Whole word, not substring: "recepcao 12345678" contains "cep" and would
+// otherwise satisfy a CEP gate, masking an ordinary eight-digit number — the
+// exact false positive these gates exist to prevent. Multi-word labels are
+// matched against the joined tokens so "codigo postal" still works.
+func labelBefore(text string, start int, labels ...string) bool {
+	const window = 24
+	from := start - window
+	if from < 0 {
+		from = 0
+	}
+	prefix := strings.ToLower(text[from:start])
+	fields := strings.FieldsFunc(prefix, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	if len(fields) == 0 {
+		return false
+	}
+	joined := strings.Join(fields, " ")
+	for _, l := range labels {
+		if !strings.Contains(l, " ") {
+			for _, f := range fields {
+				if f == l {
+					return true
+				}
+			}
+			continue
+		}
+		if joined == l || strings.HasPrefix(joined, l+" ") ||
+			strings.HasSuffix(joined, " "+l) || strings.Contains(joined, " "+l+" ") {
+			return true
+		}
+	}
+	return false
 }

--- a/recognizers/brazil_test.go
+++ b/recognizers/brazil_test.go
@@ -1,0 +1,93 @@
+package recognizers_test
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz/analyzer"
+	"github.com/hoophq/alcatraz/entities"
+	"github.com/hoophq/alcatraz/recognizers"
+)
+
+// detectBR runs the default recognizer set over text and returns the first
+// value found for entity. It exercises registration, pattern, validator and
+// context together, the way a caller experiences them.
+func detectBR(t *testing.T, text, entity string) string {
+	t.Helper()
+	reg := analyzer.NewRegistry("en")
+	recognizers.LoadDefaults(reg, "en")
+	eng := analyzer.NewEngine(reg, []string{"en"})
+
+	for _, r := range eng.Analyze(text, analyzer.Options{Language: "en", Entities: []string{entity}}) {
+		return text[r.Start:r.End]
+	}
+	return ""
+}
+
+// TestBrazilianIdentifiers pins that each recognizer fires on a checksum-valid
+// value in the context it appears in production.
+func TestBrazilianIdentifiers(t *testing.T) {
+	cases := []struct{ name, text, entity, want string }{
+		{"cns", "cns do paciente: 297220185600003", entities.BRCNS, "297220185600003"},
+		{"cns provisional", "cns 823111431391203 sus", entities.BRCNS, "823111431391203"},
+		{"titulo", "titulo de eleitor 483917830248 emitido", entities.BRTitulo, "483917830248"},
+		{"renavam", "renavam 20193580815 do veiculo", entities.BRRenavam, "20193580815"},
+		{"cep", "endereco cep 86759-690 zona sul", entities.BRCEP, "86759-690"},
+		{"cep unformatted", "cep 04571010 zona sul", entities.BRCEP, "04571010"},
+		{"placa mercosul", "placa IXR5D51 apreendida", entities.BRPlaca, "IXR5D51"},
+		{"placa legacy", "placa ABC-1234 apreendida", entities.BRPlaca, "ABC-1234"},
+		// A dump or a note stores the plate as typed, not as painted.
+		{"placa lowercase", "placa ixr5d51 apreendida", entities.BRPlaca, "ixr5d51"},
+		{"pix", "chave pix 0eac66dd-182d-434f-8ab8-297738b2d66d", entities.BRPixKey, "0eac66dd-182d-434f-8ab8-297738b2d66d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectBR(t, tc.text, tc.entity); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.entity, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBrazilianRejectsNonIdentifiers is the point of the validators and the
+// context gates: an eleven-digit number is a phone, a fifteen-digit one is an
+// order id, and neither should be masked for being long.
+func TestBrazilianRejectsNonIdentifiers(t *testing.T) {
+	const uuid = "0eac66dd-182d-434f-8ab8-297738b2d66d"
+	cases := []struct{ name, text, entity string }{
+		{"cns bad check", "cns do paciente: 297220185600004", entities.BRCNS},
+		// Control block corrupted while the weighted sum stays a multiple of 11.
+		{"cns bad control block", "cns do paciente: 297220185600100", entities.BRCNS},
+		{"titulo bad check", "titulo de eleitor 483917830249", entities.BRTitulo},
+		{"renavam bad check", "renavam 20193580816 do veiculo", entities.BRRenavam},
+		{"renavam repdigit", "renavam 11111111111 do veiculo", entities.BRRenavam},
+
+		// Ordinary values that must pass through: the label gates match whole
+		// words, so a token merely containing "cep" or "pix" is not a label.
+		{"plain order id", "order 45012876 shipped", entities.BRCEP},
+		{"cep substring", "recepcao 12345678 registrada", entities.BRCEP},
+		{"pix substring", "pixel " + uuid + " id", entities.BRPixKey},
+		{"bare uuid", "row id " + uuid + " updated", entities.BRPixKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectBR(t, tc.text, tc.entity); got != "" {
+				t.Errorf("%s matched %q, want no detection", tc.entity, got)
+			}
+		})
+	}
+}
+
+// TestRenavamAndPisShareTheirChecksum documents a collision callers have to
+// live with: PIS and RENAVAM are both eleven digits with the same mod-11
+// weights, so every valid RENAVAM is also a structurally valid PIS. Only the
+// surrounding word separates them, and in a context-free dump neither
+// recognizer can claim to be the right one.
+func TestRenavamAndPisShareTheirChecksum(t *testing.T) {
+	const v = "20193580815"
+	if got := detectBR(t, "renavam "+v+" do veiculo", entities.BRRenavam); got != v {
+		t.Errorf("RENAVAM in vehicle context = %q, want %q", got, v)
+	}
+	if got := detectBR(t, "pis "+v+" do trabalhador", entities.BRPIS); got != v {
+		t.Errorf("same digits in PIS context = %q, want %q — the checksums are identical", got, v)
+	}
+}

--- a/recognizers/brazil_test.go
+++ b/recognizers/brazil_test.go
@@ -23,6 +23,23 @@ func detectBR(t *testing.T, text, entity string) string {
 	return ""
 }
 
+// detectBRAt is detectBR with an explicit score threshold.
+func detectBRAt(t *testing.T, text, entity string, threshold float64) string {
+	t.Helper()
+	reg := analyzer.NewRegistry("en")
+	recognizers.LoadDefaults(reg, "en")
+	eng := analyzer.NewEngine(reg, []string{"en"})
+
+	opts := analyzer.Options{Language: "en", Entities: []string{entity}}
+	if threshold > 0 {
+		opts.Threshold = &threshold
+	}
+	for _, r := range eng.Analyze(text, opts) {
+		return text[r.Start:r.End]
+	}
+	return ""
+}
+
 // TestBrazilianIdentifiers pins that each recognizer fires on a checksum-valid
 // value in the context it appears in production.
 func TestBrazilianIdentifiers(t *testing.T) {
@@ -89,5 +106,48 @@ func TestRenavamAndPisShareTheirChecksum(t *testing.T) {
 	}
 	if got := detectBR(t, "pis "+v+" do trabalhador", entities.BRPIS); got != v {
 		t.Errorf("same digits in PIS context = %q, want %q — the checksums are identical", got, v)
+	}
+}
+
+// TestContextGatedSurviveThreshold pins that the two context-gated recognizers
+// are reachable at a realistic caller threshold.
+//
+// WithContextValidator only filters; unlike WithContext it does not raise the
+// score. A gated pattern scored at or below the caller's threshold is therefore
+// dropped even though its label gate passed, which makes the recognizer
+// unreachable rather than merely conservative.
+func TestContextGatedSurviveThreshold(t *testing.T) {
+	const uuid = "0eac66dd-182d-434f-8ab8-297738b2d66d"
+	for _, th := range []float64{0, 0.4, 0.6, 0.75} {
+		if got := detectBRAt(t, "cep 04571010 zona sul", entities.BRCEP, th); got != "04571010" {
+			t.Errorf("threshold %.2f: unformatted CEP = %q, want 04571010", th, got)
+		}
+		if got := detectBRAt(t, "chave pix "+uuid, entities.BRPixKey, th); got != uuid {
+			t.Errorf("threshold %.2f: PIX key = %q, want the uuid", th, got)
+		}
+	}
+}
+
+// TestPixLabelIsPixSpecific pins that the gate needs a PIX word, not merely the
+// Portuguese word for "key": "chave primária" precedes ordinary row ids.
+func TestPixLabelIsPixSpecific(t *testing.T) {
+	const uuid = "0eac66dd-182d-434f-8ab8-297738b2d66d"
+	for _, text := range []string{
+		"chave primaria " + uuid,
+		"chave estrangeira " + uuid,
+		"a chave " + uuid,
+	} {
+		if got := detectBR(t, text, entities.BRPixKey); got != "" {
+			t.Errorf("%q: masked %q as a PIX key on a generic 'chave'", text, got)
+		}
+	}
+	for _, text := range []string{
+		"chave pix " + uuid,
+		"pix " + uuid,
+		"evp " + uuid,
+	} {
+		if got := detectBR(t, text, entities.BRPixKey); got != uuid {
+			t.Errorf("%q: PIX key = %q, want the uuid", text, got)
+		}
 	}
 }

--- a/recognizers/defaults.go
+++ b/recognizers/defaults.go
@@ -70,7 +70,11 @@ func singapore() []analyzer.Recognizer {
 }
 
 func brazil() []analyzer.Recognizer {
-	return []analyzer.Recognizer{BRCPF(), BRCNPJ(), BRRG(), BRCNH(), BRPIS()}
+	return []analyzer.Recognizer{
+		BRCPF(), BRCNPJ(), BRRG(), BRCNH(), BRPIS(),
+		BRCNS(), BRTitulo(), BRRenavam(),
+		BRCEP(), BRCEPUnformatted(), BRPlaca(), BRPixKey(),
+	}
 }
 
 func other() []analyzer.Recognizer {

--- a/recognizers/example_test.go
+++ b/recognizers/example_test.go
@@ -72,8 +72,8 @@ func ExampleAll() {
 	fmt.Println(len(recognizers.All()), "built-ins,", len(reg.Recognizers("pt", nil)), "registered")
 	fmt.Println(reg.SupportedEntities("pt"))
 	// Output:
-	// 45 built-ins, 6 registered
-	// [BR_CNH BR_CNPJ BR_CPF BR_PIS BR_RG EMAIL_ADDRESS]
+	// 52 built-ins, 13 registered
+	// [BR_CEP BR_CNH BR_CNPJ BR_CNS BR_CPF BR_PIS BR_PIX_KEY BR_PLACA BR_RENAVAM BR_RG BR_TITULO_ELEITORAL EMAIL_ADDRESS]
 }
 
 // CreditCard pairs a deliberately weak 0.3 regex with the Luhn checksum. A

--- a/recognizers/validators_test.go
+++ b/recognizers/validators_test.go
@@ -150,6 +150,25 @@ func TestValidators(t *testing.T) {
 			[]string{"12345678900"},
 			[]string{"12345678901", "00000000000"},
 		},
+		{
+			// Definitive cards (leading 1-2) carry a 000/001 control block; the
+			// third invalid corrupts that block while keeping the 15-digit
+			// weighted sum a multiple of 11, which a sum-only rule accepts.
+			"br_cns", validateBRCNS,
+			[]string{"297220185600003", "165969980860009", "823111431391203"},
+			[]string{"297220185600004", "397220185600003", "297220185600100"},
+		},
+		{
+			"br_titulo", validateBRTitulo,
+			[]string{"483917830248", "070923291295"},
+			// bad check digit, then an electoral region outside 01-28.
+			[]string{"483917830249", "483917839948"},
+		},
+		{
+			"br_renavam", validateBRRenavam,
+			[]string{"20193580815", "31974898449"},
+			[]string{"20193580816", "11111111111"},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Adds CNS, título eleitoral, RENAVAM, CEP, vehicle plate and PIX random key
beside the five Brazilian types already here. Raised from a masking benchmark
where these passed through unmasked, or were masked by an unrelated recognizer
that matched the same digits.

RENAVAM is the motivating case: eleven digits with the same mod-11 weights as
PIS, so every valid RENAVAM is also a structurally valid PIS. Only the
surrounding word separates them — `TestRenavamAndPisShareTheirChecksum`
documents that rather than pretending otherwise.

Notes on the two design choices worth a second look:

- **CNS is validated by range.** A definitive card (leading 1-2) has its
  `000`/`001` control block and check digit recomputed from the PIS base. The
  15-digit weighted sum alone is not enough — the block can be corrupted while
  the sum stays a multiple of 11.
- **CEP-unformatted and PIX use a context validator, not a low score.** Both
  lack a checksum, and a pattern scored under the caller's threshold is dropped
  before `WithContext` can lift it, so a low score would make them dead on
  arrival. The gate matches whole tokens: `recepcao 12345678` contains "cep"
  and must not mask an ordinary number.

Plate patterns are case-insensitive — a dump stores the plate as typed, not as
painted.

Entity types 45 → 51; `ExampleAll` and the docs tables are updated. Full suite
green.

 Generated with Mister Maluco

Co-Authored-By: MisterMal <teskeslab@lucasteske.dev>