### PR TITLE
feat(models): add a per-model origin to the pin table (ATR-216)

### DIFF
--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -126,6 +126,9 @@
 //		from)
 //	-model string
 //		model id to download (default "KnightsAnalytics/distilbert-NER")
+//	-origin string
+//		base URL to fetch from, laid out like the hub (empty = the
+//		model's pinned origin)
 //
 // Without -dest it warms the cache ner.New reads from; with -dest it writes
 // a self-contained directory to copy into an image or a shared volume.
@@ -134,7 +137,18 @@
 // two paths a deployment wires into its config. SIGINT or SIGTERM cancels
 // the fetch so an evicted init container does not strand a partial file.
 //
-// The heavy lifting is [models.EnsureModelIn], which lives in the root
+// -origin points the fetch at a mirror — an internal bucket, an air-gapped
+// cache — without the pin table having to know about that build. Only the
+// base URL moves: the layout under it stays
+// {origin}/{model}/resolve/{revision}/{file}, so a mirror is a bucket keyed
+// like the hub rather than a second code path. The pinned digests are
+// unchanged, so a mirror serving anything else fails exactly as a corrupted
+// transfer does and installs nothing — an origin is trusted for
+// availability, never for content. The origin actually used is printed
+// before the fetch, and every pinned model is listed with its own in the
+// usage text.
+//
+// The heavy lifting is [models.EnsureModelFrom], which lives in the root
 // module so this command costs the CLI no dependencies: the ONNX runtime
 // stays behind the ner module.
 package main

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -19,19 +19,18 @@ import (
 // The model downloader for the optional NER backend, exposed so a model can
 // be materialised as a build or deploy step rather than on first use:
 //
-//	alcatraz models download [-dest dir] [-model id]
+//	alcatraz models download [-dest dir] [-model id] [-origin url]
 //
 // This is the one alcatraz command that touches the network, and it only
 // fetches the pinned URLs. Scanning never does.
 //
-// The heavy lifting is [models.EnsureModelIn], which lives in the root
+// The heavy lifting is [models.EnsureModelFrom], which lives in the root
 // module precisely so this command costs the CLI no dependencies: the ONNX
 // runtime stays behind the ner module.
 
-// ensureModelIn is the download entry point, indirected so tests can run the
-// command without a network. The models package hides its hub URL, so the
-// seam has to be here.
-var ensureModelIn = models.EnsureModelIn
+// ensureModelFrom is the download entry point, indirected so tests can run
+// the command without a network.
+var ensureModelFrom = models.EnsureModelFrom
 
 func runModels(args []string) (int, error) {
 	if len(args) == 0 {
@@ -47,6 +46,7 @@ func runModels(args []string) (int, error) {
 	fs := flag.NewFlagSet("models download", flag.ContinueOnError)
 	dest := fs.String("dest", "", "directory to write the model into (empty = the cache ner reads from)")
 	model := fs.String("model", models.DefaultModel, "model id to download")
+	origin := fs.String("origin", "", "base URL to fetch from, laid out like the hub (empty = the model's pinned origin)")
 	if err := fs.Parse(rest); err != nil {
 		return 0, err
 	}
@@ -63,14 +63,21 @@ func runModels(args []string) (int, error) {
 	// follows SIGTERM and the grace period.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	return download(ctx, os.Stdout, *model, *dest)
+	return download(ctx, os.Stdout, *model, *dest, *origin)
 }
 
-func download(ctx context.Context, out io.Writer, model, dest string) (int, error) {
+func download(ctx context.Context, out io.Writer, model, dest, origin string) (int, error) {
 	files := models.PinnedFiles(model)
 	if files == nil {
 		return 0, fmt.Errorf("models download: %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
 			model, strings.Join(models.PinnedModels(), ", "))
+	}
+	// Resolved here rather than left to the models package, so the origin
+	// printed below is the one actually fetched from. With two possible
+	// origins, a receipt that only says "downloaded" answers the wrong half
+	// of the question a mirrored build raises.
+	if origin == "" {
+		origin = models.Origin(model)
 	}
 
 	// The manifest goes out before the first byte is fetched: 250MB over a
@@ -81,12 +88,13 @@ func download(ctx context.Context, out io.Writer, model, dest string) (int, erro
 		total += f.Size
 	}
 	fmt.Fprintf(out, "%s @ %s\n", model, shortRev(models.Revision(model)))
+	fmt.Fprintf(out, "origin: %s\n", origin)
 	fmt.Fprintf(out, "fetching %d files, %s total (cached files are verified, not re-fetched):\n", len(files), humanSize(total))
 	for _, f := range files {
 		fmt.Fprintf(out, "  %-24s %10s\n", f.Name, humanSize(f.Size))
 	}
 
-	modelPath, err := ensureModelIn(ctx, model, dest)
+	modelPath, err := ensureModelFrom(ctx, model, dest, origin)
 	if err != nil {
 		return 0, fmt.Errorf("models download: %w%s", err, hintFor(err))
 	}
@@ -111,6 +119,11 @@ func download(ctx context.Context, out io.Writer, model, dest string) (int, erro
 // this command is built for — a non-root container writing a mounted volume —
 // and answering it with a note about proxies sends the operator off to debug
 // egress that was never involved.
+//
+// For the same reason no hint names huggingface.co any more: the pin table can
+// send a model somewhere else and -origin overrides both, so a hint that
+// assumes the hub would send an operator to allow-list a host their build
+// never contacted.
 func hintFor(err error) string {
 	var urlErr *url.Error
 	switch msg := err.Error(); {
@@ -123,13 +136,25 @@ func hintFor(err error) string {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return "\n  the download was interrupted; re-run to resume (verified files are not re-fetched)."
 	case errors.As(err, &urlErr):
-		return "\n  only huggingface.co is contacted; behind a proxy, set HTTPS_PROXY."
+		return fmt.Sprintf("\n  only %s is contacted; behind a proxy, set HTTPS_PROXY.", hostOf(urlErr.URL))
 	case strings.Contains(msg, "unexpected status"):
-		return "\n  huggingface.co answered but would not serve the file; the pinned revision may have" +
-			"\n  been withdrawn, or the request was rate limited."
+		return "\n  the origin answered but would not serve the file; the pinned revision may have been" +
+			"\n  withdrawn, a mirror may not carry it, or the request was rate limited."
 	default:
 		return ""
 	}
+}
+
+// hostOf names the host a request was aimed at, for a hint that has to tell an
+// operator which host to reach. It reads the host off the failure rather than
+// off the flag because the two can differ: a redirect is followed, and what
+// could not be reached is where the request ended up.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "the model origin"
+	}
+	return u.Host
 }
 
 // shortRev abbreviates a commit sha for display, leaving anything that is not
@@ -157,12 +182,15 @@ func humanSize(n int64) string {
 }
 
 func modelsUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id]")
+	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id] [-origin url]")
 	fmt.Fprintln(w, "\nDownloads a NER model and verifies every file against its pinned sha256.")
 	fmt.Fprintln(w, "Without -dest it warms the cache ner.New reads from; with -dest it writes a")
 	fmt.Fprintln(w, "self-contained directory to copy into an image or a shared volume.")
+	fmt.Fprintln(w, "\n-origin points the fetch at a mirror laid out like the hub, at")
+	fmt.Fprintln(w, "{origin}/{model}/resolve/{revision}/{file}. The pinned digests are unchanged,")
+	fmt.Fprintln(w, "so a mirror serving anything else fails the same way a corrupt transfer does.")
 	fmt.Fprintln(w, "\nverifiable models:")
 	for _, id := range models.PinnedModels() {
-		fmt.Fprintf(w, "  %s\n", id)
+		fmt.Fprintf(w, "  %-40s %s\n", id, models.Origin(id))
 	}
 }

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -15,8 +15,8 @@ import (
 
 // ensureCall records what the swapped-in downloader was handed.
 type ensureCall struct {
-	ctx         context.Context
-	model, dest string
+	ctx                 context.Context
+	model, dest, origin string
 }
 
 // stubEnsure swaps the downloader for the duration of a test, so the command
@@ -25,12 +25,12 @@ type ensureCall struct {
 func stubEnsure(t *testing.T, ret string, err error) *ensureCall {
 	t.Helper()
 	got := &ensureCall{}
-	prev := ensureModelIn
-	ensureModelIn = func(ctx context.Context, model, dest string) (string, error) {
-		got.ctx, got.model, got.dest = ctx, model, dest
+	prev := ensureModelFrom
+	ensureModelFrom = func(ctx context.Context, model, dest, origin string) (string, error) {
+		got.ctx, got.model, got.dest, got.origin = ctx, model, dest, origin
 		return ret, err
 	}
-	t.Cleanup(func() { ensureModelIn = prev })
+	t.Cleanup(func() { ensureModelFrom = prev })
 	return got
 }
 
@@ -64,12 +64,45 @@ func TestModelsDownloadDestIsHonoured(t *testing.T) {
 	}
 }
 
+func TestModelsDownloadOriginIsHonoured(t *testing.T) {
+	got := stubEnsure(t, "/opt/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	const mirror = "https://models.internal/alcatraz"
+	if _, err := runModels([]string{"download", "-origin", mirror}); err != nil {
+		t.Fatalf("runModels: %v", err)
+	}
+	if got.origin != mirror {
+		t.Errorf("origin = %q, want %q", got.origin, mirror)
+	}
+}
+
+func TestModelsDownloadResolvesTheOriginItReports(t *testing.T) {
+	got := stubEnsure(t, "/opt/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	var out bytes.Buffer
+	if _, err := download(context.Background(), &out, models.DefaultModel, "", ""); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+
+	// An omitted -origin is resolved here, not left to the models package, so
+	// that the origin on the receipt is the one the bytes came from. Printing
+	// "origin: (default)" while the pin table quietly redirected the fetch is
+	// the confusion this command exists to prevent.
+	want := models.Origin(models.DefaultModel)
+	if got.origin != want {
+		t.Errorf("origin passed to the downloader = %q, want the resolved %q", got.origin, want)
+	}
+	if !strings.Contains(out.String(), "origin: "+want) {
+		t.Errorf("output does not report the origin %q:\n%s", want, out.String())
+	}
+}
+
 func TestModelsDownloadPrintsBothPaths(t *testing.T) {
 	modelPath := filepath.Join("/opt/alcatraz/models", "KnightsAnalytics_distilbert-NER")
 	stubEnsure(t, modelPath, nil)
 
 	var out bytes.Buffer
-	if _, err := download(context.Background(), &out, models.DefaultModel, "/opt/alcatraz/models"); err != nil {
+	if _, err := download(context.Background(), &out, models.DefaultModel, "/opt/alcatraz/models", ""); err != nil {
 		t.Fatalf("download: %v", err)
 	}
 	got := out.String()
@@ -160,6 +193,34 @@ func TestModelsDownloadFailureIsActionable(t *testing.T) {
 	}
 }
 
+func TestHintNamesTheHostThatFailed(t *testing.T) {
+	// A hint that hardcodes the hub tells an operator running against a mirror
+	// to allow-list a host their build never contacts. The host is read off the
+	// failure, so it survives a redirect too.
+	cases := []struct {
+		name, url, want string
+	}{
+		{"hub", "https://huggingface.co/x/resolve/abc/model.onnx", "huggingface.co"},
+		{"mirror", "https://models.internal/alcatraz/x/resolve/abc/model.onnx", "models.internal"},
+		// Nothing to name: better a vague hint than a confident wrong host.
+		{"unparseable", "://nonsense", "the model origin"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := fmt.Errorf("models: downloading model.onnx: %w", &url.Error{
+				Op: "Get", URL: c.url, Err: errors.New("dial tcp: i/o timeout"),
+			})
+			got := hintFor(err)
+			if !strings.Contains(got, c.want) {
+				t.Errorf("hint = %q, want it to name %q", got, c.want)
+			}
+			if c.want != "huggingface.co" && strings.Contains(got, "huggingface.co") {
+				t.Errorf("hint = %q, want no mention of the hub", got)
+			}
+		})
+	}
+}
+
 func TestModelsDownloadContextIsCancellable(t *testing.T) {
 	got := stubEnsure(t, t.TempDir(), nil)
 	if _, err := runModels([]string{"download"}); err != nil {
@@ -187,10 +248,22 @@ func TestModelsUsage(t *testing.T) {
 	if !strings.Contains(got, "alcatraz models download") {
 		t.Errorf("usage does not show the command:\n%s", got)
 	}
-	// The list of verifiable ids is the point of the usage text.
+	// The list of verifiable ids is the point of the usage text, and each one
+	// is listed with where it is fetched from: with two possible origins, an id
+	// on its own no longer says what a bare download would contact.
 	for _, id := range models.PinnedModels() {
 		if !strings.Contains(got, id) {
 			t.Errorf("usage does not list the pinned model %q:\n%s", id, got)
+		}
+		if !strings.Contains(got, models.Origin(id)) {
+			t.Errorf("usage does not show the origin of %q:\n%s", id, got)
+		}
+	}
+	// The layout is the contract a mirror has to satisfy, so it belongs in the
+	// usage rather than only in the package docs.
+	for _, want := range []string{"-origin", "{origin}/{model}/resolve/{revision}/{file}"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("usage does not mention %q:\n%s", want, got)
 		}
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,9 +90,18 @@ Warns or blocks when the user's own prompt carries PII.
 |---|---|---|
 | `--dest` | the cache `ner.New` reads from | install into a self-contained directory instead |
 | `--model` | `KnightsAnalytics/distilbert-NER` | which pinned model to fetch |
+| `--origin` | the model's pinned origin | fetch from a mirror laid out like the hub |
 
-Both accept a single dash too; the double-dash form is what `ner`'s own error
+All accept a single dash too; the double-dash form is what `ner`'s own error
 messages tell you to run, so it is the spelling used throughout these docs.
+
+`--origin` points the fetch at an internal bucket or an air-gapped cache. Only
+the base URL moves — the layout under it stays
+`{origin}/{model}/resolve/{revision}/{file}` — so a mirror is a bucket keyed
+like the hub, not a different command. The pinned digests are unchanged, so a
+mirror serving anything else fails exactly as a corrupt transfer does and
+installs nothing. Run without the flag to see each pinned model's origin in the
+usage text; the origin actually used is printed before the fetch starts.
 
 See [Running NER without internet access](ner-offline.md) for the deployment
 patterns this command exists for.

--- a/models/doc.go
+++ b/models/doc.go
@@ -22,6 +22,23 @@
 // observes a partial file, and the functions are safe to call from several
 // goroutines and several processes at once.
 //
+// # Origins
+//
+// Where the bytes come from is separate from what is accepted. Each pin table
+// entry may name an origin — the base URL its files hang off — and defaults to
+// Hugging Face; [Origin] reports the one a model would use, and
+// [EnsureModelFrom] overrides it for a single call, which is what points a
+// build at an internal bucket or an air-gapped cache without the table having
+// to know about that build. Only the base URL moves. The layout under it is
+// fixed at {origin}/{model}/resolve/{revision}/{file}, so a mirror is a bucket
+// keyed like the hub rather than a second code path.
+//
+// Moving the origin does not move the digests. Files are checked against the
+// same pinned sha256 and byte length wherever they were served from, so an
+// origin serving anything else fails exactly as a corrupted transfer does and
+// installs nothing. That is what makes a second origin safe to offer: an
+// origin is trusted for availability, never for content.
+//
 // # Directories
 //
 // Two different paths, consistently named. The models directory is the parent

--- a/models/download.go
+++ b/models/download.go
@@ -11,9 +11,11 @@ import (
 	"path/filepath"
 )
 
-// hubBaseURL is the Hugging Face origin the pinned artifacts are fetched
-// from. It is a var so tests can point it at a local server.
-var hubBaseURL = "https://huggingface.co"
+// defaultOrigin is where a pinned artifact is fetched from unless its table
+// entry names somewhere else. Hugging Face stays the default because alcatraz
+// is public: an internal mirror as the default would make every outside user
+// fetch from a bucket Hoop pays the egress on, to no benefit of theirs.
+const defaultOrigin = "https://huggingface.co"
 
 // fileMatches reports whether path's contents hash to wantSHA256, keeping an
 // I/O failure separate from a false result. A file that cannot be read is not

--- a/models/models.go
+++ b/models/models.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,6 +46,17 @@ type modelArtifact struct {
 	// the tokenizer and the config files), so a directory produced here is
 	// interchangeable with one produced by hugot.DownloadModel.
 	files []modelFile
+	// origin is the base URL the files hang off, empty for defaultOrigin. It
+	// belongs to the model rather than to the downloader because the two move
+	// separately: a model Hoop trains and mirrors itself is not on the hub at
+	// all, while the ones that are should keep being fetched from it. Only the
+	// base URL moves — the path under it stays hub-shaped — so a mirror is a
+	// bucket laid out like the hub, not a second code path.
+	//
+	// Trusting an origin for availability is not trusting it for content. The
+	// digests below are what a file is accepted against wherever it came from,
+	// so the worst a wrong origin can do is fail the download.
+	origin string
 }
 
 // modelArtifacts holds every model EnsureModel can verify. Adding a model
@@ -123,6 +135,49 @@ func Revision(model string) string {
 	return modelArtifacts[model].revision
 }
 
+// Origin returns the base URL a model's files are fetched from — the one its
+// table entry names, or Hugging Face — or "" if the model is not pinned. It is
+// what a caller reports before a download; the origin argument of
+// [EnsureModelFrom] is what overrides it.
+func Origin(model string) string {
+	art, ok := modelArtifacts[model]
+	if !ok {
+		return ""
+	}
+	if art.origin != "" {
+		return art.origin
+	}
+	return defaultOrigin
+}
+
+// originFor applies the precedence — caller, then the pin table, then Hugging
+// Face — and rejects an origin the downloader cannot use.
+//
+// The check is here rather than at the call site because the failure it
+// prevents is unhelpful: an origin missing its scheme reaches net/http as a
+// relative URL and comes back as "unsupported protocol scheme """, which names
+// neither the origin nor the mistake.
+func originFor(art modelArtifact, override string) (string, error) {
+	origin := override
+	if origin == "" {
+		origin = art.origin
+	}
+	if origin == "" {
+		origin = defaultOrigin
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return "", fmt.Errorf("models: origin %q is not a URL: %w", origin, err)
+	}
+	if u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("models: origin %q must be an http or https base URL, like %q", origin, defaultOrigin)
+	}
+	// A trailing slash would leave an empty path segment in the middle of the
+	// URL. Most servers collapse it; S3 does not, because the key is literal,
+	// and answers 404 for an object that is sitting right there.
+	return strings.TrimSuffix(origin, "/"), nil
+}
+
 // EnsureModel downloads model into the models directory ner.New reads from
 // and returns the local directory holding it, so a warm cache makes ner.New
 // network-free and the returned path can be handed straight to
@@ -150,12 +205,38 @@ func EnsureModel(ctx context.Context, model string) (string, error) {
 // subdirectory named after it, exactly as under the cache, so the layout is
 // the same wherever it is built.
 func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
+	return EnsureModelFrom(ctx, model, dir, "")
+}
+
+// EnsureModelFrom is EnsureModelIn fetching from an explicit origin: the base
+// URL the pinned paths hang off, in place of the one the pin table names. An
+// empty origin means the pinned one. It is for a build running against a
+// mirror — an internal bucket, an air-gapped cache — without the model's table
+// entry having to know about that build.
+//
+// Only the base URL moves. The layout under it is fixed at
+// {origin}/{model}/resolve/{revision}/{file}, so a mirror is a bucket keyed
+// like the hub rather than a second code path, and pointing at one is a flag
+// rather than a format.
+//
+// Moving where the bytes come from does not move what is accepted: files are
+// checked against the same pinned digests and byte lengths, so an origin
+// serving anything else fails exactly as a corrupted transfer does and
+// installs nothing. That is what makes a second origin safe to offer at all —
+// an origin is trusted for availability, never for content.
+func EnsureModelFrom(ctx context.Context, model, dir, origin string) (string, error) {
 	art, ok := modelArtifacts[model]
 	if !ok {
 		return "", fmt.Errorf("models: model %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
 			model, strings.Join(PinnedModels(), ", "))
 	}
-	dir, err := ResolveDir(dir)
+	// Before ResolveDir, which creates directories: a rejected origin should
+	// not leave a models directory behind for a download that never ran.
+	origin, err := originFor(art, origin)
+	if err != nil {
+		return "", err
+	}
+	dir, err = ResolveDir(dir)
 	if err != nil {
 		return "", err
 	}
@@ -170,8 +251,8 @@ func EnsureModelIn(ctx context.Context, model, dir string) (string, error) {
 		if cachedFileValid(dest, f.sha256) {
 			continue
 		}
-		url := fmt.Sprintf("%s/%s/resolve/%s/%s", hubBaseURL, model, art.revision, f.path)
-		if err := download(ctx, url, dest, f.sha256, f.size, 0o644); err != nil {
+		src := fmt.Sprintf("%s/%s/resolve/%s/%s", origin, model, art.revision, f.path)
+		if err := download(ctx, src, dest, f.sha256, f.size, 0o644); err != nil {
 			return "", fmt.Errorf("models: downloading %s for model %s: %w", f.path, model, err)
 		}
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -174,8 +174,10 @@ func originFor(art modelArtifact, override string) (string, error) {
 	}
 	// A trailing slash would leave an empty path segment in the middle of the
 	// URL. Most servers collapse it; S3 does not, because the key is literal,
-	// and answers 404 for an object that is sitting right there.
-	return strings.TrimSuffix(origin, "/"), nil
+	// and answers 404 for an object that is sitting right there. TrimRight,
+	// not TrimSuffix: an origin pasted out of a config or joined by hand can
+	// end in more than one, and two empty segments fail the same way as one.
+	return strings.TrimRight(origin, "/"), nil
 }
 
 // EnsureModel downloads model into the models directory ner.New reads from

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -354,23 +354,29 @@ func TestEnsureModelFromOverridesThePinnedOrigin(t *testing.T) {
 
 // TestEnsureModelFromKeepsTheHubLayout pins the shape of the URL under the
 // origin. A mirror is a bucket keyed like the hub, so the only difference
-// between origins must be the base URL — and a trailing slash on it must not
-// leak an empty path segment into the key, which S3 would answer 404 for.
+// between origins must be the base URL — and trailing slashes on it must not
+// leak empty path segments into the key, which S3 would answer 404 for. One
+// is the copy-paste; more than one is the config value joined to a path that
+// already had it.
 func TestEnsureModelFromKeepsTheHubLayout(t *testing.T) {
-	id, files, art := testModel(t)
-	hub := newFakeHub(t, files)
-	pinTestModel(t, hub, id, art)
+	for _, suffix := range []string{"", "/", "///"} {
+		t.Run("origin"+suffix, func(t *testing.T) {
+			id, files, art := testModel(t)
+			hub := newFakeHub(t, files)
+			pinTestModel(t, hub, id, art)
 
-	if _, err := EnsureModelFrom(context.Background(), id, t.TempDir(), hub.URL+"/"); err != nil {
-		t.Fatalf("EnsureModelFrom: %v", err)
-	}
-	want := []string{
-		"/" + id + "/resolve/" + art.revision + "/model.onnx",
-		"/" + id + "/resolve/" + art.revision + "/tokenizer.json",
-	}
-	sort.Strings(want)
-	if got := hub.paths(); !slices.Equal(got, want) {
-		t.Errorf("requested %v, want %v", got, want)
+			if _, err := EnsureModelFrom(context.Background(), id, t.TempDir(), hub.URL+suffix); err != nil {
+				t.Fatalf("EnsureModelFrom: %v", err)
+			}
+			want := []string{
+				"/" + id + "/resolve/" + art.revision + "/model.onnx",
+				"/" + id + "/resolve/" + art.revision + "/tokenizer.json",
+			}
+			sort.Strings(want)
+			if got := hub.paths(); !slices.Equal(got, want) {
+				t.Errorf("requested %v, want %v", got, want)
+			}
+		})
 	}
 }
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -61,6 +64,18 @@ func (h *fakeHub) totalHits() int {
 	return n
 }
 
+// paths returns the request paths the hub saw, sorted.
+func (h *fakeHub) paths() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, 0, len(h.hits))
+	for p := range h.hits {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // fileOfURL pulls the file path out of /{org}/{repo}/resolve/{rev}/{file}.
 func fileOfURL(p string) string {
 	parts := strings.SplitN(strings.TrimPrefix(p, "/"), "/", 5)
@@ -70,20 +85,19 @@ func fileOfURL(p string) string {
 	return parts[4]
 }
 
-// pinTestModel registers a model served by hub for the duration of the test
-// and points the downloader at it.
+// pinTestModel registers a model served by hub for the duration of the test.
+// The origin travels in the artifact, so a test model is pointed at a local
+// server the same way a real one would be pointed at a mirror.
 func pinTestModel(t *testing.T, hub *fakeHub, id string, art modelArtifact) {
 	t.Helper()
 	if _, exists := modelArtifacts[id]; exists {
 		t.Fatalf("test model id %q collides with a real pinned model", id)
 	}
+	if art.origin == "" {
+		art.origin = hub.URL
+	}
 	modelArtifacts[id] = art
-	prev := hubBaseURL
-	hubBaseURL = hub.URL
-	t.Cleanup(func() {
-		delete(modelArtifacts, id)
-		hubBaseURL = prev
-	})
+	t.Cleanup(func() { delete(modelArtifacts, id) })
 }
 
 // testModel is a two-file stand-in for a real model directory.
@@ -296,6 +310,130 @@ func TestEnsureModelInMissingFileLeavesNoPartial(t *testing.T) {
 	assertNoLeftovers(t, Dir(dir, id), "model.onnx")
 }
 
+func TestOrigin(t *testing.T) {
+	if got := Origin(DefaultModel); got != defaultOrigin {
+		t.Errorf("Origin(default) = %q, want the hub %q", got, defaultOrigin)
+	}
+	// alcatraz is a public repository. A model that names no origin has to
+	// keep coming from the hub, or every outside user starts fetching from
+	// infrastructure that exists for Hoop's own deployments.
+	if art := modelArtifacts[DefaultModel]; art.origin != "" {
+		t.Errorf("the default model pins origin %q; it should fall back to the hub", art.origin)
+	}
+	if got := Origin("some-org/unpinned-model"); got != "" {
+		t.Errorf("Origin(unpinned) = %q, want empty", got)
+	}
+
+	id, files, art := testModel(t)
+	art.origin = "https://mirror.internal/models"
+	pinTestModel(t, newFakeHub(t, files), id, art)
+	if got := Origin(id); got != art.origin {
+		t.Errorf("Origin(%s) = %q, want the pinned origin %q", id, got, art.origin)
+	}
+}
+
+// TestEnsureModelFromOverridesThePinnedOrigin is the case a build against an
+// internal mirror needs: the caller redirects the fetch without the model's
+// table entry knowing anything about that build.
+func TestEnsureModelFromOverridesThePinnedOrigin(t *testing.T) {
+	id, files, art := testModel(t)
+	pinned, mirror := newFakeHub(t, files), newFakeHub(t, files)
+	art.origin = pinned.URL
+	pinTestModel(t, pinned, id, art)
+
+	if _, err := EnsureModelFrom(context.Background(), id, t.TempDir(), mirror.URL); err != nil {
+		t.Fatalf("EnsureModelFrom: %v", err)
+	}
+	if got := mirror.totalHits(); got != len(files) {
+		t.Errorf("the mirror served %d files, want %d", got, len(files))
+	}
+	if got := pinned.totalHits(); got != 0 {
+		t.Errorf("the pinned origin was contacted %d times, want 0", got)
+	}
+}
+
+// TestEnsureModelFromKeepsTheHubLayout pins the shape of the URL under the
+// origin. A mirror is a bucket keyed like the hub, so the only difference
+// between origins must be the base URL — and a trailing slash on it must not
+// leak an empty path segment into the key, which S3 would answer 404 for.
+func TestEnsureModelFromKeepsTheHubLayout(t *testing.T) {
+	id, files, art := testModel(t)
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	if _, err := EnsureModelFrom(context.Background(), id, t.TempDir(), hub.URL+"/"); err != nil {
+		t.Fatalf("EnsureModelFrom: %v", err)
+	}
+	want := []string{
+		"/" + id + "/resolve/" + art.revision + "/model.onnx",
+		"/" + id + "/resolve/" + art.revision + "/tokenizer.json",
+	}
+	sort.Strings(want)
+	if got := hub.paths(); !slices.Equal(got, want) {
+		t.Errorf("requested %v, want %v", got, want)
+	}
+}
+
+// TestEnsureModelFromRejectsUnusableOrigin keeps the failure at the origin the
+// operator typed. Left to net/http, a missing scheme surfaces as
+// `unsupported protocol scheme ""`, which names neither.
+func TestEnsureModelFromRejectsUnusableOrigin(t *testing.T) {
+	id, files, art := testModel(t)
+	pinTestModel(t, newFakeHub(t, files), id, art)
+
+	for _, origin := range []string{
+		"huggingface.co",        // no scheme
+		"ftp://mirror.internal", // not a scheme we can fetch over
+		"file:///mnt/models",    // a mirror is fetched, not mounted
+		"https://",              // no host
+		"://mirror.internal",    // not a URL at all
+	} {
+		t.Run(origin, func(t *testing.T) {
+			// A models directory that does not exist yet: a rejected origin
+			// must not create one for a download that never ran.
+			dir := filepath.Join(t.TempDir(), "models")
+			_, err := EnsureModelFrom(context.Background(), id, dir, origin)
+			if err == nil {
+				t.Fatalf("EnsureModelFrom accepted origin %q", origin)
+			}
+			if !strings.Contains(err.Error(), origin) {
+				t.Errorf("error = %v, want it to name the origin %q", err, origin)
+			}
+			if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("a rejected origin created %s", dir)
+			}
+		})
+	}
+}
+
+// TestEnsureModelFromMirrorCannotSubstituteBytes is why a second origin is
+// safe to offer. An origin is trusted to have the file, never to decide what
+// is in it: the digests are the same wherever the bytes came from, so a
+// mirror serving something else fails exactly as a corrupt transfer does.
+func TestEnsureModelFromMirrorCannotSubstituteBytes(t *testing.T) {
+	id, files, art := testModel(t)
+	pinTestModel(t, newFakeHub(t, files), id, art)
+
+	// Same length as the pin, so the digest is what has to reject it.
+	swapped := map[string][]byte{}
+	for name, body := range files {
+		swapped[name] = []byte(strings.Repeat("z", len(body)))
+	}
+	mirror := newFakeHub(t, swapped)
+
+	dir := t.TempDir()
+	_, err := EnsureModelFrom(context.Background(), id, dir, mirror.URL)
+	if err == nil {
+		t.Fatal("EnsureModelFrom accepted a mirror serving other bytes")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error = %v, want it to name the sha256 mismatch", err)
+	}
+	for name := range files {
+		assertNoLeftovers(t, Dir(dir, id), name)
+	}
+}
+
 func TestEnsureModelUnpinnedModel(t *testing.T) {
 	_, err := EnsureModel(context.Background(), "some-org/unpinned-model")
 	if err == nil {
@@ -455,6 +593,17 @@ func TestPinnedArtifactsWellFormed(t *testing.T) {
 	for id, art := range modelArtifacts {
 		if !commit.MatchString(art.revision) {
 			t.Errorf("%s: revision %q is not a 40-hex commit sha", id, art.revision)
+		}
+		// An origin in the table is never validated at call time — Origin
+		// hands it straight back — so a malformed one has to fail here rather
+		// than as a transport error on somebody's build.
+		if art.origin != "" {
+			if _, err := originFor(art, ""); err != nil {
+				t.Errorf("%s: %v", id, err)
+			}
+			if strings.HasSuffix(art.origin, "/") {
+				t.Errorf("%s: origin %q has a trailing slash", id, art.origin)
+			}
 		}
 		seen := map[string]bool{}
 		for _, f := range art.files {


### PR DESCRIPTION
Closes ATR-216.

A pinned model was always fetched from `huggingface.co`. A deployment that
cannot reach the hub — an air-gapped build, a cluster behind an egress
allow-list — had no way to point the fetch anywhere else short of seeding the
directory by hand. This makes the origin a property of the model, and lets a
single build override it.

## What changes

- `modelArtifact` gains an `origin`; empty means Hugging Face. `Origin(model)`
  reports the one a model would use.
- `EnsureModelFrom(ctx, model, dir, origin)` fetches from an explicit base URL.
  `EnsureModelIn` delegates to it with an empty origin, so **every existing
  caller is unchanged** — including `ner`, which picks up a pin-table origin
  automatically.
- `alcatraz models download` grows `-origin`, prints the origin it resolved
  before fetching, and lists each pinned model with its own in the usage text.
- The two `huggingface.co`-specific failure hints now name the host read off
  the failure, so an operator running against a mirror is not sent to
  allow-list a host their build never contacts.
- `hubBaseURL`, a package global that existed only so tests could swap it, is
  gone: the tests now point a test model at a local server the same way a real
  one would be pointed at a mirror.

## Hugging Face stays the default

alcatraz is a public repository. An internal mirror as the default would make
every outside user fetch from a bucket Hoop pays the egress on, to no benefit
of theirs.

## Only the base URL moves

The layout under it stays `{origin}/{model}/resolve/{revision}/{file}`, so a
mirror is a bucket keyed like the hub rather than a second code path, and
pointing at one is a flag rather than a format. Two details are load-bearing
for S3 specifically:

- a trailing slash is trimmed — it would leave an empty path segment, which
  most servers collapse and S3 does not, 404ing for an object that is sitting
  right there;
- an origin with no `http`/`https` scheme is rejected up front, because
  `net/http` would otherwise report only `unsupported protocol scheme ""`,
  naming neither the origin nor the mistake. The check runs before
  `ResolveDir`, so a rejected origin leaves no models directory behind.

## An origin is trusted for availability, never for content

Moving where the bytes come from does not move what is accepted. Files are
still verified against the same pinned sha256 and byte length, so an origin
serving anything else fails exactly as a corrupted transfer does and installs
nothing. `TestEnsureModelFromMirrorCannotSubstituteBytes` proves it with a
mirror serving same-length different bytes: `sha256 mismatch`, no leftovers.

## Testing

`go build ./... && go vet ./... && go test ./...` green in both modules;
`gofmt` clean. New coverage: origin precedence, override, URL layout including
the trailing-slash case, rejection of unusable origins, the substitution
attempt above, the CLI flag and receipt line, and the host-naming hints. The
pin-table guard now validates any origin an entry names, so a malformed one
fails in CI rather than as a transport error on somebody's build.

Unblocks ATR-218 (mirror a pinned model to an S3 origin).
