### PR TITLE
feat(cli): expose models verify (ATR-217)

### DIFF
--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -10,6 +10,7 @@
 //	alcatraz hook claude-prompt [flags]
 //	                                   UserPromptSubmit guard for Claude Code
 //	alcatraz models download [flags]   fetch a verified NER model
+//	alcatraz models verify [flags]     re-check an already-seeded model
 //	alcatraz version                   print the version (also -version, --version)
 //
 // Scanning is the network-free part, and it is the whole product: no
@@ -115,7 +116,7 @@
 // the model not to repeat the values; in block mode the prompt is rejected
 // with a masked view of what tripped it.
 //
-// # Model download
+// # Model download and verify
 //
 // alcatraz models download fetches the optional NER backend's model and
 // verifies every file against its pinned sha256. This is the one alcatraz
@@ -148,7 +149,32 @@
 // before the fetch, and every pinned model is listed with its own in the
 // usage text.
 //
-// The heavy lifting is [models.EnsureModelFrom], which lives in the root
-// module so this command costs the CLI no dependencies: the ONNX runtime
-// stays behind the ner module.
+// alcatraz models verify re-checks a directory download already filled,
+// without fetching anything:
+//
+//	-dir string
+//		models directory to check (empty = the cache ner reads from)
+//	-model string
+//		model id to check (default "KnightsAnalytics/distilbert-NER")
+//
+// It opens no socket and writes nothing — not even the default cache
+// directory, which it names but does not create — so it is safe against a
+// read-only mount and inside a network-sealed build. It exits non-zero
+// naming the first file that is absent, mismatched or unreadable, three
+// problems worth telling apart: absent means the directory was never seeded,
+// mismatched means it was seeded with the wrong bytes, and unreadable means
+// the bytes may be fine and the process cannot see them. Two callers need
+// this rather than a second download: a CI job proving an image really
+// carries the model it claims to, asserted from outside because a distroless
+// image has no shell, and an operator diagnosing a volume the model runtime
+// rejected.
+//
+// -dir is the models directory, the same one download fills with -dest.
+// Handing it a model's own directory is the mistake the ModelsDir/ModelPath
+// split exists to prevent, so the failure says so instead of advising a
+// download that would nest a second copy inside the first.
+//
+// The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
+// which live in the root module so these commands cost the CLI no
+// dependencies: the ONNX runtime stays behind the ner module.
 package main

--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -154,6 +154,9 @@
 //
 //	-dir string
 //		models directory to check (empty = the cache ner reads from)
+//	-dest string
+//		alias for -dir, so a line lifted out of a download runbook runs
+//		unedited
 //	-model string
 //		model id to check (default "KnightsAnalytics/distilbert-NER")
 //
@@ -172,7 +175,10 @@
 // -dir is the models directory, the same one download fills with -dest.
 // Handing it a model's own directory is the mistake the ModelsDir/ModelPath
 // split exists to prevent, so the failure says so instead of advising a
-// download that would nest a second copy inside the first.
+// download that would nest a second copy inside the first. It is spelled -dir
+// rather than -dest because this command writes nothing and so has no
+// destination, but -dest names the same directory and is accepted: the two
+// commands sit next to each other in every runbook that has either.
 //
 // The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
 // which live in the root module so these commands cost the CLI no

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -84,12 +84,23 @@ func runModelsVerify(rest []string) (int, error) {
 	// thing worth being pedantic about here. It is the same directory
 	// "download -dest" fills.
 	dir := fs.String("dir", "", "models directory to check (empty = the cache ner reads from)")
+	// -dest is accepted as an alias all the same, so a line lifted out of a
+	// download runbook runs unedited. The two commands sit next to each other
+	// in every runbook that has either; failing one of them over the name of
+	// the same path is friction with nothing on the other side of it.
+	dest := fs.String("dest", "", "alias for -dir, for symmetry with download")
 	model := fs.String("model", models.DefaultModel, "model id to check")
 	if err := fs.Parse(rest); err != nil {
 		return 0, err
 	}
 	if fs.NArg() > 0 {
 		return 0, fmt.Errorf("models verify: unexpected argument %q", fs.Arg(0))
+	}
+	switch {
+	case *dir != "" && *dest != "" && *dir != *dest:
+		return 0, fmt.Errorf("models verify: -dir %q and -dest %q name different directories, and they are the same flag", *dir, *dest)
+	case *dir == "":
+		*dir = *dest
 	}
 	// No signal handling, unlike download: this opens no socket and creates no
 	// file, so an interrupted run leaves nothing behind to clean up.
@@ -117,11 +128,17 @@ func download(ctx context.Context, out io.Writer, model, dest, origin string) (i
 	for _, f := range files {
 		total += f.Size
 	}
-	fmt.Fprintf(out, "%s @ %s\n", model, shortRev(models.Revision(model)))
-	fmt.Fprintf(out, "origin: %s\n", origin)
-	fmt.Fprintf(out, "fetching %d files, %s total (cached files are verified, not re-fetched):\n", len(files), humanSize(total))
+	w := &errWriter{w: out}
+	w.printf("%s @ %s\n", model, shortRev(models.Revision(model)))
+	w.printf("origin: %s\n", origin)
+	w.printf("fetching %d files, %s total (cached files are verified, not re-fetched):\n", len(files), humanSize(total))
 	for _, f := range files {
-		fmt.Fprintf(out, "  %-24s %10s\n", f.Name, humanSize(f.Size))
+		w.printf("  %-24s %10s\n", f.Name, humanSize(f.Size))
+	}
+	// Checked before the fetch, not only at the end: there is no point pulling
+	// 250MB to report it into a writer that is already failing.
+	if w.err != nil {
+		return 0, fmt.Errorf("models download: writing output: %w", w.err)
 	}
 
 	modelPath, err := ensureModelFrom(ctx, model, dest, origin)
@@ -129,15 +146,18 @@ func download(ctx context.Context, out io.Writer, model, dest, origin string) (i
 		return 0, fmt.Errorf("models download: %w%s", err, hintFor(err))
 	}
 
-	fmt.Fprintln(out, "verified:")
+	w.printf("verified:\n")
 	for _, f := range files {
-		fmt.Fprintf(out, "  %-24s %s\n", f.Name, f.SHA256)
+		w.printf("  %-24s %s\n", f.Name, f.SHA256)
 	}
 	// Both directories, because they are one level apart and picking the
 	// wrong one is the likeliest way to misconfigure this: ModelsDir is the
 	// parent that holds every model, ModelPath is this model's own directory.
-	fmt.Fprintf(out, "\nModelsDir: %s\n", filepath.Dir(modelPath))
-	fmt.Fprintf(out, "ModelPath: %s\n", modelPath)
+	w.printf("\nModelsDir: %s\n", filepath.Dir(modelPath))
+	w.printf("ModelPath: %s\n", modelPath)
+	if w.err != nil {
+		return 0, fmt.Errorf("models download: writing output: %w", w.err)
+	}
 	return 0, nil
 }
 
@@ -168,10 +188,16 @@ func verify(out io.Writer, model, dir string) (int, error) {
 		shown = d
 	}
 
-	fmt.Fprintf(out, "%s @ %s\n", model, shortRev(models.Revision(model)))
-	fmt.Fprintf(out, "checking %d files in %s (no network, no writes):\n", len(files), shown)
+	w := &errWriter{w: out}
+	w.printf("%s @ %s\n", model, shortRev(models.Revision(model)))
+	w.printf("checking %d files in %s (no network, no writes):\n", len(files), shown)
 	for _, f := range files {
-		fmt.Fprintf(out, "  %-24s %10s\n", f.Name, humanSize(f.Size))
+		w.printf("  %-24s %10s\n", f.Name, humanSize(f.Size))
+	}
+	// Checked before the hashing, not only at the end: re-reading 250MB to
+	// report the result into a writer that is already failing helps nobody.
+	if w.err != nil {
+		return 0, fmt.Errorf("models verify: writing output: %w", w.err)
 	}
 
 	modelPath, err := verifyModelIn(model, dir)
@@ -179,13 +205,40 @@ func verify(out io.Writer, model, dir string) (int, error) {
 		return 0, fmt.Errorf("models verify: %w%s", err, verifyHintFor(err, model, dir))
 	}
 
-	fmt.Fprintln(out, "verified:")
+	w.printf("verified:\n")
 	for _, f := range files {
-		fmt.Fprintf(out, "  %-24s %s\n", f.Name, f.SHA256)
+		w.printf("  %-24s %s\n", f.Name, f.SHA256)
 	}
-	fmt.Fprintf(out, "\nModelsDir: %s\n", filepath.Dir(modelPath))
-	fmt.Fprintf(out, "ModelPath: %s\n", modelPath)
+	w.printf("\nModelsDir: %s\n", filepath.Dir(modelPath))
+	w.printf("ModelPath: %s\n", modelPath)
+	// A verify that could not report is not a verify that passed: the whole
+	// output is the result, and a caller reading exit 0 with nothing on stdout
+	// would conclude the model is good on no evidence.
+	if w.err != nil {
+		return 0, fmt.Errorf("models verify: writing output: %w", w.err)
+	}
 	return 0, nil
+}
+
+// errWriter latches the first write error so a run of report lines can be
+// written straight through and answered for once, instead of nesting eight
+// error checks around what is conceptually one paragraph.
+//
+// Write errors are returned rather than dropped, per the contract writeFindings
+// already keeps: a stdout that failed — a full disk, a descriptor closed under
+// the process — has to surface as exit code 2. Reporting nothing and exiting 0
+// is the one outcome these commands must not produce, since both are read by
+// something deciding whether a model is usable.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, a ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, a...)
 }
 
 // verifyHintFor turns a verification failure into the next thing to do. The
@@ -322,7 +375,8 @@ func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "anything: no network, no writes, safe against a read-only mount. It exits")
 	fmt.Fprintln(w, "non-zero naming the first file that is absent, mismatched or unreadable —")
 	fmt.Fprintln(w, "three different problems that are worth telling apart. -dir is the models")
-	fmt.Fprintln(w, "directory, the same one download fills with -dest.")
+	fmt.Fprintln(w, "directory, the same one download fills with -dest, and -dest is accepted")
+	fmt.Fprintln(w, "as an alias for it.")
 	fmt.Fprintln(w, "\nverifiable models:")
 	for _, id := range models.PinnedModels() {
 		fmt.Fprintf(w, "  %-40s %s\n", id, models.Origin(id))

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -16,21 +16,25 @@ import (
 	"github.com/hoophq/alcatraz/models"
 )
 
-// The model downloader for the optional NER backend, exposed so a model can
-// be materialised as a build or deploy step rather than on first use:
+// The model commands for the optional NER backend, exposed so a model can be
+// materialised and checked as a build or deploy step rather than on first use:
 //
 //	alcatraz models download [-dest dir] [-model id] [-origin url]
+//	alcatraz models verify   [-dir dir] [-model id]
 //
-// This is the one alcatraz command that touches the network, and it only
-// fetches the pinned URLs. Scanning never does.
+// download is the one alcatraz command that touches the network, and it only
+// fetches the pinned URLs. Scanning never does, and neither does verify.
 //
-// The heavy lifting is [models.EnsureModelFrom], which lives in the root
-// module precisely so this command costs the CLI no dependencies: the ONNX
-// runtime stays behind the ner module.
+// The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
+// which live in the root module precisely so these commands cost the CLI no
+// dependencies: the ONNX runtime stays behind the ner module.
 
-// ensureModelFrom is the download entry point, indirected so tests can run
-// the command without a network.
-var ensureModelFrom = models.EnsureModelFrom
+// ensureModelFrom and verifyModelIn are the entry points, indirected so tests
+// can run the commands without a network and without a seeded directory.
+var (
+	ensureModelFrom = models.EnsureModelFrom
+	verifyModelIn   = models.VerifyModelIn
+)
 
 func runModels(args []string) (int, error) {
 	if len(args) == 0 {
@@ -38,11 +42,18 @@ func runModels(args []string) (int, error) {
 		return 0, errors.New("models: expected a subcommand")
 	}
 	sub, rest := args[0], args[1:]
-	if sub != "download" {
+	switch sub {
+	case "download":
+		return runModelsDownload(rest)
+	case "verify":
+		return runModelsVerify(rest)
+	default:
 		modelsUsage(os.Stderr)
-		return 0, fmt.Errorf("models: unknown subcommand %q (want download)", sub)
+		return 0, fmt.Errorf("models: unknown subcommand %q (want download or verify)", sub)
 	}
+}
 
+func runModelsDownload(rest []string) (int, error) {
 	fs := flag.NewFlagSet("models download", flag.ContinueOnError)
 	dest := fs.String("dest", "", "directory to write the model into (empty = the cache ner reads from)")
 	model := fs.String("model", models.DefaultModel, "model id to download")
@@ -64,6 +75,25 @@ func runModels(args []string) (int, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return download(ctx, os.Stdout, *model, *dest, *origin)
+}
+
+func runModelsVerify(rest []string) (int, error) {
+	fs := flag.NewFlagSet("models verify", flag.ContinueOnError)
+	// -dir, not -dest: this command writes nothing, and the naming split
+	// between the models directory and a model's own directory is the one
+	// thing worth being pedantic about here. It is the same directory
+	// "download -dest" fills.
+	dir := fs.String("dir", "", "models directory to check (empty = the cache ner reads from)")
+	model := fs.String("model", models.DefaultModel, "model id to check")
+	if err := fs.Parse(rest); err != nil {
+		return 0, err
+	}
+	if fs.NArg() > 0 {
+		return 0, fmt.Errorf("models verify: unexpected argument %q", fs.Arg(0))
+	}
+	// No signal handling, unlike download: this opens no socket and creates no
+	// file, so an interrupted run leaves nothing behind to clean up.
+	return verify(os.Stdout, *model, *dir)
 }
 
 func download(ctx context.Context, out io.Writer, model, dest, origin string) (int, error) {
@@ -109,6 +139,104 @@ func download(ctx context.Context, out io.Writer, model, dest, origin string) (i
 	fmt.Fprintf(out, "\nModelsDir: %s\n", filepath.Dir(modelPath))
 	fmt.Fprintf(out, "ModelPath: %s\n", modelPath)
 	return 0, nil
+}
+
+// verify re-checks an already-seeded models directory against the pin table
+// and reports what it found. It is the assertion half of download, for the two
+// places that cannot just re-run download: a CI job proving an image really
+// carries the model it claims to — from outside the image, since a distroless
+// one has no shell — and an operator staring at a volume the model runtime
+// rejected.
+//
+// It opens no socket and writes nothing, so it is safe against a read-only
+// mount and safe to run in a network-sealed build.
+func verify(out io.Writer, model, dir string) (int, error) {
+	files := models.PinnedFiles(model)
+	if files == nil {
+		return 0, fmt.Errorf("models verify: %q has no pinned checksums, so it cannot be verified (pinned models: %s)",
+			model, strings.Join(models.PinnedModels(), ", "))
+	}
+	// DefaultDir names the cache without creating it, which is exactly the
+	// property this command needs: looking is not a reason to write. Resolved
+	// here only so the line below names a real path rather than "the default".
+	shown := dir
+	if shown == "" {
+		d, err := models.DefaultDir()
+		if err != nil {
+			return 0, fmt.Errorf("models verify: %w", err)
+		}
+		shown = d
+	}
+
+	fmt.Fprintf(out, "%s @ %s\n", model, shortRev(models.Revision(model)))
+	fmt.Fprintf(out, "checking %d files in %s (no network, no writes):\n", len(files), shown)
+	for _, f := range files {
+		fmt.Fprintf(out, "  %-24s %10s\n", f.Name, humanSize(f.Size))
+	}
+
+	modelPath, err := verifyModelIn(model, dir)
+	if err != nil {
+		return 0, fmt.Errorf("models verify: %w%s", err, verifyHintFor(err, model, dir))
+	}
+
+	fmt.Fprintln(out, "verified:")
+	for _, f := range files {
+		fmt.Fprintf(out, "  %-24s %s\n", f.Name, f.SHA256)
+	}
+	fmt.Fprintf(out, "\nModelsDir: %s\n", filepath.Dir(modelPath))
+	fmt.Fprintf(out, "ModelPath: %s\n", modelPath)
+	return 0, nil
+}
+
+// verifyHintFor turns a verification failure into the next thing to do. The
+// three kinds VerifyModelIn keeps apart lead to three different places, and
+// collapsing them is how an operator ends up re-provisioning a model whose
+// only problem was its mode.
+func verifyHintFor(err error, model, dir string) string {
+	// A models directory that is really a model directory fails as "nothing
+	// here", which reads as a missing download rather than as an argument one
+	// level too deep. Checked first, because the advice it replaces — download
+	// it again — would write a second copy nested inside the first.
+	if wrongLevel := wrongLevelHint(err, model, dir); wrongLevel != "" {
+		return wrongLevel
+	}
+	switch msg := err.Error(); {
+	case strings.Contains(msg, "does not match its pinned sha256"):
+		return "\n  the file is there and its bytes are not the pinned ones — a stale image layer, a" +
+			"\n  truncated copy, or a modified volume. Re-fetch it with: alcatraz models download" + destHint(dir)
+	case strings.Contains(msg, "cannot read"):
+		return "\n  the bytes may be fine and this process cannot see them; check ownership and mode" +
+			"\n  before re-provisioning the model."
+	case strings.Contains(msg, "is missing from"), strings.Contains(msg, "no model directory at"),
+		strings.Contains(msg, "is not a directory"):
+		return "\n  seed the directory with: alcatraz models download" + destHint(dir)
+	default:
+		return ""
+	}
+}
+
+// wrongLevelHint catches the mistake the ModelsDir/ModelPath split exists to
+// prevent: -dir given this model's own directory instead of the parent that
+// holds every model. Detected by name, because that is all there is to go on —
+// the directory the command then looks in does not exist.
+func wrongLevelHint(err error, model, dir string) string {
+	if dir == "" || !strings.Contains(err.Error(), "no model directory at") {
+		return ""
+	}
+	if filepath.Base(dir) != models.Dir("", model) {
+		return ""
+	}
+	return "\n  -dir wants the models directory, the parent that holds every model, not this model's" +
+		"\n  own directory. Try: alcatraz models verify -dir " + filepath.Dir(dir)
+}
+
+// destHint repeats the directory back in the form the download command takes
+// it, so the suggestion can be pasted rather than reassembled.
+func destHint(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	return " --dest " + dir
 }
 
 // hintFor turns a download failure into something the operator can act on.
@@ -183,12 +311,18 @@ func humanSize(n int64) string {
 
 func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id] [-origin url]")
+	fmt.Fprintln(w, "       alcatraz models verify   [-dir dir] [-model id]")
 	fmt.Fprintln(w, "\nDownloads a NER model and verifies every file against its pinned sha256.")
 	fmt.Fprintln(w, "Without -dest it warms the cache ner.New reads from; with -dest it writes a")
 	fmt.Fprintln(w, "self-contained directory to copy into an image or a shared volume.")
 	fmt.Fprintln(w, "\n-origin points the fetch at a mirror laid out like the hub, at")
 	fmt.Fprintln(w, "{origin}/{model}/resolve/{revision}/{file}. The pinned digests are unchanged,")
 	fmt.Fprintln(w, "so a mirror serving anything else fails the same way a corrupt transfer does.")
+	fmt.Fprintln(w, "\nverify re-checks a directory download already filled, without fetching")
+	fmt.Fprintln(w, "anything: no network, no writes, safe against a read-only mount. It exits")
+	fmt.Fprintln(w, "non-zero naming the first file that is absent, mismatched or unreadable —")
+	fmt.Fprintln(w, "three different problems that are worth telling apart. -dir is the models")
+	fmt.Fprintln(w, "directory, the same one download fills with -dest.")
 	fmt.Fprintln(w, "\nverifiable models:")
 	for _, id := range models.PinnedModels() {
 		fmt.Fprintf(w, "  %-40s %s\n", id, models.Origin(id))

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -245,8 +248,10 @@ func TestModelsUsage(t *testing.T) {
 	var out bytes.Buffer
 	modelsUsage(&out)
 	got := out.String()
-	if !strings.Contains(got, "alcatraz models download") {
-		t.Errorf("usage does not show the command:\n%s", got)
+	for _, want := range []string{"alcatraz models download", "alcatraz models verify"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("usage does not show %q:\n%s", want, got)
+		}
 	}
 	// The list of verifiable ids is the point of the usage text, and each one
 	// is listed with where it is fetched from: with two possible origins, an id
@@ -264,6 +269,217 @@ func TestModelsUsage(t *testing.T) {
 	for _, want := range []string{"-origin", "{origin}/{model}/resolve/{revision}/{file}"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("usage does not mention %q:\n%s", want, got)
+		}
+	}
+}
+
+// verifyCall records what the swapped-in verifier was handed.
+type verifyCall struct {
+	model, dir string
+}
+
+// stubVerify swaps the verifier for the duration of a test, for the cases that
+// are about flag handling and output rather than about verification itself.
+func stubVerify(t *testing.T, ret string, err error) *verifyCall {
+	t.Helper()
+	got := &verifyCall{}
+	prev := verifyModelIn
+	verifyModelIn = func(model, dir string) (string, error) {
+		got.model, got.dir = model, dir
+		return ret, err
+	}
+	t.Cleanup(func() { verifyModelIn = prev })
+	return got
+}
+
+func TestModelsVerifyDefaults(t *testing.T) {
+	got := stubVerify(t, "/cache/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	code, err := runModels([]string{"verify"})
+	if err != nil || code != 0 {
+		t.Fatalf("runModels = (%d, %v), want (0, nil)", code, err)
+	}
+	if got.model != models.DefaultModel {
+		t.Errorf("model = %q, want the default %q", got.model, models.DefaultModel)
+	}
+	// Empty is passed through: that is what checks the same cache ner.New
+	// reads from, and unlike download it must not create it.
+	if got.dir != "" {
+		t.Errorf("dir = %q, want empty so the default cache is checked", got.dir)
+	}
+}
+
+func TestModelsVerifyDirIsHonoured(t *testing.T) {
+	got := stubVerify(t, "/opt/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+	if _, err := runModels([]string{"verify", "--dir", "/opt/alcatraz/models"}); err != nil {
+		t.Fatalf("runModels: %v", err)
+	}
+	if got.dir != "/opt/alcatraz/models" {
+		t.Errorf("dir = %q, want /opt/alcatraz/models", got.dir)
+	}
+}
+
+func TestModelsVerifyPrintsWhatItChecked(t *testing.T) {
+	modelPath := filepath.Join("/opt/alcatraz/models", "KnightsAnalytics_distilbert-NER")
+	stubVerify(t, modelPath, nil)
+
+	var out bytes.Buffer
+	if _, err := verify(&out, models.DefaultModel, "/opt/alcatraz/models"); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	got := out.String()
+
+	for _, want := range []string{
+		// Same two paths download prints, for the same reason: one of them is
+		// what the caller's config wants and they are one level apart.
+		"ModelsDir: " + filepath.Dir(modelPath),
+		"ModelPath: " + modelPath,
+		// A CI job asserting an image's contents is reading this line to know
+		// the assertion did not quietly reach for the network.
+		"no network, no writes",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	for _, f := range models.PinnedFiles(models.DefaultModel) {
+		if !strings.Contains(got, f.Name) || !strings.Contains(got, f.SHA256) {
+			t.Errorf("output does not report %s and its digest:\n%s", f.Name, got)
+		}
+	}
+}
+
+// seedState lays out a models directory in one of the states VerifyModelIn
+// tells apart and returns the real failure it produces. Real, not hand-copied:
+// the hints below are matched by substring, so the thing worth testing is that
+// they still fire on the messages the models package actually emits.
+//
+// The pinned files are hundreds of megabytes; none of these states needs their
+// contents, only their names.
+func seedState(t *testing.T, state string) (dir string, err error) {
+	t.Helper()
+	dir = t.TempDir()
+	modelPath := models.Dir(dir, models.DefaultModel)
+	first := models.PinnedFiles(models.DefaultModel)[0].Name
+
+	switch state {
+	case "no-dir": // nothing was ever seeded here
+	case "missing", "mismatch", "unreadable":
+		if err := os.MkdirAll(modelPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if state != "missing" {
+			bad := filepath.Join(modelPath, first)
+			if err := os.WriteFile(bad, []byte("not the pinned bytes"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if state == "unreadable" {
+				if err := os.Chmod(bad, 0o000); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { os.Chmod(bad, 0o644) })
+			}
+		}
+	default:
+		t.Fatalf("unknown state %q", state)
+	}
+
+	_, err = models.VerifyModelIn(models.DefaultModel, dir)
+	if err == nil {
+		t.Fatalf("VerifyModelIn succeeded on state %q, want a failure to hint about", state)
+	}
+	return dir, err
+}
+
+func TestModelsVerifyFailureIsActionable(t *testing.T) {
+	cases := []struct {
+		state, want string
+		// unwanted is advice that would send the operator to the wrong place.
+		unwanted string
+	}{
+		{state: "no-dir", want: "alcatraz models download"},
+		{state: "missing", want: "alcatraz models download"},
+		{state: "mismatch", want: "stale image layer"},
+		// The likeliest failure in the deployment this command is for — a
+		// model owned by the build stage that put it there, read by a non-root
+		// process — and the one where re-downloading fixes nothing.
+		{state: "unreadable", want: "ownership and mode", unwanted: "alcatraz models download"},
+	}
+	for _, c := range cases {
+		t.Run(c.state, func(t *testing.T) {
+			if c.state == "unreadable" {
+				if runtime.GOOS == "windows" {
+					t.Skip("unix permission bits")
+				}
+				if os.Geteuid() == 0 {
+					t.Skip("running as root, which ignores the permission bits under test")
+				}
+			}
+			dir, err := seedState(t, c.state)
+
+			hint := verifyHintFor(err, models.DefaultModel, dir)
+			if !strings.Contains(hint, c.want) {
+				t.Errorf("hint = %q, want it to mention %q (error: %v)", hint, c.want, err)
+			}
+			if c.unwanted != "" && strings.Contains(hint, c.unwanted) {
+				t.Errorf("hint = %q, want no mention of %q", hint, c.unwanted)
+			}
+			// The suggestion has to be pastable: a checked directory that is
+			// not the default has to come back with it.
+			if strings.Contains(hint, "alcatraz models download") && !strings.Contains(hint, dir) {
+				t.Errorf("hint = %q, want it to name the directory %q", hint, dir)
+			}
+		})
+	}
+}
+
+// TestModelsVerifyHintsTheWrongLevel covers the mistake the ModelsDir/ModelPath
+// split exists to prevent. Untreated it reads as a missing download, and acting
+// on that advice nests a second copy of the model inside the first.
+func TestModelsVerifyHintsTheWrongLevel(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := models.Dir(dir, models.DefaultModel)
+
+	_, err := models.VerifyModelIn(models.DefaultModel, modelPath)
+	if err == nil {
+		t.Fatal("VerifyModelIn succeeded one level too deep")
+	}
+	hint := verifyHintFor(err, models.DefaultModel, modelPath)
+	if !strings.Contains(hint, "models directory") || !strings.Contains(hint, dir) {
+		t.Errorf("hint = %q, want it to name the parent %q", hint, dir)
+	}
+	if strings.Contains(hint, "alcatraz models download") {
+		t.Errorf("hint = %q, want it not to advise a download that would nest a second copy", hint)
+	}
+}
+
+// TestModelsVerifyWritesNothing runs the real verifier, not the stub: the
+// promise is that this command is safe against a read-only mount and against
+// the cache directory not existing yet, and only the real one can keep it.
+func TestModelsVerifyWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := verify(io.Discard, models.DefaultModel, dir); err == nil {
+		t.Fatal("verify succeeded against an empty models directory")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("verify created %d entries in the models directory", len(entries))
+	}
+}
+
+func TestModelsVerifyUnpinnedModel(t *testing.T) {
+	// No stub: an unpinned id has to be rejected before anything is read.
+	_, err := runModels([]string{"verify", "-model", "some-org/unpinned-model"})
+	if err == nil {
+		t.Fatal("runModels succeeded for an unpinned model, want an error")
+	}
+	for _, want := range []string{"some-org/unpinned-model", models.DefaultModel} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
 		}
 	}
 }

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -320,6 +320,132 @@ func TestModelsVerifyDirIsHonoured(t *testing.T) {
 	}
 }
 
+// TestModelsVerifyAcceptsDestAsAnAlias covers the runbook case the alias is
+// for: the verify line sits under the download line, and copying the path
+// across must not fail over the name of the flag holding it.
+func TestModelsVerifyAcceptsDestAsAnAlias(t *testing.T) {
+	for _, flag := range []string{"--dir", "--dest", "-dest"} {
+		t.Run(flag, func(t *testing.T) {
+			got := stubVerify(t, "/opt/alcatraz/models/KnightsAnalytics_distilbert-NER", nil)
+
+			if _, err := runModels([]string{"verify", flag, "/opt/alcatraz/models"}); err != nil {
+				t.Fatalf("runModels: %v", err)
+			}
+			if got.dir != "/opt/alcatraz/models" {
+				t.Errorf("%s: dir = %q, want /opt/alcatraz/models", flag, got.dir)
+			}
+		})
+	}
+}
+
+// TestModelsVerifyRejectsTwoDirectories keeps the alias from silently picking
+// one: two spellings of the same flag disagreeing is a mistake in the caller's
+// script, and verifying whichever won would answer a question nobody asked.
+func TestModelsVerifyRejectsTwoDirectories(t *testing.T) {
+	got := stubVerify(t, "/unused", nil)
+
+	_, err := runModels([]string{"verify", "--dir", "/opt/a", "--dest", "/opt/b"})
+	if err == nil {
+		t.Fatal("runModels accepted -dir and -dest naming different directories")
+	}
+	for _, want := range []string{"/opt/a", "/opt/b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to name %s", err, want)
+		}
+	}
+	if got.dir != "" {
+		t.Errorf("verified %q anyway", got.dir)
+	}
+}
+
+// failAfter accepts n bytes and then refuses, standing in for a stdout that
+// fails partway through: a full disk, a descriptor closed under the process.
+// (A broken pipe on fd 1 is not this case — Go raises SIGPIPE and the process
+// dies where it stands, which is already the right answer.)
+type failAfter struct {
+	left int
+	err  error
+}
+
+func (f *failAfter) Write(p []byte) (int, error) {
+	if f.left <= 0 {
+		return 0, f.err
+	}
+	if len(p) > f.left {
+		n := f.left
+		f.left = 0
+		return n, f.err
+	}
+	f.left -= len(p)
+	return len(p), nil
+}
+
+// TestModelsCommandsReportAFailedStdout holds these two commands to the
+// contract writeFindings states: a stdout that failed surfaces as an error,
+// never as a silent exit 0. It matters more here than for a scan — both
+// commands are read by something deciding whether a model is usable, and
+// "verified" with no output would be taken as a pass.
+func TestModelsCommandsReportAFailedStdout(t *testing.T) {
+	errFull := errors.New("no space left on device")
+	const dir = "/opt/alcatraz/models"
+	modelPath := filepath.Join(dir, "KnightsAnalytics_distilbert-NER")
+
+	// The length of a whole successful run, so a writer can be made to fail on
+	// its very last write — past every early check, where only the final one
+	// can catch it.
+	full := func(run func(io.Writer)) int {
+		var buf bytes.Buffer
+		run(&buf)
+		return buf.Len()
+	}
+
+	t.Run("verify before hashing", func(t *testing.T) {
+		got := stubVerify(t, modelPath, nil)
+
+		_, err := verify(&failAfter{err: errFull}, models.DefaultModel, dir)
+		if !errors.Is(err, errFull) {
+			t.Fatalf("verify: %v, want %v", err, errFull)
+		}
+		// The manifest is printed before the hashing starts, so a writer that
+		// is already gone should stop the run there rather than re-read 250MB
+		// to report into it.
+		if got.dir != "" {
+			t.Error("hashed the model into a writer that had already failed")
+		}
+	})
+
+	t.Run("verify on the last line", func(t *testing.T) {
+		stubVerify(t, modelPath, nil)
+		n := full(func(w io.Writer) { verify(w, models.DefaultModel, dir) })
+
+		if _, err := verify(&failAfter{left: n - 1, err: errFull}, models.DefaultModel, dir); !errors.Is(err, errFull) {
+			t.Fatalf("verify: %v, want %v", err, errFull)
+		}
+	})
+
+	t.Run("download before fetching", func(t *testing.T) {
+		got := stubEnsure(t, modelPath, nil)
+
+		_, err := download(context.Background(), &failAfter{err: errFull}, models.DefaultModel, dir, "")
+		if !errors.Is(err, errFull) {
+			t.Fatalf("download: %v, want %v", err, errFull)
+		}
+		if got.model != "" {
+			t.Error("fetched 250MB into a writer that had already failed")
+		}
+	})
+
+	t.Run("download on the last line", func(t *testing.T) {
+		stubEnsure(t, modelPath, nil)
+		n := full(func(w io.Writer) { download(context.Background(), w, models.DefaultModel, dir, "") })
+
+		_, err := download(context.Background(), &failAfter{left: n - 1, err: errFull}, models.DefaultModel, dir, "")
+		if !errors.Is(err, errFull) {
+			t.Fatalf("download: %v, want %v", err, errFull)
+		}
+	})
+}
+
 func TestModelsVerifyPrintsWhatItChecked(t *testing.T) {
 	modelPath := filepath.Join("/opt/alcatraz/models", "KnightsAnalytics_distilbert-NER")
 	stubVerify(t, modelPath, nil)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,6 +109,7 @@ usage text; the origin actually used is printed before the fetch starts.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--dir` | the cache `ner.New` reads from | models directory to check |
+| `--dest` | — | alias for `--dir`, so a `download` line copies across unedited |
 | `--model` | `KnightsAnalytics/distilbert-NER` | which pinned model to check |
 
 `verify` re-checks a directory `download` already filled. It opens no socket
@@ -128,6 +129,15 @@ runtime rejected.
 > is the same one `download --dest` fills. Passing a model's own directory is
 > the classic slip; `verify` recognises it and points at the parent instead of
 > telling you to download a second copy nested inside the first.
+
+The flag is `--dir` rather than `--dest` because this command writes nothing,
+so it has no destination — but `--dest` names the same directory and is
+accepted, so the two lines in a runbook differ only in the verb:
+
+```bash
+alcatraz models download --dest /opt/alcatraz/models   # in the build
+alcatraz models verify   --dest /opt/alcatraz/models   # in the test that follows
+```
 
 See [Running NER without internet access](ner-offline.md) for the deployment
 patterns these commands exist for.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,7 @@ alcatraz diff [flags]                scan only the lines a unified diff adds
 alcatraz hook claude-post [flags]    Claude Code PostToolUse output rewriter
 alcatraz hook claude-prompt [flags]  Claude Code UserPromptSubmit guard
 alcatraz models download [flags]     fetch and verify the optional NER model
+alcatraz models verify [flags]       re-check an already-seeded model directory
 alcatraz version                     print the version (also -version/--version)
 ```
 
@@ -103,8 +104,33 @@ mirror serving anything else fails exactly as a corrupt transfer does and
 installs nothing. Run without the flag to see each pinned model's origin in the
 usage text; the origin actually used is printed before the fetch starts.
 
+## Flags: `models verify`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--dir` | the cache `ner.New` reads from | models directory to check |
+| `--model` | `KnightsAnalytics/distilbert-NER` | which pinned model to check |
+
+`verify` re-checks a directory `download` already filled. It opens no socket
+and writes nothing — not even the default cache directory, which it names but
+does not create — so it is safe against a read-only mount and inside a
+network-sealed build. It exits non-zero naming the first file that is absent,
+mismatched or unreadable; those are three different problems, and the message
+says which one you have.
+
+Two callers need this rather than a second `download`: a CI job proving an
+image really carries the model it claims to, asserted from outside because a
+distroless image has no shell, and an operator diagnosing a volume the model
+runtime rejected.
+
+> [!NOTE]
+> `--dir` is the *models* directory — the parent holding every model — which
+> is the same one `download --dest` fills. Passing a model's own directory is
+> the classic slip; `verify` recognises it and points at the parent instead of
+> telling you to download a second copy nested inside the first.
+
 See [Running NER without internet access](ner-offline.md) for the deployment
-patterns this command exists for.
+patterns these commands exist for.
 
 ## Network
 


### PR DESCRIPTION
Closes ATR-217.

`models.VerifyModelIn` was implemented, tested and unreachable: `runModels`
rejected every subcommand but `download`. The only way to check an
already-seeded directory was to run `download` again and read between the
lines of a command whose job is to write.

```
alcatraz models verify [-dir dir] [-model id]
```

## No socket, no writes

Not even the default cache directory, which it names but does not create —
looking is not a reason to write. That is what makes it usable against a
read-only mount and inside a network-sealed build, which is where both callers
live.

## Three different problems, three different answers

It exits non-zero naming the first file that is absent, mismatched or
unreadable, and the hint differs per kind:

- **mismatched** — the directory was seeded with the wrong bytes; re-fetch it.
- **absent** — it was never seeded; seed it.
- **unreadable** — the bytes may be fine and this process cannot see them.
  This one deliberately does *not* suggest `download`: re-fetching a file you
  lack permission to read solves nothing and may fail for the same reason.

Passing a model's own directory to `-dir` is the `ModelsDir`/`ModelPath` slip
the split exists to prevent, so that failure points at the parent rather than
advising a download that would nest a second copy inside the first.

## Who needs this rather than a second `download`

A CI job proving an image really carries the model it claims to — asserted
from outside, because a distroless image has no shell — and an operator
diagnosing a volume the model runtime rejected.

## Review follow-ups

Two findings from Qodo, in 501bb59.

**A failed stdout was reported as success.** Neither models command checked
its writes, while `report.go` states the contract they were skipping: a stdout
that failed has to surface as exit code 2. It matters more here than for a
scan — both commands are read by something deciding whether a model is usable,
so "verified" with no output would be taken as a pass. An `errWriter` latches
the first error so the report stays one paragraph instead of eight nested
checks, and it is consulted *before* the expensive step too: there is no point
fetching or re-hashing 250 MiB to report it into a writer that is already
failing. `download` had the same gap and is fixed with it, rather than left as
the odd function out in the same file.

Not the broken-pipe case, incidentally: a failed write to fd 1 raises SIGPIPE
and the process dies where it stands. This is the full disk and the descriptor
closed under the process.

**`-dest` is accepted as an alias for `-dir`.** `-dir` stays the documented
spelling, because the command writes nothing and so has no destination, but
the two commands sit next to each other in every runbook that has either, and
failing one of them over the name of the same path is friction with nothing on
the other side of it:

```bash
alcatraz models download --dest /opt/alcatraz/models   # in the build
alcatraz models verify   --dest /opt/alcatraz/models   # in the test that follows
```

Both spellings naming *different* directories is rejected rather than
resolved: that is a mistake in the caller's script, and verifying whichever
won would answer a question nobody asked.

## Scope

No new API in `models`. `VerifyModelIn` already keeps the three failure kinds
apart, and the package is deliberately small and standard-library only. The
CLI prints the full expected manifest up front, so an operator sees everything
being checked, while the error names the first file that failed. Reporting
*every* bad file at once would need a new per-file API; it is not worth
widening the package for, and the manifest covers most of what it would buy.

## Testing

`gofmt` clean; `go build ./... && go vet ./... && go test ./...` green against
the post-merge `main`.

The hints are asserted against errors the **real** verifier produces over
cheaply-built directories — the fixtures need the pinned file *names*, not the
250 MiB of pinned bytes — instead of hand-copied strings, so a reworded
message cannot silently drop its hint. `TestModelsVerifyWritesNothing` runs
the real verifier against an empty parent and asserts zero entries created.
The unreadable case skips on Windows and as root, where a 0000 mode proves
nothing.

`TestModelsCommandsReportAFailedStdout` covers both commands at both checks.
It first renders a successful run to measure its length, then fails the writer
one byte short of it, so the "last line" subtests provably exercise the final
check rather than an early one.

Unblocks ATR-219 (publish an agent image with the model baked in), whose CI
assertions are exactly this command.
