### PR TITLE
feat(models): record each pinned model's license (ATR-219)

### DIFF
--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -180,6 +180,14 @@
 // destination, but -dest names the same directory and is accepted: the two
 // commands sit next to each other in every runbook that has either.
 //
+// Both commands report the model's pinned license, and the usage lists it per
+// model: baking weights into a published image is a redistribution, so the
+// question is settled before the first build rather than during one. The
+// identifier travels with the URL declaring it, which for the default model is
+// not the repository the files come from — that one is an ONNX conversion
+// published with no model card, inheriting Apache-2.0 from
+// dslim/distilbert-NER.
+//
 // The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
 // which live in the root module so these commands cost the CLI no
 // dependencies: the ONNX runtime stays behind the ner module.

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -131,6 +131,7 @@ func download(ctx context.Context, out io.Writer, model, dest, origin string) (i
 	w := &errWriter{w: out}
 	w.printf("%s @ %s\n", model, shortRev(models.Revision(model)))
 	w.printf("origin: %s\n", origin)
+	w.printf("license: %s\n", licenseOf(model))
 	w.printf("fetching %d files, %s total (cached files are verified, not re-fetched):\n", len(files), humanSize(total))
 	for _, f := range files {
 		w.printf("  %-24s %10s\n", f.Name, humanSize(f.Size))
@@ -190,6 +191,7 @@ func verify(out io.Writer, model, dir string) (int, error) {
 
 	w := &errWriter{w: out}
 	w.printf("%s @ %s\n", model, shortRev(models.Revision(model)))
+	w.printf("license: %s\n", licenseOf(model))
 	w.printf("checking %d files in %s (no network, no writes):\n", len(files), shown)
 	for _, f := range files {
 		w.printf("  %-24s %10s\n", f.Name, humanSize(f.Size))
@@ -347,6 +349,21 @@ func shortRev(rev string) string {
 	return rev
 }
 
+// licenseOf renders a pinned model's license for the report. The URL is on the
+// line because for the default model it is not the repository the files come
+// from, and "Apache-2.0" alone would send an auditor to one that never
+// claimed so.
+func licenseOf(model string) string {
+	id, source := models.License(model)
+	switch {
+	case id == "":
+		return "unrecorded"
+	case source == "":
+		return id
+	}
+	return fmt.Sprintf("%s (declared at %s)", id, source)
+}
+
 // humanSize renders a byte count in the units an operator sizing an image
 // layer or a volume thinks in.
 func humanSize(n int64) string {
@@ -377,8 +394,11 @@ func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "three different problems that are worth telling apart. -dir is the models")
 	fmt.Fprintln(w, "directory, the same one download fills with -dest, and -dest is accepted")
 	fmt.Fprintln(w, "as an alias for it.")
+	// Listed here, not only in a run's report: whether a model may be baked
+	// into an image we publish is a question that comes up before any fetch.
 	fmt.Fprintln(w, "\nverifiable models:")
 	for _, id := range models.PinnedModels() {
-		fmt.Fprintf(w, "  %-40s %s\n", id, models.Origin(id))
+		license, _ := models.License(id)
+		fmt.Fprintf(w, "  %-40s %-24s %s\n", id, models.Origin(id), license)
 	}
 }

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -237,6 +237,43 @@ func TestModelsDownloadContextIsCancellable(t *testing.T) {
 	}
 }
 
+// TestModelsReportsCarryTheLicense pins the license into both commands'
+// output, because the output is the artefact: a build log for download, and
+// for verify the evidence a release keeps about what an image contains.
+func TestModelsReportsCarryTheLicense(t *testing.T) {
+	license, source := models.License(models.DefaultModel)
+
+	for _, tc := range []struct {
+		name string
+		run  func(io.Writer) (int, error)
+	}{
+		{"download", func(w io.Writer) (int, error) {
+			stubEnsure(t, "/models/KnightsAnalytics_distilbert-NER", nil)
+			return download(context.Background(), w, models.DefaultModel, "/models", "")
+		}},
+		{"verify", func(w io.Writer) (int, error) {
+			stubVerify(t, "/models/KnightsAnalytics_distilbert-NER", nil)
+			return verify(w, models.DefaultModel, "/models")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if code, err := tc.run(&out); err != nil || code != 0 {
+				t.Fatalf("%s = (%d, %v), want (0, nil)", tc.name, code, err)
+			}
+			got := out.String()
+			if !strings.Contains(got, license) {
+				t.Errorf("%s does not report the license %q:\n%s", tc.name, license, got)
+			}
+			// The repository the files come from declares no license, so the
+			// id alone points an auditor at the wrong place.
+			if !strings.Contains(got, source) {
+				t.Errorf("%s does not report where %q is declared:\n%s", tc.name, license, got)
+			}
+		})
+	}
+}
+
 func TestModelsUsage(t *testing.T) {
 	for _, args := range [][]string{{}, {"downlaod"}} {
 		_, err := runModels(args)
@@ -262,6 +299,12 @@ func TestModelsUsage(t *testing.T) {
 		}
 		if !strings.Contains(got, models.Origin(id)) {
 			t.Errorf("usage does not show the origin of %q:\n%s", id, got)
+		}
+		// Answered by the list rather than by a run: whether a model may go
+		// into an image we publish is decided before anything is fetched.
+		license, _ := models.License(id)
+		if !strings.Contains(got, license) {
+			t.Errorf("usage does not show the license of %q:\n%s", id, got)
 		}
 	}
 	// The layout is the contract a mirror has to satisfy, so it belongs in the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,6 +139,29 @@ alcatraz models download --dest /opt/alcatraz/models   # in the build
 alcatraz models verify   --dest /opt/alcatraz/models   # in the test that follows
 ```
 
+## Model licences
+
+Both commands print the model's pinned licence, and `alcatraz models` lists it
+per model. Baking weights into an image you publish is a redistribution, so the
+question is answered before the first build, not during one.
+
+The identifier travels with the URL declaring it, because the two are not
+always the same repository:
+
+```
+license: Apache-2.0 (declared at https://huggingface.co/dslim/distilbert-NER)
+```
+
+`KnightsAnalytics/distilbert-NER` is an ONNX conversion published with no model
+card, so it declares nothing; the licence is inherited from the weights it
+converted.
+
+> [!NOTE]
+> The fine-tune is trained on CoNLL-2003, whose underlying Reuters corpus has
+> terms of its own. Those bind the training data rather than the published
+> weights, but they are worth checking on a larger candidate model — the class
+> most likely to be non-commercial.
+
 See [Running NER without internet access](ner-offline.md) for the deployment
 patterns these commands exist for.
 

--- a/models/models.go
+++ b/models/models.go
@@ -57,6 +57,14 @@ type modelArtifact struct {
 	// digests below are what a file is accepted against wherever it came from,
 	// so the worst a wrong origin can do is fail the download.
 	origin string
+	// license is the SPDX identifier the weights are distributed under.
+	// Pinned like the digests because baking a model into a published image is
+	// a redistribution, and a layer cannot be taken back out of a history.
+	license string
+	// licenseSource is the URL declaring that identifier — not always the
+	// model's own repository, since a conversion published without a model
+	// card inherits the license of the weights it converted.
+	licenseSource string
 }
 
 // modelArtifacts holds every model EnsureModel can verify. Adding a model
@@ -69,6 +77,11 @@ type modelArtifact struct {
 var modelArtifacts = map[string]modelArtifact{
 	DefaultModel: {
 		revision: "13a742d5ea02349d17e18f3755301282c9ee33f7",
+		// Inherited, not declared: this repository ships no model card. The
+		// weights are an ONNX export of dslim/distilbert-NER, Apache-2.0,
+		// itself a fine-tune of distilbert-base-cased, Apache-2.0.
+		license:       "Apache-2.0",
+		licenseSource: "https://huggingface.co/dslim/distilbert-NER",
 		files: []modelFile{
 			{path: "config.json", sha256: "8f9f01d47f61087197f9fa85185d4a7a6248333c15af1b221aa5e8b9b76462b5", size: 925},
 			{path: "model.onnx", sha256: "4440f9fc64cd28ac75d83a38d89716f25947799640cd0e5f1f9f6e57b9c14160", size: 260926482},
@@ -148,6 +161,20 @@ func Origin(model string) string {
 		return art.origin
 	}
 	return defaultOrigin
+}
+
+// License returns the SPDX identifier model's weights are distributed under
+// and the URL declaring it, or "", "" if the model is not pinned.
+//
+// The source comes back alongside the id because it is not always the model's
+// own repository: an inherited license reported as a bare identifier reads as
+// a claim the origin never made.
+func License(model string) (id, source string) {
+	art, ok := modelArtifacts[model]
+	if !ok {
+		return "", ""
+	}
+	return art.license, art.licenseSource
 }
 
 // originFor applies the precedence — caller, then the pin table, then Hugging

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -611,6 +612,21 @@ func TestPinnedArtifactsWellFormed(t *testing.T) {
 				t.Errorf("%s: origin %q has a trailing slash", id, art.origin)
 			}
 		}
+		// A model with no recorded license is one nobody checked, and pinning
+		// is the moment to find out: the consumer of this table bakes the
+		// weights into an image and cannot take them back out of its history.
+		if art.license == "" {
+			t.Errorf("%s: no license recorded", id)
+		}
+		if u, err := url.Parse(art.licenseSource); art.licenseSource == "" || err != nil || u.Scheme != "https" || u.Host == "" {
+			t.Errorf("%s: license source %q is not an https URL", id, art.licenseSource)
+		}
+		// hoophq/hoopagent may carry no AGPL- or SSPL-licensed component
+		// anywhere in its history. The rule is that repository's, but this
+		// table is where the mistake would be made.
+		if l := strings.ToUpper(art.license); strings.HasPrefix(l, "AGPL") || strings.HasPrefix(l, "SSPL") {
+			t.Errorf("%s: license %q cannot ship in an image published under hoophq/hoopagent", id, art.license)
+		}
 		seen := map[string]bool{}
 		for _, f := range art.files {
 			if !digest.MatchString(f.sha256) {
@@ -632,6 +648,21 @@ func TestPinnedArtifactsWellFormed(t *testing.T) {
 				t.Errorf("%s: %s is not pinned", id, required)
 			}
 		}
+	}
+}
+
+func TestLicense(t *testing.T) {
+	if id, src := License("some-org/unpinned-model"); id != "" || src != "" {
+		t.Errorf(`License(unpinned) = %q, %q, want "", ""`, id, src)
+	}
+	id, src := License(DefaultModel)
+	if id != "Apache-2.0" {
+		t.Errorf("License(%s) = %q, want Apache-2.0", DefaultModel, id)
+	}
+	// The upstream repository, not the one the files are fetched from, which
+	// is the point of recording it separately.
+	if want := "https://huggingface.co/dslim/distilbert-NER"; src != want {
+		t.Errorf("License(%s) source = %q, want %q", DefaultModel, src, want)
 	}
 }
 


### PR DESCRIPTION
Records the licence each pinned model's weights are distributed under, next to the digests that already pin its bytes.

## Why

Baking a model into an image we publish is a redistribution, and weights carry licences of their own. `hoophq/hoopagent` may carry no AGPL- or SSPL-licensed component anywhere in its history, and a layer cannot be taken back out of a history afterwards — so this has to be known before the first build rather than found during one. The pin table is where a model enters the project, so it is where the question belongs.

This is the first piece of ATR-219 (bake the model into an agent image); the Dockerfile and its CI land in `hoophq/hoop`.

## The default model's licence is inherited, not declared

`KnightsAnalytics/distilbert-NER` is six files and no model card — it declares nothing. The weights are an ONNX export of [`dslim/distilbert-NER`](https://huggingface.co/dslim/distilbert-NER), Apache-2.0, itself a fine-tune of `distilbert-base-cased`, Apache-2.0.

So the identifier is stored with the URL that declares it, and both are reported:

```
license: Apache-2.0 (declared at https://huggingface.co/dslim/distilbert-NER)
```

A build log reading only `Apache-2.0` would send whoever audits it to a repository that never claimed so. Apache-2.0 permits the redistribution a baked-in image performs and is neither AGPL nor SSPL, so the bright line holds.

**Worth a second opinion before this merges:** treating an undeclared conversion as inheriting its upstream's licence is a judgement, not a fact the origin states.

## What changed

- `models`: `license` and `licenseSource` on `modelArtifact`, plus `models.License(model) (id, source string)`.
- `alcatraz models download` and `verify` print a `license:` line; `alcatraz models` lists it per model in the usage.
- `TestPinnedArtifactsWellFormed` fails a model added with no licence, with a non-https source, or with an AGPL/SSPL identifier. A record nothing reads is not a control.
- Package docs and `docs/cli.md`.

## Not encoded anywhere

The fine-tune is trained on CoNLL-2003, whose underlying Reuters corpus has terms of its own. Those bind the training data rather than the published weights, but a larger candidate model should be checked for it — that class is the one most likely to be non-commercial.

## Testing

`gofmt`, `go build`, `go vet`, `go test ./...` all clean. The new report test was mutation-checked: it fails when the `license:` line is removed and passes when restored.

Sample output:

```
$ alcatraz models verify --dir /tmp/nope
KnightsAnalytics/distilbert-NER @ 13a742d5
license: Apache-2.0 (declared at https://huggingface.co/dslim/distilbert-NER)
checking 6 files in /tmp/nope (no network, no writes):
```

```
$ alcatraz models
verifiable models:
  KnightsAnalytics/distilbert-NER          https://huggingface.co   Apache-2.0
```

Refs ATR-219.
