### PR TITLE
ci(models): mirror pinned models to S3 and publish from CI (ATR-218)

### DIFF
--- a/.github/workflows/mirror-check.yml
+++ b/.github/workflows/mirror-check.yml
@@ -39,6 +39,9 @@ jobs:
             echo "::warning::MODELS_ORIGIN is not set, so there is no mirror to check."
             exit 0
           fi
+          # The downloader trims these itself, so an origin that works there has
+          # to work here: a trailing slash asks S3 for a key starting with one.
+          ORIGIN="${ORIGIN%"${ORIGIN##*[!/]}"}"
 
           alcatraz="$RUNNER_TEMP/alcatraz"
           go build -o "$alcatraz" ./cmd/alcatraz

--- a/.github/workflows/mirror-check.yml
+++ b/.github/workflows/mirror-check.yml
@@ -1,0 +1,69 @@
+# Fails a PR that pins a model the mirror does not serve yet. Without it the
+# gap surfaces later, in a production image build, far from the change that
+# caused it.
+#
+# The mirror is served publicly, so this needs no credentials: it is a HEAD per
+# pinned file against the same origin an image build would use.
+name: Mirror check
+
+on:
+  pull_request:
+    paths:
+      - "models/**"
+      - ".github/workflows/mirror-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Mirror serves every pinned file
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Check the mirror
+        env:
+          ORIGIN: ${{ vars.MODELS_ORIGIN }}
+        run: |
+          if [ -z "$ORIGIN" ]; then
+            echo "::warning::MODELS_ORIGIN is not set, so there is no mirror to check."
+            exit 0
+          fi
+
+          alcatraz="$RUNNER_TEMP/alcatraz"
+          go build -o "$alcatraz" ./cmd/alcatraz
+
+          missing=0
+          for model in $("$alcatraz" models pins -list); do
+            echo "$model"
+            # Size, not just a 200: a truncated or half-uploaded object answers
+            # a HEAD perfectly well and then fails the digest check on use.
+            while IFS=$'\t' read -r key size; do
+              # -L and the tail: an origin may redirect large files to a CDN,
+              # as the hub does, and then two sets of headers come back.
+              got=$(curl -fsSIL --max-time 30 "$ORIGIN/$key" \
+                | awk 'tolower($1) == "content-length:" { print $2 }' | tail -1 | tr -d '\r') || got=""
+              if [ "$got" = "$size" ]; then
+                echo "  ok      $key"
+              else
+                echo "  MISSING $key"
+                echo "::error::$ORIGIN/$key is not served as $size bytes (got ${got:-no response})"
+                missing=$((missing + 1))
+              fi
+            done < <("$alcatraz" models pins -model "$model" | jq -r '.files[] | [.key, .size] | @tsv')
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::$missing file(s) are pinned but not mirrored. Run the \"Mirror model\" workflow before merging."
+            exit 1
+          fi

--- a/.github/workflows/mirror-model.yml
+++ b/.github/workflows/mirror-model.yml
@@ -1,0 +1,79 @@
+# Publishes a pinned model to the S3 mirror that serves `models download
+# -origin`. Manual by design: a model is mirrored when its pin lands, which is
+# a handful of times a year, and every upload is write-once.
+#
+# Credentials are assumed via OIDC and last minutes, so this repository — which
+# is public — never holds a key with write access to the bucket. The role's
+# trust policy is scoped to the models-publish environment, not to the repo, so
+# a job that skipped the reviewer gate cannot assume it.
+name: Mirror model
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model id to mirror (blank = the pinned default)"
+        type: string
+      dry_run:
+        description: "List the keys and stop, without credentials"
+        type: boolean
+        default: true
+      force:
+        description: "Overwrite keys that already exist"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+# Two runs uploading the same revision would race on the head-object precheck.
+concurrency:
+  group: mirror-model
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Mirror
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: models-publish
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      # A dry run reaches neither AWS nor the bucket, so it gets no credentials.
+      # The arn is a secret because it carries the account id; the rest stay
+      # variables, so a failed run shows which bucket and origin it used.
+      - name: Assume the publisher role
+        if: ${{ !inputs.dry_run }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.MODELS_PUBLISH_ROLE }}
+          aws-region: ${{ vars.MODELS_REGION || 'us-east-1' }}
+
+      - name: Mirror the model
+        env:
+          # Inputs go through the environment rather than into the script text:
+          # a workflow_dispatch input is a string someone typed.
+          BUCKET: ${{ vars.MODELS_BUCKET }}
+          ORIGIN: ${{ vars.MODELS_ORIGIN }}
+          MODEL: ${{ inputs.model }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          if [ -z "$BUCKET" ]; then
+            echo "::error::the MODELS_BUCKET variable is not set on the models-publish environment"
+            exit 1
+          fi
+          args=(--bucket "$BUCKET")
+          # The origin drives the round-trip check the script ends with, which
+          # is the real acceptance test: bytes in the bucket that the
+          # downloader cannot consume are not a published model.
+          if [ -n "$ORIGIN" ]; then args+=(--origin "$ORIGIN"); fi
+          if [ -n "$MODEL" ]; then args+=(--model "$MODEL"); fi
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+          if [ "$FORCE" = "true" ]; then args+=(--force); fi
+          hack/mirror-model.sh "${args[@]}"

--- a/.github/workflows/mirror-model.yml
+++ b/.github/workflows/mirror-model.yml
@@ -68,10 +68,17 @@ jobs:
             echo "::error::the MODELS_BUCKET variable is not set on the models-publish environment"
             exit 1
           fi
+          # The origin drives the round-trip the script ends with, which is the
+          # real acceptance test: bytes in the bucket the downloader cannot
+          # consume are not a published model. The script leaves it optional,
+          # for a bucket filled before anything serves it; a publish from here
+          # has no such excuse.
+          if [ -z "$ORIGIN" ] && [ "$DRY_RUN" != "true" ]; then
+            echo "::error::the MODELS_ORIGIN variable is not set, so the upload could not be verified"
+            exit 1
+          fi
+
           args=(--bucket "$BUCKET")
-          # The origin drives the round-trip check the script ends with, which
-          # is the real acceptance test: bytes in the bucket that the
-          # downloader cannot consume are not a published model.
           if [ -n "$ORIGIN" ]; then args+=(--origin "$ORIGIN"); fi
           if [ -n "$MODEL" ]; then args+=(--model "$MODEL"); fi
           if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi

--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -199,8 +199,8 @@
 // Each file carries its digest, size and the key the downloader requests —
 // {model}/resolve/{revision}/{file} — so a tool populating a mirror uploads to
 // the layout the fetch already expects instead of rebuilding it. That is what
-// hack/mirror-model.sh does. Output is always JSON; download prints the
-// human-readable manifest.
+// hack/mirror-model.sh does. The manifest is JSON, -list being the one
+// exception; download prints the human-readable version.
 //
 // The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
 // which live in the root module so these commands cost the CLI no

--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -193,6 +193,8 @@
 //
 //	-model string
 //		model id to describe (default "KnightsAnalytics/distilbert-NER")
+//	-list
+//		print every pinned model id, one per line, and exit
 //
 // Each file carries its digest, size and the key the downloader requests —
 // {model}/resolve/{revision}/{file} — so a tool populating a mirror uploads to

--- a/cmd/alcatraz/doc.go
+++ b/cmd/alcatraz/doc.go
@@ -11,6 +11,7 @@
 //	                                   UserPromptSubmit guard for Claude Code
 //	alcatraz models download [flags]   fetch a verified NER model
 //	alcatraz models verify [flags]     re-check an already-seeded model
+//	alcatraz models pins [flags]       print a model's pin table entry as JSON
 //	alcatraz version                   print the version (also -version, --version)
 //
 // Scanning is the network-free part, and it is the whole product: no
@@ -187,6 +188,17 @@
 // not the repository the files come from — that one is an ONNX conversion
 // published with no model card, inheriting Apache-2.0 from
 // dslim/distilbert-NER.
+//
+// alcatraz models pins writes the pin table's entry for a model as JSON:
+//
+//	-model string
+//		model id to describe (default "KnightsAnalytics/distilbert-NER")
+//
+// Each file carries its digest, size and the key the downloader requests —
+// {model}/resolve/{revision}/{file} — so a tool populating a mirror uploads to
+// the layout the fetch already expects instead of rebuilding it. That is what
+// hack/mirror-model.sh does. Output is always JSON; download prints the
+// human-readable manifest.
 //
 // The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
 // which live in the root module so these commands cost the CLI no

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,9 +22,10 @@ import (
 //
 //	alcatraz models download [-dest dir] [-model id] [-origin url]
 //	alcatraz models verify   [-dir dir] [-model id]
+//	alcatraz models pins     [-model id]
 //
 // download is the one alcatraz command that touches the network, and it only
-// fetches the pinned URLs. Scanning never does, and neither does verify.
+// fetches the pinned URLs. Scanning never does, and neither do verify or pins.
 //
 // The heavy lifting is [models.EnsureModelFrom] and [models.VerifyModelIn],
 // which live in the root module precisely so these commands cost the CLI no
@@ -47,9 +49,11 @@ func runModels(args []string) (int, error) {
 		return runModelsDownload(rest)
 	case "verify":
 		return runModelsVerify(rest)
+	case "pins":
+		return runModelsPins(rest)
 	default:
 		modelsUsage(os.Stderr)
-		return 0, fmt.Errorf("models: unknown subcommand %q (want download or verify)", sub)
+		return 0, fmt.Errorf("models: unknown subcommand %q (want download, verify or pins)", sub)
 	}
 }
 
@@ -105,6 +109,77 @@ func runModelsVerify(rest []string) (int, error) {
 	// No signal handling, unlike download: this opens no socket and creates no
 	// file, so an interrupted run leaves nothing behind to clean up.
 	return verify(os.Stdout, *model, *dir)
+}
+
+func runModelsPins(rest []string) (int, error) {
+	fs := flag.NewFlagSet("models pins", flag.ContinueOnError)
+	model := fs.String("model", models.DefaultModel, "model id to describe")
+	if err := fs.Parse(rest); err != nil {
+		return 0, err
+	}
+	if fs.NArg() > 0 {
+		return 0, fmt.Errorf("models pins: unexpected argument %q", fs.Arg(0))
+	}
+	return pins(os.Stdout, *model)
+}
+
+// pinManifest is the wire format of "models pins", declared here rather than
+// reusing models.PinnedFile so an internal rename cannot break scripts.
+type pinManifest struct {
+	Model    string       `json:"model"`
+	Revision string       `json:"revision"`
+	Origin   string       `json:"origin"`
+	License  pinLicense   `json:"license"`
+	Files    []pinFileOut `json:"files"`
+}
+
+type pinLicense struct {
+	ID     string `json:"id"`
+	Source string `json:"source"`
+}
+
+type pinFileOut struct {
+	// Key is the path under an origin the downloader asks for, precomputed so
+	// a mirror does not keep its own copy of the layout.
+	Key    string `json:"key"`
+	Path   string `json:"path"`
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// pins writes the pin table's entry for model as JSON, so a publisher mirrors
+// from the same source of truth the downloader verifies against.
+func pins(out io.Writer, model string) (int, error) {
+	files := models.PinnedFiles(model)
+	if files == nil {
+		return 0, fmt.Errorf("models pins: %q has no pinned checksums (pinned models: %s)",
+			model, strings.Join(models.PinnedModels(), ", "))
+	}
+	rev := models.Revision(model)
+	id, source := models.License(model)
+	m := pinManifest{
+		Model:    model,
+		Revision: rev,
+		Origin:   models.Origin(model),
+		License:  pinLicense{ID: id, Source: source},
+		Files:    make([]pinFileOut, 0, len(files)),
+	}
+	for _, f := range files {
+		m.Files = append(m.Files, pinFileOut{
+			Key:    fmt.Sprintf("%s/resolve/%s/%s", model, rev, f.Path),
+			Path:   f.Path,
+			Name:   f.Name,
+			SHA256: f.SHA256,
+			Size:   f.Size,
+		})
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(m); err != nil {
+		return 0, fmt.Errorf("models pins: writing output: %w", err)
+	}
+	return 0, nil
 }
 
 func download(ctx context.Context, out io.Writer, model, dest, origin string) (int, error) {
@@ -382,6 +457,7 @@ func humanSize(n int64) string {
 func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id] [-origin url]")
 	fmt.Fprintln(w, "       alcatraz models verify   [-dir dir] [-model id]")
+	fmt.Fprintln(w, "       alcatraz models pins     [-model id]")
 	fmt.Fprintln(w, "\nDownloads a NER model and verifies every file against its pinned sha256.")
 	fmt.Fprintln(w, "Without -dest it warms the cache ner.New reads from; with -dest it writes a")
 	fmt.Fprintln(w, "self-contained directory to copy into an image or a shared volume.")
@@ -394,6 +470,10 @@ func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "three different problems that are worth telling apart. -dir is the models")
 	fmt.Fprintln(w, "directory, the same one download fills with -dest, and -dest is accepted")
 	fmt.Fprintln(w, "as an alias for it.")
+	fmt.Fprintln(w, "\npins writes the pin table's entry for a model as JSON — revision, license,")
+	fmt.Fprintln(w, "and every file with its digest, size and the key an origin must serve it")
+	fmt.Fprintln(w, "under. It exists so a publisher mirroring the model reads the table instead")
+	fmt.Fprintln(w, "of keeping a second copy of it that drifts.")
 	// Listed here, not only in a run's report: whether a model may be baked
 	// into an image we publish is a question that comes up before any fetch.
 	fmt.Fprintln(w, "\nverifiable models:")

--- a/cmd/alcatraz/models.go
+++ b/cmd/alcatraz/models.go
@@ -114,13 +114,30 @@ func runModelsVerify(rest []string) (int, error) {
 func runModelsPins(rest []string) (int, error) {
 	fs := flag.NewFlagSet("models pins", flag.ContinueOnError)
 	model := fs.String("model", models.DefaultModel, "model id to describe")
+	list := fs.Bool("list", false, "print every pinned model id, one per line")
 	if err := fs.Parse(rest); err != nil {
 		return 0, err
 	}
 	if fs.NArg() > 0 {
 		return 0, fmt.Errorf("models pins: unexpected argument %q", fs.Arg(0))
 	}
+	if *list {
+		return pinsList(os.Stdout)
+	}
 	return pins(os.Stdout, *model)
+}
+
+// pinsList prints the pinned model ids, so a publisher can loop over the table
+// without carrying its own list of what is in it.
+func pinsList(out io.Writer) (int, error) {
+	w := &errWriter{w: out}
+	for _, id := range models.PinnedModels() {
+		w.printf("%s\n", id)
+	}
+	if w.err != nil {
+		return 0, fmt.Errorf("models pins: writing output: %w", w.err)
+	}
+	return 0, nil
 }
 
 // pinManifest is the wire format of "models pins", declared here rather than
@@ -457,7 +474,7 @@ func humanSize(n int64) string {
 func modelsUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage: alcatraz models download [-dest dir] [-model id] [-origin url]")
 	fmt.Fprintln(w, "       alcatraz models verify   [-dir dir] [-model id]")
-	fmt.Fprintln(w, "       alcatraz models pins     [-model id]")
+	fmt.Fprintln(w, "       alcatraz models pins     [-model id] [-list]")
 	fmt.Fprintln(w, "\nDownloads a NER model and verifies every file against its pinned sha256.")
 	fmt.Fprintln(w, "Without -dest it warms the cache ner.New reads from; with -dest it writes a")
 	fmt.Fprintln(w, "self-contained directory to copy into an image or a shared volume.")

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -326,6 +327,24 @@ func TestModelsPinsRejectsAnUnpinnedModel(t *testing.T) {
 	}
 	if out.Len() > 0 {
 		t.Errorf("pins wrote output for an unpinned model: %s", out.String())
+	}
+}
+
+// TestModelsPinsListIsLoopable pins the shape CI depends on: one id per line,
+// each of them a model "pins -model" then accepts.
+func TestModelsPinsListIsLoopable(t *testing.T) {
+	var out bytes.Buffer
+	if code, err := pinsList(&out); err != nil || code != 0 {
+		t.Fatalf("pinsList = (%d, %v), want (0, nil)", code, err)
+	}
+	got := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	if want := models.PinnedModels(); !slices.Equal(got, want) {
+		t.Fatalf("pins -list = %q, want %q", got, want)
+	}
+	for _, id := range got {
+		if m := decodePins(t, id); m.Model != id {
+			t.Errorf("pins -model %q reported %q", id, m.Model)
+		}
 	}
 }
 

--- a/cmd/alcatraz/models_test.go
+++ b/cmd/alcatraz/models_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -271,6 +272,60 @@ func TestModelsReportsCarryTheLicense(t *testing.T) {
 				t.Errorf("%s does not report where %q is declared:\n%s", tc.name, license, got)
 			}
 		})
+	}
+}
+
+// decodePins runs "models pins" and decodes it, failing on either.
+func decodePins(t *testing.T, model string) pinManifest {
+	t.Helper()
+	var out bytes.Buffer
+	if code, err := pins(&out, model); err != nil || code != 0 {
+		t.Fatalf("pins(%q) = (%d, %v), want (0, nil)", model, code, err)
+	}
+	var got pinManifest
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("pins(%q) emitted invalid JSON: %v\n%s", model, err, out.String())
+	}
+	return got
+}
+
+func TestModelsPinsMatchesTheTable(t *testing.T) {
+	got := decodePins(t, models.DefaultModel)
+
+	id, source := models.License(models.DefaultModel)
+	if got.Model != models.DefaultModel || got.Revision != models.Revision(models.DefaultModel) ||
+		got.Origin != models.Origin(models.DefaultModel) || got.License.ID != id || got.License.Source != source {
+		t.Errorf("pins header = %+v, does not match the table", got)
+	}
+
+	want := models.PinnedFiles(models.DefaultModel)
+	if len(got.Files) != len(want) {
+		t.Fatalf("pins listed %d files, want %d", len(got.Files), len(want))
+	}
+	for i, f := range want {
+		// A publisher uploads by key and checks by digest, so both have to be
+		// right for the mirror to serve anything the downloader accepts.
+		g := got.Files[i]
+		if g.Name != f.Name || g.Path != f.Path || g.SHA256 != f.SHA256 || g.Size != f.Size {
+			t.Errorf("pins file %d = %+v, want %+v", i, g, f)
+		}
+		if wantKey := models.DefaultModel + "/resolve" + "/" + got.Revision + "/" + f.Path; g.Key != wantKey {
+			t.Errorf("pins file %d key = %q, want %q", i, g.Key, wantKey)
+		}
+	}
+}
+
+func TestModelsPinsRejectsAnUnpinnedModel(t *testing.T) {
+	var out bytes.Buffer
+	_, err := pins(&out, "some-org/unpinned-model")
+	if err == nil {
+		t.Fatal("pins succeeded for an unpinned model, want an error naming the pinned ones")
+	}
+	if !strings.Contains(err.Error(), models.DefaultModel) {
+		t.Errorf("error %q does not list the pinned models", err)
+	}
+	if out.Len() > 0 {
+		t.Errorf("pins wrote output for an unpinned model: %s", out.String())
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,6 +154,11 @@ file with its digest, size and the key the downloader requests:
 {
   "model": "KnightsAnalytics/distilbert-NER",
   "revision": "13a742d5ea02349d17e18f3755301282c9ee33f7",
+  "origin": "https://huggingface.co",
+  "license": {
+    "id": "Apache-2.0",
+    "source": "https://huggingface.co/dslim/distilbert-NER"
+  },
   "files": [
     {
       "key": "KnightsAnalytics/distilbert-NER/resolve/13a742d5.../config.json",
@@ -165,6 +170,9 @@ file with its digest, size and the key the downloader requests:
   ]
 }
 ```
+
+`files` holds every pinned file; one is shown here, and the digest and key are
+elided for width.
 
 This exists so a tool filling a mirror reads the same table the downloader
 verifies against, rather than keeping its own list that drifts. `key` is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,6 +145,7 @@ alcatraz models verify   --dest /opt/alcatraz/models   # in the test that follow
 | Flag | Default | Meaning |
 |---|---|---|
 | `--model` | `KnightsAnalytics/distilbert-NER` | which pinned model to describe |
+| `--list` | off | print every pinned model id, one per line, and exit |
 
 Prints the pin table's entry as JSON — revision, origin, licence, and every
 file with its digest, size and the key the downloader requests:
@@ -171,11 +172,18 @@ precomputed for the same reason: the layout lives in one place.
 
 ```bash
 alcatraz models pins | jq -r '.files[].key'   # what the bucket has to hold
+alcatraz models pins --list                   # every model that has to be mirrored
 ```
 
 `hack/mirror-model.sh` drives the `aws` CLI from this output — it downloads and
 verifies locally, uploads write-once, then round-trips through `--origin` to
 prove the mirror actually serves what the downloader will accept.
+
+Two workflows wrap it. `Mirror model` publishes, manually, assuming an AWS role
+via OIDC behind a reviewer gate. `Mirror check` runs on any PR touching
+`models/`, and fails it if the mirror does not already serve every pinned file
+at its pinned size — so a pin that nobody mirrored is caught there rather than
+in a later image build.
 
 ## Model licences
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ alcatraz hook claude-post [flags]    Claude Code PostToolUse output rewriter
 alcatraz hook claude-prompt [flags]  Claude Code UserPromptSubmit guard
 alcatraz models download [flags]     fetch and verify the optional NER model
 alcatraz models verify [flags]       re-check an already-seeded model directory
+alcatraz models pins [flags]         print a model's pin table entry as JSON
 alcatraz version                     print the version (also -version/--version)
 ```
 
@@ -138,6 +139,43 @@ accepted, so the two lines in a runbook differ only in the verb:
 alcatraz models download --dest /opt/alcatraz/models   # in the build
 alcatraz models verify   --dest /opt/alcatraz/models   # in the test that follows
 ```
+
+## Flags: `models pins`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--model` | `KnightsAnalytics/distilbert-NER` | which pinned model to describe |
+
+Prints the pin table's entry as JSON — revision, origin, licence, and every
+file with its digest, size and the key the downloader requests:
+
+```json
+{
+  "model": "KnightsAnalytics/distilbert-NER",
+  "revision": "13a742d5ea02349d17e18f3755301282c9ee33f7",
+  "files": [
+    {
+      "key": "KnightsAnalytics/distilbert-NER/resolve/13a742d5.../config.json",
+      "path": "config.json",
+      "name": "config.json",
+      "sha256": "a2b1...",
+      "size": 925
+    }
+  ]
+}
+```
+
+This exists so a tool filling a mirror reads the same table the downloader
+verifies against, rather than keeping its own list that drifts. `key` is
+precomputed for the same reason: the layout lives in one place.
+
+```bash
+alcatraz models pins | jq -r '.files[].key'   # what the bucket has to hold
+```
+
+`hack/mirror-model.sh` drives the `aws` CLI from this output — it downloads and
+verifies locally, uploads write-once, then round-trips through `--origin` to
+prove the mirror actually serves what the downloader will accept.
 
 ## Model licences
 

--- a/docs/ner-offline.md
+++ b/docs/ner-offline.md
@@ -75,6 +75,28 @@ spec:
         - { name: alcatraz-models, mountPath: /models }
 ```
 
+## Or serve the model from your own mirror
+
+When the build can reach an internal bucket but not huggingface.co, point
+`--origin` at it. Only the base URL moves; the layout under it stays
+`{origin}/{model}/resolve/{revision}/{file}`, and the pinned digests are
+unchanged, so a mirror serving the wrong bytes fails exactly as a corrupt
+transfer does.
+
+```bash
+alcatraz models download --dest /opt/alcatraz/models \
+  --origin https://models.internal/alcatraz
+```
+
+To fill that bucket, `hack/mirror-model.sh` reads `alcatraz models pins` for
+the file list and keys, verifies every file locally before uploading, and
+finishes by downloading the result back through the public origin.
+
+```bash
+hack/mirror-model.sh --bucket s3://your-bucket/alcatraz \
+                     --origin https://models.internal/alcatraz
+```
+
 ## Wiring the result into the config
 
 The command prints two paths one directory apart, and they are not

--- a/hack/mirror-model.sh
+++ b/hack/mirror-model.sh
@@ -19,8 +19,8 @@ usage() {
 usage: hack/mirror-model.sh --bucket s3://bucket/prefix --origin https://host/prefix [options]
 
   --bucket   s3 destination, optionally with a key prefix (required)
-  --origin   public base URL the bucket is served under, used for the
-             round-trip verify (required unless --dry-run)
+  --origin   public base URL the bucket is served under. Given, the upload is
+             followed by a download through it; omitted, that check is skipped
   --model    model id to mirror (default: the pinned default)
   --dry-run  print what would be uploaded and exit
   --force    overwrite keys that already exist
@@ -54,7 +54,6 @@ die() {
 }
 
 [ -n "$bucket" ] || die "--bucket is required"
-[ -n "$origin" ] || [ "$dry_run" = true ] || die "--origin is required (or pass --dry-run)"
 
 for tool in aws jq; do
 	command -v "$tool" >/dev/null || die "$tool is not installed"
@@ -134,7 +133,16 @@ echo "uploaded $uploaded, skipped $skipped"
 
 # The upload is only useful if the downloader can consume it, and that is a
 # different question from whether the bytes arrived: a wrong prefix, a missing
-# public-read policy or a stray redirect all pass the upload and fail here.
+# read policy or a stray redirect all pass the upload and fail here. It is
+# skippable because the bucket is often filled before anything serves it.
+if [ -z "$origin" ]; then
+	echo
+	echo "no --origin given, skipping the round-trip verify. Once the bucket is"
+	echo "served, check it with:"
+	echo "  alcatraz models download --model $model --origin <base url> --dest /tmp/roundtrip"
+	exit 0
+fi
+
 echo
 echo "verifying round trip from $origin"
 "$alcatraz" models download --dest "$work/roundtrip" --model "$model" --origin "$origin"

--- a/hack/mirror-model.sh
+++ b/hack/mirror-model.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Mirror a pinned model into an S3 bucket laid out like the hub, then prove the
+# result by downloading it back through the origin an operator would use.
+#
+# The file list, digests and keys all come from "alcatraz models pins", so this
+# script never carries a second copy of the pin table.
+#
+#   hack/mirror-model.sh --bucket s3://hoop-models/alcatraz \
+#                        --origin https://models.hoop.dev/alcatraz
+#
+# Credentials come from the ambient AWS config; none belong in this repository.
+# In CI, assume a role via OIDC rather than issuing a long-lived key with write
+# access to a public bucket.
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+usage: hack/mirror-model.sh --bucket s3://bucket/prefix --origin https://host/prefix [options]
+
+  --bucket   s3 destination, optionally with a key prefix (required)
+  --origin   public base URL the bucket is served under, used for the
+             round-trip verify (required unless --dry-run)
+  --model    model id to mirror (default: the pinned default)
+  --dry-run  print what would be uploaded and exit
+  --force    overwrite keys that already exist
+
+Uploads are write-once by default: a revision already present is left alone,
+because a pinned revision that changes bytes is a mistake, not an update.
+EOF
+}
+
+bucket=""
+origin=""
+model=""
+dry_run=false
+force=false
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--bucket) bucket="${2:-}"; shift 2 ;;
+	--origin) origin="${2:-}"; shift 2 ;;
+	--model) model="${2:-}"; shift 2 ;;
+	--dry-run) dry_run=true; shift ;;
+	--force) force=true; shift ;;
+	-h | --help) usage; exit 0 ;;
+	*) echo "mirror-model: unknown argument $1" >&2; usage >&2; exit 2 ;;
+	esac
+done
+
+die() {
+	echo "mirror-model: $*" >&2
+	exit 1
+}
+
+[ -n "$bucket" ] || die "--bucket is required"
+[ -n "$origin" ] || [ "$dry_run" = true ] || die "--origin is required (or pass --dry-run)"
+
+for tool in aws jq; do
+	command -v "$tool" >/dev/null || die "$tool is not installed"
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Build the CLI rather than expecting one on PATH: the mirror has to match the
+# pin table in this checkout, not whatever version happens to be installed.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+alcatraz="$work/alcatraz"
+go build -o "$alcatraz" ./cmd/alcatraz
+
+pins_args=(models pins)
+[ -n "$model" ] && pins_args+=(-model "$model")
+manifest="$work/pins.json"
+"$alcatraz" "${pins_args[@]}" >"$manifest"
+
+model="$(jq -r .model "$manifest")"
+revision="$(jq -r .revision "$manifest")"
+source_origin="$(jq -r .origin "$manifest")"
+license="$(jq -r '.license.id + " (declared at " + .license.source + ")"' "$manifest")"
+
+# s3://bucket/prefix -> bucket, prefix
+bucket_path="${bucket#s3://}"
+bucket_name="${bucket_path%%/*}"
+prefix="${bucket_path#"$bucket_name"}"
+prefix="${prefix#/}"
+prefix="${prefix%/}"
+
+echo "$model @ ${revision:0:8}"
+echo "license: $license"
+echo "source:  $source_origin"
+echo "dest:    s3://$bucket_name/${prefix:+$prefix/}"
+echo
+
+if [ "$dry_run" = true ]; then
+	jq -r --arg p "${prefix:+$prefix/}" '.files[] | "  \($p)\(.key)  \(.size) bytes"' "$manifest"
+	exit 0
+fi
+
+# Download through the normal path: every file is verified against its pinned
+# digest on the way in, so nothing unverified can reach the bucket.
+staging="$work/models"
+"$alcatraz" models download --dest "$staging" --model "$model" >/dev/null
+model_dir="$staging/$(echo "$model" | tr '/' '_')"
+
+uploaded=0
+skipped=0
+while IFS=$'\t' read -r key name size; do
+	s3_key="${prefix:+$prefix/}$key"
+	local_file="$model_dir/$name"
+	[ -f "$local_file" ] || die "$name is missing from $model_dir after download"
+
+	if [ "$force" != true ] && aws s3api head-object --bucket "$bucket_name" --key "$s3_key" >/dev/null 2>&1; then
+		echo "  skip   $s3_key (already present)"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	echo "  upload $s3_key ($size bytes)"
+	# A pinned revision is immutable, so it is cached forever.
+	aws s3api put-object \
+		--bucket "$bucket_name" \
+		--key "$s3_key" \
+		--body "$local_file" \
+		--cache-control "public, max-age=31536000, immutable" \
+		--checksum-algorithm SHA256 \
+		>/dev/null
+	uploaded=$((uploaded + 1))
+done < <(jq -r '.files[] | [.key, .name, .size] | @tsv' "$manifest")
+
+echo
+echo "uploaded $uploaded, skipped $skipped"
+
+# The upload is only useful if the downloader can consume it, and that is a
+# different question from whether the bytes arrived: a wrong prefix, a missing
+# public-read policy or a stray redirect all pass the upload and fail here.
+echo
+echo "verifying round trip from $origin"
+"$alcatraz" models download --dest "$work/roundtrip" --model "$model" --origin "$origin"

--- a/models/models.go
+++ b/models/models.go
@@ -118,6 +118,10 @@ type PinnedFile struct {
 	// are flattened to their base name on download, so this is what a
 	// caller finds on disk, not the path within the repository.
 	Name string
+	// Path is the file's path within the repository, which the fetch URL is
+	// built from. Every model pinned today is flat, so it matches Name, but a
+	// mirror needs Path: that is the key the downloader asks for.
+	Path string
 	// SHA256 is the hex digest EnsureModel verifies the file against.
 	SHA256 string
 	// Size is the exact byte length.
@@ -137,7 +141,7 @@ func PinnedFiles(model string) []PinnedFile {
 	for _, f := range art.files {
 		// path.Base, not filepath.Base: repository paths are always
 		// slash-separated, whatever the host OS uses.
-		out = append(out, PinnedFile{Name: path.Base(f.path), SHA256: f.sha256, Size: f.size})
+		out = append(out, PinnedFile{Name: path.Base(f.path), Path: f.path, SHA256: f.sha256, Size: f.size})
 	}
 	return out
 }

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -381,6 +381,48 @@ func TestEnsureModelFromKeepsTheHubLayout(t *testing.T) {
 	}
 }
 
+// TestPinnedFilePathIsTheKeyTheDownloaderRequests pins the contract a mirror
+// relies on: uploading to the key built from PinnedFile.Path is what the
+// downloader then requests. The fixture nests a file so Path and Name differ,
+// which no model pinned today does.
+func TestPinnedFilePathIsTheKeyTheDownloaderRequests(t *testing.T) {
+	files := map[string][]byte{
+		"model.onnx":          []byte("not really onnx"),
+		"onnx/tokenizer.json": []byte(`{"tokenizer":"nested"}`),
+	}
+	id := "alcatraz-test/nested-NER"
+	art := modelArtifact{
+		revision:      "1111111111111111111111111111111111111111",
+		license:       "Apache-2.0",
+		licenseSource: "https://example.invalid/nested",
+		files: []modelFile{
+			{path: "model.onnx", sha256: sum(files["model.onnx"]), size: int64(len(files["model.onnx"]))},
+			{path: "onnx/tokenizer.json", sha256: sum(files["onnx/tokenizer.json"]), size: int64(len(files["onnx/tokenizer.json"]))},
+		},
+	}
+	hub := newFakeHub(t, files)
+	pinTestModel(t, hub, id, art)
+
+	dir := t.TempDir()
+	modelPath, err := EnsureModelIn(context.Background(), id, dir)
+	if err != nil {
+		t.Fatalf("EnsureModelIn: %v", err)
+	}
+
+	var want []string
+	for _, f := range PinnedFiles(id) {
+		want = append(want, "/"+id+"/resolve/"+art.revision+"/"+f.Path)
+		// The nested file lands flat, so Name is what is on disk.
+		if _, err := os.Stat(filepath.Join(modelPath, f.Name)); err != nil {
+			t.Errorf("PinnedFile.Name %q is not what landed on disk: %v", f.Name, err)
+		}
+	}
+	sort.Strings(want)
+	if got := hub.paths(); !slices.Equal(got, want) {
+		t.Errorf("requested %v, want the keys built from PinnedFile.Path %v", got, want)
+	}
+}
+
 // TestEnsureModelFromRejectsUnusableOrigin keeps the failure at the origin the
 // operator typed. Left to net/http, a missing scheme surfaces as
 // `unsupported protocol scheme ""`, which names neither.
@@ -690,7 +732,7 @@ func TestPinnedFiles(t *testing.T) {
 		t.Fatalf("PinnedFiles returned %d files, want %d", len(got), len(art.files))
 	}
 	for i, f := range art.files {
-		want := PinnedFile{Name: path.Base(f.path), SHA256: f.sha256, Size: f.size}
+		want := PinnedFile{Name: path.Base(f.path), Path: f.path, SHA256: f.sha256, Size: f.size}
 		if got[i] != want {
 			t.Errorf("file %d = %+v, want %+v", i, got[i], want)
 		}


### PR DESCRIPTION
Mirrors the pinned NER models to an S3 bucket so a deployment does not depend
on reaching huggingface.co, and publishes them from a workflow rather than from
someone's laptop.

## What lands

**`alcatraz models pins`** prints the pin table's entry for a model as JSON —
revision, origin, licence, and every file with its digest, size and the key the
downloader requests. `-list` prints every pinned model id, one per line, so a
loop does not have to carry its own idea of what is in the table.

**`hack/mirror-model.sh`** drives the `aws` CLI from that output. It downloads
through the normal path — so every file is verified against its pinned digest
on the way in, and nothing unverified can reach the bucket — uploads write-once,
then round-trips back through `--origin` to prove the mirror serves what the
downloader will accept.

**`Mirror model`** is the publish job. Manual: a model is mirrored when its pin
lands, a handful of times a year. Credentials are assumed via OIDC and last
minutes, so this repository — which is public — never holds a key with write
access to the bucket. The role's trust policy is scoped to the `models-publish`
environment rather than to the repo, so a run that skipped the reviewer gate
cannot assume it.

**`Mirror check`** is the half that earns its keep on an ordinary day. Pinning a
model nobody mirrored otherwise surfaces in a production image build, far from
the PR that caused it. It needs no credentials, since the mirror is served
publicly, and it compares `content-length` rather than just status, because a
half-uploaded object answers a HEAD perfectly well and only fails later, on its
digest.

## Why there is no staging bucket

The artifact is content-addressed — the key carries an immutable commit sha and
every file is checked against a pinned digest on load, including cache hits. So
the bytes a mirror serves during review are the bytes production reads, or the
downloader rejects them. Promotion is the pin reaching `main`, and then a
version bump in whatever image consumes it. A second bucket would hold a second
copy of identical bytes and add a step that can fail.

For the same reason a mirror is a base-URL swap, not a second code path: an
origin is trusted for availability, never for content.

## Deploying this

The workflows no-op until the infrastructure exists. `Mirror check` warns and
exits 0 while `MODELS_ORIGIN` is unset, which is deliberate — it must not fail
PRs against an empty bucket, including this one.

Bucket `hoop-alcatraz-models` (us-east-1, versioned, private) is served through
CloudFront with an OAC, and the publisher role is assumed via OIDC. The
`models-publish` environment carries `MODELS_PUBLISH_ROLE` as a secret — the arn
is the one value here holding the account id — plus `MODELS_BUCKET`,
`MODELS_ORIGIN` and `MODELS_REGION` as variables, so a failed run shows which
bucket and origin it used.

Order after merge: run `Mirror model` as a dry run, then for real, then add
`MODELS_ORIGIN` at the repository level to arm the PR gate.

Part of ATR-189. Closes ATR-218.
